### PR TITLE
feat: more flexible root config

### DIFF
--- a/.changeset/silly-pillows-tan.md
+++ b/.changeset/silly-pillows-tan.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+feat: more flexible root config

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,6 +38,17 @@ cli
 
     const startDevServer = async () => {
       const config = await loadConfigFile(options.config);
+
+      // Support root relative to cwd
+      if (config.root && !path.isAbsolute(config.root)) {
+        config.root = path.join(cwd, config.root);
+      }
+
+      // Support root in command, override config file
+      if (root) {
+        config.root = path.join(cwd, root);
+      }
+
       docDirectory = config.root || path.join(cwd, root ?? 'docs');
       devServer = await dev({
         appDirectory: cwd,
@@ -87,6 +98,9 @@ cli
     setNodeEnv('production');
     const cwd = process.cwd();
     const config = await loadConfigFile(options.config);
+    if (root) {
+      config.root = path.join(cwd, root);
+    }
     await build({
       appDirectory: cwd,
       docDirectory: config.root || path.join(cwd, root ?? 'docs'),

--- a/packages/core/src/node/runtimeModule/routeData.ts
+++ b/packages/core/src/node/runtimeModule/routeData.ts
@@ -9,7 +9,6 @@ export const normalizeRoutePath = (routePath: string) => {
 export async function routeVMPlugin(context: FactoryContext) {
   const { routeService } = context;
   // client: The components of route is lazy loaded
-
   return {
     [RuntimeModuleID.RouteForClient]: routeService.generateRoutesCode(false),
     [RuntimeModuleID.RouteForSSR]: routeService.generateRoutesCode(true),

--- a/packages/core/src/theme-default/layout/DocLayout/docComponents/pre.tsx
+++ b/packages/core/src/theme-default/layout/DocLayout/docComponents/pre.tsx
@@ -31,7 +31,7 @@ export function Pre({
   return (
     <div className={className || DEFAULT_LANGUAGE_CLASS}>
       {codeTitle && <div className="rspress-code-title">{codeTitle}</div>}
-      <div className="rspress-code-content">{children}</div>
+      <div className="rspress-code-content rspress-scrollbar">{children}</div>
     </div>
   );
 }

--- a/packages/document/docs/en/api/commands.mdx
+++ b/packages/document/docs/en/api/commands.mdx
@@ -6,10 +6,11 @@ Through this chapter, you can learn about the built-in commands of Rspress and h
 
 The `rspress dev` command is used to start a local development server, providing a development environment for document preview and debugging.
 
-```bash
-Usage: rspress dev [options]
+```txt
+Usage: rspress dev [root] [options]
 
 Options:
+   root specify the root directory of the project, which is `docs` in current directory by default, Optional
    -c --config <config> specify config file path, which can be a relative path or an absolute path
    -h, --help show command help
 ```
@@ -18,10 +19,11 @@ Options:
 
 The `rspress build` command is used to build documentation site for production.
 
-```bash
-Usage: rspress build [options]
+```txt
+Usage: rspress build [root] [options]
 
 Options:
+   root specify the root directory of the project, which is `docs` in current directory by default, Optional
    -c --config <config> specify config file path, which can be a relative path or an absolute path
    -h, --help show command help
 ```
@@ -30,7 +32,7 @@ Options:
 
 The `rspress preview` command is used to preview the output files of the `rspress build` command locally.
 
-```bash
+```txt
 Usage: rspress preview [options]
 
 Options:

--- a/packages/document/docs/en/api/config/config-basic.mdx
+++ b/packages/document/docs/en/api/config/config-basic.mdx
@@ -1,5 +1,29 @@
 # Basic Config
 
+## root
+
+- Type: `string`
+- Default: `docs`
+
+Specifies the document root directory. For example:
+
+```ts title="rspress.config.ts"
+import { defineConfig } from 'rspress/config';
+
+export default defineConfig({
+  root: 'docs',
+});
+```
+
+This config supports both relative and absolute paths, with relative paths being relative to the current working directory(cwd).
+
+Of course, in addition to specifying the document root directory through the config file, you can also specify it through command line parameters, such as:
+
+```bash
+rspress dev docs
+rspress build docs
+```
+
 ## base
 
 - Type: `string`

--- a/packages/document/docs/en/guide/basic/static-assets.mdx
+++ b/packages/document/docs/en/guide/basic/static-assets.mdx
@@ -18,9 +18,9 @@ The `document root directory` mentioned below refers to the directory specified 
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';
-import path from 'path';
+
 export default defineConfig({
-  root: path.join(__dirname, 'docs'),
+  root: 'docs',
 });
 ```
 

--- a/packages/document/docs/en/guide/start/getting-started.mdx
+++ b/packages/document/docs/en/guide/start/getting-started.mdx
@@ -46,10 +46,9 @@ Then initialize a configuration file `rspress.config.ts`:
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';
-import path from 'path';
 
 export default defineConfig({
-  root: path.join(__dirname, 'docs'),
+  root: 'docs',
 });
 ```
 

--- a/packages/document/docs/en/guide/start/introduction.mdx
+++ b/packages/document/docs/en/guide/start/introduction.mdx
@@ -50,10 +50,9 @@ Based on [PrismJS](https://github.com/PrismJS/prism) for runtime code coloring, 
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';
-import path from 'path';
 
 export default defineConfig({
-  root: path.join(__dirname, 'docs'),
+  root: 'docs',
 });
 ```
 

--- a/packages/document/docs/zh/api/commands.mdx
+++ b/packages/document/docs/zh/api/commands.mdx
@@ -7,9 +7,10 @@
 `rspress dev` 命令用于启动一个本地开发服务器，提供一个文档进行预览和调试的开发环境。
 
 ```bash
-Usage: rspress dev [options]
+Usage: rspress dev [root] [options]
 
 Options:
+  root                  指定文档根目录，默认为当前工作目录下的 docs 目录，可选
   -c --config <config>  指定配置文件路径，可以为相对路径或绝对路径
   -h, --help            显示命令帮助
 ```
@@ -19,9 +20,10 @@ Options:
 `rspress build` 命令用于构建出针对生产环境的文档产物。
 
 ```bash
-Usage: rspress build [options]
+Usage: rspress build [root] [options]
 
 Options:
+  root                  指定文档根目录，默认为当前工作目录下的 docs 目录，可选
   -c --config <config>  指定配置文件路径，可以为相对路径或绝对路径
   -h, --help  显示命令帮助
 ```

--- a/packages/document/docs/zh/api/config/config-basic.mdx
+++ b/packages/document/docs/zh/api/config/config-basic.mdx
@@ -1,5 +1,29 @@
 # 基础配置
 
+## root
+
+- Type: `string`
+- Default: `docs`
+
+指定文档根目录。比如：
+
+```ts title="rspress.config.ts"
+import { defineConfig } from 'rspress/config';
+
+export default defineConfig({
+  root: 'docs',
+});
+```
+
+该配置同时支持相对路径和绝对路径，相对路径相对于当前工作目录。
+
+当然，除了通过配置文件来指定文档根目录，你也可以通过命令行参数来指定，比如：
+
+```bash
+rspress dev docs
+rspress build docs
+```
+
 ## base
 
 - Type: `string`
@@ -323,7 +347,7 @@ import { defineConfig } from 'rspress/config';
 
 export default defineConfig({
   route: {
-    cleanUrls: true
+    cleanUrls: true,
   },
 });
 ```

--- a/packages/document/docs/zh/guide/basic/static-assets.mdx
+++ b/packages/document/docs/zh/guide/basic/static-assets.mdx
@@ -18,9 +18,10 @@
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';
-import path from 'path';
+
 export default defineConfig({
-  root: path.join(__dirname, 'docs'),
+  // 同时支持相对路径和绝对路径
+  root: 'docs',
 });
 ```
 

--- a/packages/document/docs/zh/guide/start/getting-started.mdx
+++ b/packages/document/docs/zh/guide/start/getting-started.mdx
@@ -46,10 +46,10 @@ mkdir docs && echo '# Hello World' > docs/index.md
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';
-import path from 'path';
 
 export default defineConfig({
-  root: path.join(__dirname, 'docs'),
+  // 文档根目录
+  root: 'docs',
 });
 ```
 

--- a/packages/document/docs/zh/guide/start/introduction.mdx
+++ b/packages/document/docs/zh/guide/start/introduction.mdx
@@ -50,10 +50,10 @@ Rspress 基于 [MDX](https://mdxjs.com/) 来进行 Markdown 语法的扩展，�
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';
-import path from 'path';
 
 export default defineConfig({
-  root: path.join(__dirname, 'docs'),
+  // 文档根目录
+  root: 'docs',
 });
 ```
 

--- a/packages/document/rspress.config.ts
+++ b/packages/document/rspress.config.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import { defineConfig } from 'rspress/config';
 
 export default defineConfig({
@@ -6,7 +5,7 @@ export default defineConfig({
     experimentalMdxRs: true,
     checkDeadLinks: true,
   },
-  root: path.join(__dirname, 'docs'),
+  root: 'docs',
   title: 'Rspress',
   description: 'Rspack based static site generator',
   lang: 'en',


### PR DESCRIPTION
## Summary

Optimize root config experience:

1. Support relative path in `config.root` param.
2. Support specifying root through command param such as `rspress dev docs`.
3. Add docs for root config.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
