### PR TITLE
chore: no need to print the server bundles size

### DIFF
--- a/.changeset/seven-emus-learn.md
+++ b/.changeset/seven-emus-learn.md
@@ -1,0 +1,7 @@
+---
+'@rspress/core': patch
+---
+
+chore: no need to print the server bundles size
+
+chore: 无须输出 server bundles 的体积

--- a/packages/core/src/node/createBuilder.ts
+++ b/packages/core/src/node/createBuilder.ts
@@ -126,6 +126,10 @@ async function createInternalBuildConfig(
         'process.env.TEST': JSON.stringify(process.env.TEST),
       },
     },
+    performance: {
+      // No need to print the server bundles size
+      printFileSize: !isSSR,
+    },
     tools: {
       devServer: {
         // Serve static files


### PR DESCRIPTION
## Summary

There is no need to print the server bundle size. Users may be confused by the large server bundle size, which will not affect the production performance.

![image](https://github.com/web-infra-dev/rspress/assets/7237365/d38f866d-68fc-4266-9dda-00eb7973800a)


<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

copilot:summary

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

copilot:walkthrough

## Related Issue

https://github.com/web-infra-dev/rspress/issues/62

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
