### PR TITLE
fix(cli): incorrect node env when build

### DIFF
--- a/.changeset/strong-dolls-occur.md
+++ b/.changeset/strong-dolls-occur.md
@@ -1,0 +1,7 @@
+---
+'rspress': patch
+---
+
+fix(cli): incorrect node env when building
+
+fix(cli): 修复 build 时 node env 不正确的问题

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,16 +21,23 @@ const landingMessage = `🔥 Rspress v${packageJson.version}\n`;
 const rainbowMessage = gradient.cristal(landingMessage);
 console.log(chalk.bold(rainbowMessage));
 
+const setNodeEnv = (env: 'development' | 'production') => {
+  process.env.NODE_ENV = env;
+};
+
 cli.option('--config [config]', 'Specify the path to the config file');
 
 cli
   .command('[root]', 'start dev server') // default command
   .alias('dev')
   .action(async (root, options) => {
+    setNodeEnv('development');
+
     const cwd = process.cwd();
     let docDirectory: string;
     let cliWatcher: chokidar.FSWatcher;
     let devServer: Awaited<ReturnType<typeof dev>>;
+
     const startDevServer = async () => {
       const config = await loadConfigFile(options.config);
       docDirectory = config.root || path.join(cwd, root ?? 'docs');
@@ -79,6 +86,8 @@ cli
   .command('build [root]')
   .option('-c --config <config>', 'specify config file')
   .action(async (root, options) => {
+    setNodeEnv('production');
+
     const cwd = process.cwd();
     const config = await loadConfigFile(options.config);
     await build({
@@ -96,6 +105,8 @@ cli
   .option('--host [host]', 'hostname')
   .action(
     async (options?: { port?: number; host?: string; config?: string }) => {
+      setNodeEnv('production');
+
       const { port, host } = options || {};
       const config = await loadConfigFile(options?.config);
 

--- a/packages/cli/src/modern-app-env.d.ts
+++ b/packages/cli/src/modern-app-env.d.ts
@@ -1,2 +1,0 @@
-/// <reference types='@modern-js/module-tools/types' />
-/// <reference types='@modern-js/plugin-testing/types' />


### PR DESCRIPTION
## Summary

Fix `isProduction()` is `false` when running the `build` command.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
