### PR TITLE
fix: asset prefix not work for search index url

### DIFF
--- a/.changeset/short-toys-decide.md
+++ b/.changeset/short-toys-decide.md
@@ -1,0 +1,19 @@
+---
+'@rspress/core': patch
+'rspress': patch
+'create-rspress': patch
+'@rspress/docs': patch
+'@modern-js/plugin-rspress': patch
+'@rspress/plugin-api-docgen': patch
+'@rspress/plugin-auto-nav-sidebar': patch
+'@rspress/plugin-container-syntax': patch
+'@rspress/plugin-last-updated': patch
+'@rspress/plugin-medium-zoom': patch
+'@rspress/plugin-preview': patch
+'@rspress/plugin-typedoc': patch
+'@rspress/shared': patch
+---
+
+fix: asset prefix not work for search index url
+
+fix: asset prefix 配置在搜索索引中不生效

--- a/packages/core/src/node/createBuilder.ts
+++ b/packages/core/src/node/createBuilder.ts
@@ -118,7 +118,7 @@ async function createInternalBuildConfig(
       },
       include: [PACKAGE_ROOT],
       define: {
-        __ASSET_PREFIX__: JSON.stringify(assetPrefix),
+        'process.env.__ASSET_PREFIX__': JSON.stringify(assetPrefix),
         'process.env.__SSR__': JSON.stringify(isSSR),
         'process.env.__IS_REACT_18__': JSON.stringify(reactVersion === 18),
         'process.env.TEST': JSON.stringify(process.env.TEST),

--- a/packages/core/src/theme-default/components/Search/logic/providers/LocalProvider.ts
+++ b/packages/core/src/theme-default/components/Search/logic/providers/LocalProvider.ts
@@ -27,8 +27,7 @@ export class LocalProvider implements Provider {
 
   async #getPages(lang: string): Promise<PageIndexInfo[]> {
     const result = await fetch(
-      // @ts-expect-error __ASSET_PREFIX__ is injected by webpack
-      `${__ASSET_PREFIX__}/static/${SEARCH_INDEX_NAME}.${lang}.${searchIndexHash[lang]}.json`,
+      `${process.env.__ASSET_PREFIX__}/static/${SEARCH_INDEX_NAME}.${lang}.${searchIndexHash[lang]}.json`,
     );
     return result.json();
   }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

fix #60 

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

copilot:walkthrough

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
