### PR TITLE
feat: add details container

### DIFF
--- a/packages/plugin-container-syntax/container.css
+++ b/packages/plugin-container-syntax/container.css
@@ -16,6 +16,11 @@
   --rp-container-danger-text: #ab2131;
   --rp-container-danger-bg: rgba(237, 60, 80, 0.02);
   --rp-container-danger-code-bg: rgba(237, 60, 80, 0.1);
+
+  --rp-container-details-border: rgba(128, 128, 128, 0.3);
+  --rp-container-details-text: #666666;
+  --rp-container-details-bg: rgba(128, 128, 128, 0.02);
+  --rp-container-details-code-bg: rgba(128, 128, 128, 0.1);
 }
 
 .dark {
@@ -100,4 +105,14 @@
 .rspress-doc .modern-directive.caution code,
 .rspress-doc .modern-directive.danger code {
   background-color: var(--rp-container-danger-code-bg);
+}
+
+.rspress-doc .modern-directive.details {
+  border-color: var(--rp-container-details-border);
+  color: var(--rp-container-details-text);
+  background-color: var(--rp-container-details-bg);
+}
+
+.rspress-doc .modern-directive.details code {
+  background-color: var(--rp-container-details-code-bg);
 }

--- a/packages/plugin-container-syntax/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-container-syntax/tests/__snapshots__/index.test.ts.snap
@@ -45,3 +45,8 @@ This is a tip</p></div></div>"
 `;
 
 exports[`remark-container > With new line in all case 1`] = `"<div class=\\"modern-directive tip\\"><div class=\\"modern-directive-title\\">TIP</div><div class=\\"modern-directive-content\\"><p>This is a tip</p></div></div>"`;
+
+exports[`remark-container > details 1`] = `
+"<details class=\\"modern-directive details\\"><summary class=\\"modern-directive-title\\">DETAILS</summary><div class=\\"modern-directive-content\\"><p>
+This is a details block.</p></div></details>"
+`;

--- a/packages/plugin-container-syntax/tests/index.test.ts
+++ b/packages/plugin-container-syntax/tests/index.test.ts
@@ -138,4 +138,12 @@ sss
   :::`);
     expect(result.value).toMatchSnapshot();
   });
+
+  test('details', () => {
+    const result = processor.processSync(`::: details
+This is a details block.
+:::`);
+
+    expect(result.value).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

https://vitepress.dev/guide/markdown#custom-containers

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

usage
```md
::: details
This is a details block.
:::
```

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
