### PR TITLE
docs: navigate to introduction page when click guide

### DIFF
--- a/packages/document/docs/en/_meta.json
+++ b/packages/document/docs/en/_meta.json
@@ -1,7 +1,7 @@
 [
   {
     "text": "guide",
-    "link": "/guide/start/getting-started",
+    "link": "/guide/start/introduction",
     "activeMatch": "/guide/"
   },
   {

--- a/packages/document/docs/zh/_meta.json
+++ b/packages/document/docs/zh/_meta.json
@@ -1,7 +1,7 @@
 [
   {
     "text": "guide",
-    "link": "/guide/start/getting-started",
+    "link": "/guide/start/introduction",
     "activeMatch": "/guide/"
   },
   {


### PR DESCRIPTION
## Summary

Navigate to introduction page when click guide, because users need to read the introduction first to understand Rspress.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

copilot:summary

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

copilot:walkthrough

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
