### PR TITLE
fix: 不同平台plugin-preview插件path比较

### DIFF
--- a/packages/plugin-preview/src/codeToDemo.ts
+++ b/packages/plugin-preview/src/codeToDemo.ts
@@ -1,7 +1,11 @@
 import { join } from 'path';
 import { visit } from 'unist-util-visit';
 import fs from '@modern-js/utils/fs-extra';
-import { RSPRESS_TEMP_DIR, type RouteMeta } from '@rspress/shared';
+import {
+  RSPRESS_TEMP_DIR,
+  normalizePosixPath,
+  type RouteMeta,
+} from '@rspress/shared';
 import type { Plugin } from 'unified';
 import type { Root } from 'mdast';
 import type { MdxjsEsm } from 'mdast-util-mdxjs-esm';
@@ -27,7 +31,9 @@ export const remarkCodeToDemo: Plugin<
   return (tree, vfile) => {
     const demos: MdxjsEsm[] = [];
     const route = routeMeta.find(
-      meta => meta.absolutePath === (vfile.path || vfile.history[0]),
+      meta =>
+        normalizePosixPath(meta.absolutePath) ===
+        normalizePosixPath(vfile.path || vfile.history[0]),
     );
     if (!route) {
       return;

--- a/packages/plugin-preview/src/index.ts
+++ b/packages/plugin-preview/src/index.ts
@@ -4,6 +4,7 @@ import {
   type RspressPlugin,
   type RouteMeta,
   RSPRESS_TEMP_DIR,
+  normalizePosixPath,
 } from '@rspress/shared';
 import { remarkCodeToDemo } from './codeToDemo';
 import { injectDemoBlockImport, toValidVarName } from './utils';
@@ -103,7 +104,9 @@ import Demo from ${JSON.stringify(demoComponentPath)}
             const ast = processor.parse(source);
             let index = 1;
             const { pageName } = routeMeta.find(
-              meta => meta.absolutePath === filepath,
+              meta =>
+                normalizePosixPath(meta.absolutePath) ===
+                normalizePosixPath(filepath),
             )!;
 
             const registerDemo = (
@@ -169,7 +172,9 @@ import Demo from ${JSON.stringify(demoComponentPath)}
                   (!node?.meta?.includes('web') && isMobile);
 
                 const { pageName } = routeMeta.find(
-                  meta => meta.absolutePath === filepath,
+                  meta =>
+                    normalizePosixPath(meta.absolutePath) ===
+                    normalizePosixPath(filepath),
                 )!;
                 const id = `${toValidVarName(pageName)}_${index++}`;
 


### PR DESCRIPTION
## Summary

调用了`@rspress/shared`中的`normalizePosixPath`来比较plugin-preview中的路径

`normalizePosixPath` in `@rspress/shared` was called to compare the paths in plugin-review

## Details

在windows环境下启用插件仍然没有效果
plugin in the Windows environment has no effect
![image](https://github.com/web-infra-dev/rspress/assets/108787407/25e9e1fa-ef46-4820-a329-2b58cf720167)


原因是在进行路径比较时没有正确匹配
the reason is the path comparison did not match correctly
![image](https://github.com/web-infra-dev/rspress/assets/108787407/1f364b31-b318-435e-83d7-add1bf93482f)

PR替换了plugin-preview中涉及比较的路径
PR replaced the path involved in comparison in plugin review