### PR TITLE
fix: add hash when redirecting to target language

### DIFF
--- a/.changeset/sixty-carrots-peel.md
+++ b/.changeset/sixty-carrots-peel.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+fix: add hash when redirect to target lang

--- a/packages/core/src/theme-default/layout/Layout/index.tsx
+++ b/packages/core/src/theme-default/layout/Layout/index.tsx
@@ -104,7 +104,7 @@ export const Layout: React.FC<LayoutProps> = props => {
       return;
     }
     // Normalize current url, to ensure that the home url is always with a trailing slash
-    const { pathname } = window.location;
+    const { pathname, hash } = window.location;
     const cleanPathname = removeBase(pathname);
     // Check if the user is visiting the site for the first time
     const FIRST_VISIT_KEY = 'rspress-visited';
@@ -124,7 +124,9 @@ export const Layout: React.FC<LayoutProps> = props => {
         window.location.replace(pathname.replace(`/${currentLang}`, ''));
       } else if (currentLang === defaultLang) {
         // Redirect to the current language
-        window.location.replace(withBase(`/${targetLang}${cleanPathname}`));
+        window.location.replace(
+          withBase(`/${targetLang}${cleanPathname}${hash}`),
+        );
       } else {
         // Redirect to the current language
         window.location.replace(


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

fix #154 

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

copilot:walkthrough

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
