### PR TITLE
docs: change doc-plugin-typedoc to plugin-typedoc

### DIFF
--- a/packages/document/docs/en/plugin/official-plugins/overview.mdx
+++ b/packages/document/docs/en/plugin/official-plugins/overview.mdx
@@ -2,4 +2,4 @@
 
 Official plugins include the following:
 
-- [@rspress/doc-plugin-typedoc](./typedoc)：Integrate [TypeDoc](https://github.com/TypeStrong/typedoc), used to generate API documentation of TS module automatically.
+- [@rspress/plugin-typedoc](./typedoc)：Integrate [TypeDoc](https://github.com/TypeStrong/typedoc), used to generate API documentation of TS module automatically.

--- a/packages/document/docs/en/plugin/official-plugins/typedoc.mdx
+++ b/packages/document/docs/en/plugin/official-plugins/typedoc.mdx
@@ -1,4 +1,4 @@
-# @rspress/doc-plugin-typedoc
+# @rspress/plugin-typedoc
 
 Integration of [TypeDoc](https://github.com/TypeStrong/typedoc)'s Rspress Plugin for Automatically Generating API Documentation for TS Modules.
 
@@ -6,18 +6,18 @@ Integration of [TypeDoc](https://github.com/TypeStrong/typedoc)'s Rspress Plugin
 
 ```bash
 # npm
-npm install @rspress/doc-plugin-typedoc
+npm install @rspress/plugin-typedoc
 # yarn
-yarn add @rspress/doc-plugin-typedoc
+yarn add @rspress/plugin-typedoc
 # pnpm
-pnpm install @rspress/doc-plugin-typedoc
+pnpm install @rspress/plugin-typedoc
 ```
 
 ## Usage
 
 ```ts
 import { defineConfig } from 'rspress/config';
-import { pluginTypeDoc } from '@rspress/doc-plugin-typedoc';
+import { pluginTypeDoc } from '@rspress/plugin-typedoc';
 import path from 'path';
 
 export default defineConfig({

--- a/packages/document/docs/zh/plugin/official-plugins/overview.mdx
+++ b/packages/document/docs/zh/plugin/official-plugins/overview.mdx
@@ -2,4 +2,4 @@
 
 官方插件包括如下:
 
-- [@rspress/doc-plugin-typedoc](./typedoc)： [TypeDoc](https://github.com/TypeStrong/typedoc) 集成插件，用于自动生成 TS 模块的 API 文档。
+- [@rspress/plugin-typedoc](./typedoc)： [TypeDoc](https://github.com/TypeStrong/typedoc) 集成插件，用于自动生成 TS 模块的 API 文档。

--- a/packages/document/docs/zh/plugin/official-plugins/typedoc.mdx
+++ b/packages/document/docs/zh/plugin/official-plugins/typedoc.mdx
@@ -1,4 +1,4 @@
-# @rspress/doc-plugin-typedoc
+# @rspress/plugin-typedoc
 
 集成 [TypeDoc](https://github.com/TypeStrong/typedoc) 的 Rspress 插件，用于自动生成 TS 模块的 API 文档。
 
@@ -6,18 +6,18 @@
 
 ```bash
 # npm
-npm install @rspress/doc-plugin-typedoc
+npm install @rspress/plugin-typedoc
 # yarn
-yarn add @rspress/doc-plugin-typedoc
+yarn add @rspress/plugin-typedoc
 # pnpm
-pnpm install @rspress/doc-plugin-typedoc
+pnpm install @rspress/plugin-typedoc
 ```
 
 ## 使用
 
 ```ts
 import { defineConfig } from 'rspress/config';
-import { pluginTypeDoc } from '@rspress/doc-plugin-typedoc';
+import { pluginTypeDoc } from '@rspress/plugin-typedoc';
 import path from 'path';
 
 export default defineConfig({

--- a/packages/plugin-typedoc/src/index.ts
+++ b/packages/plugin-typedoc/src/index.ts
@@ -25,7 +25,7 @@ export function pluginTypeDoc(options: PluginTypeDocOptions): RspressPlugin {
   let docRoot: string | undefined;
   const { entryPoints = [], outDir = API_DIR } = options;
   return {
-    name: 'doc-plugin-typedoc',
+    name: '@rspress/plugin-typedoc',
     async addPages() {
       return [
         {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

1. [Official Document] Change `doc-plugin-typedoc` to `plugin-typedoc`
2. [plugin-typedoc] Change the name of the plugin

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

I notice that the guide for `@rspress/doc-plugin-typedoc` seems not correct since there's only `@rspress/plugin-typedoc` package on npmjs.org, so I update the docs a little.

Besides the change of official document, I also change the index file of `@rspress/plugin-typedoc` to make it consistent with other plugins.
<img width="264" alt="image" src="https://github.com/web-infra-dev/rspress/assets/55378595/652d1779-d420-4e18-a13f-8b64e203c0e5">

<img width="439" alt="image" src="https://github.com/web-infra-dev/rspress/assets/55378595/d53fcc57-047a-453d-890e-4225361763b0">

But I did not run `pnpm run change` since I believe this should be decided by the maintainers 😂

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
