### PR TITLE
fix: dead link invalid when having a trailing slash

### DIFF
--- a/.changeset/eight-insects-attack.md
+++ b/.changeset/eight-insects-attack.md
@@ -1,0 +1,7 @@
+---
+'@rspress/core': patch
+---
+
+fix: dead link invalid when having a trailing slash
+
+fix: 路径包含尾部斜杠时，死链检测失效

--- a/packages/core/src/node/route/RouteService.test.ts
+++ b/packages/core/src/node/route/RouteService.test.ts
@@ -38,6 +38,11 @@ describe('RouteService', async () => {
       version: 'v2',
       routePath: '/v2/zh/foo/bar',
     });
+    expect(normalizeRoutePath('/v2/en/api/', 'en', '/', 'v1')).toEqual({
+      lang: 'en',
+      version: 'v2',
+      routePath: '/v2/api/',
+    });
   });
 
   test('Conventional route by file structure', async () => {

--- a/packages/core/src/node/route/RouteService.ts
+++ b/packages/core/src/node/route/RouteService.ts
@@ -31,6 +31,7 @@ export const normalizeRoutePath = (
   base: string,
   version: string,
 ): { routePath: string; lang: string; version: string } => {
+  const hasTrailSlash = routePath.endsWith('/');
   let versionPart = '';
   let langPart = '';
   let purePathPart = '';
@@ -51,12 +52,17 @@ export const normalizeRoutePath = (
   }
   purePathPart = parts.join('/');
 
-  const normalizedRoutePath = addLeadingSlash(
+  let normalizedRoutePath = addLeadingSlash(
     [versionPart, langPart, purePathPart].filter(Boolean).join('/'),
   )
     // remove the extension
     .replace(/\.[^.]+$/, '')
     .replace(/\/index$/, '/');
+
+  // restore the trail slash
+  if (hasTrailSlash && !normalizedRoutePath.endsWith('/')) {
+    normalizedRoutePath = `${normalizedRoutePath}/`;
+  }
 
   return {
     routePath: withBase(normalizedRoutePath, base),


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

Fix #126 

## Details

The `normalizeRotuePath` needs to handle the path which has a trailing slash.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
