### PR TITLE
perf: enable deterministic chunkIds of Rspack

### DIFF
--- a/.changeset/strong-bulldogs-talk.md
+++ b/.changeset/strong-bulldogs-talk.md
@@ -4,4 +4,4 @@
 
 perf: enable deterministic chunkIds of Rspack
 
-perf:  开启 Rspack 的 deterministic chunkIds
+perf: 开启 Rspack 的 deterministic chunkIds

--- a/.changeset/strong-bulldogs-talk.md
+++ b/.changeset/strong-bulldogs-talk.md
@@ -1,0 +1,7 @@
+---
+'@rspress/core': patch
+---
+
+perf: enable deterministic chunkIds of Rspack
+
+perf:  开启 Rspack 的 deterministic chunkIds

--- a/packages/core/src/node/createBuilder.ts
+++ b/packages/core/src/node/createBuilder.ts
@@ -147,6 +147,13 @@ async function createInternalBuildConfig(
           );
         }
       },
+      rspack: {
+        // This config can be removed after upgrading Rspack v0.4
+        // https://github.com/web-infra-dev/rspack/issues/3096
+        optimization: {
+          chunkIds: 'deterministic',
+        },
+      },
       bundlerChain(chain) {
         chain.module
           .rule('MDX')


### PR DESCRIPTION
## Summary

Enable deterministic chunkIds of Rspack, it can reduce the length of filename and HMLT file size.

![image](https://github.com/web-infra-dev/rspress/assets/7237365/f6aa76bb-6b76-4e02-a5b7-d95c8f051093)

This config can be removed after upgrading Rspack v0.4: https://github.com/web-infra-dev/rspack/issues/3096

## Related Issue

- https://github.com/web-infra-dev/rspress/issues/62

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
