### PR TITLE
fix: rspress-sidebar-group divider style in dark mode

### DIFF
--- a/packages/core/src/theme-default/components/Sidebar/index.module.scss
+++ b/packages/core/src/theme-default/components/Sidebar/index.module.scss
@@ -105,6 +105,12 @@
     left: 12px;
     width: 1px;
     height: 100%;
-    background-color: var(--rp-c-gray-light-4);
+    background-color: var(--rp-c-bg-mute);
+  }
+}
+
+:global(.dark .rspress-sidebar-group) {
+  &::before {
+    background-color: var(--rp-c-bg-mute);
   }
 }

--- a/packages/core/src/theme-default/components/Sidebar/index.module.scss
+++ b/packages/core/src/theme-default/components/Sidebar/index.module.scss
@@ -105,7 +105,7 @@
     left: 12px;
     width: 1px;
     height: 100%;
-    background-color: var(--rp-c-bg-mute);
+    background-color: var(--rp-c-gray-light-4);
   }
 }
 


### PR DESCRIPTION
## Summary

Before:

<img width="265" alt="Screenshot 2023-08-30 at 11 25 06" src="https://github.com/web-infra-dev/rspress/assets/7237365/4c2695b7-158f-4f81-9db0-10dc145c9de5">

After:

<img width="274" alt="Screenshot 2023-08-30 at 11 34 19" src="https://github.com/web-infra-dev/rspress/assets/7237365/ac61c3fb-4dc6-4654-bad1-45b066396bbd">

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
