### PR TITLE
fix: home page hmr invalid

### DIFF
--- a/.changeset/warm-eels-notice.md
+++ b/.changeset/warm-eels-notice.md
@@ -1,0 +1,7 @@
+---
+'@rspress/core': patch
+---
+
+fix: home page hmr invalid
+
+fix: home 页面热更新失效

--- a/packages/core/src/runtime/App.tsx
+++ b/packages/core/src/runtime/App.tsx
@@ -15,7 +15,6 @@ type RspressPageMeta = Record<
   {
     title: string;
     toc: Header[];
-    frontmatter: Record<string, any>;
   }
 >;
 
@@ -44,12 +43,11 @@ export async function initPageData(routePath: string): Promise<PageData> {
       toc = [],
       // eslint-disable-next-line prefer-const
       title = '',
-      frontmatter,
-    } = (globalThis.__RSPRESS_PAGE_META as RspressPageMeta)?.[
-      encodedPagePath
-    ] || {};
+    } =
+      (mod.default.__RSPRESS_PAGE_META as RspressPageMeta)?.[encodedPagePath] ||
+      {};
 
-    frontmatter = frontmatter || mod.frontmatter || {};
+    const frontmatter = mod.frontmatter || {};
 
     return {
       siteData,

--- a/packages/core/src/theme-default/layout/HomeLayout/index.tsx
+++ b/packages/core/src/theme-default/layout/HomeLayout/index.tsx
@@ -16,6 +16,7 @@ export function HomeLayout(props: HomeLayoutProps) {
   const {
     page: { frontmatter },
   } = usePageData();
+
   return (
     <div
       className="relative"


### PR DESCRIPTION
## Summary

Fix #111 

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

In the page which has frontmatter, we degrade it to page reload after the frontmatter changes.

In the best solution, we can watch the change of module in the component and reset the state but i cannot find the API exposed by Rspack. So i use the current pr to solve the hmr issue as much as possible.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
