### PR TITLE
feat: add hideNavbar config

### DIFF
--- a/.changeset/ten-rats-enjoy.md
+++ b/.changeset/ten-rats-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+feat: support hideNavbar config

--- a/packages/core/src/theme-default/components/Sidebar/index.tsx
+++ b/packages/core/src/theme-default/components/Sidebar/index.tsx
@@ -52,7 +52,7 @@ export function SideBar(props: Props) {
     page: { frontmatter },
   } = usePageData();
   const hideNavbar =
-    frontmatter?.hideNavbar ?? themeConfig?.hideNavbar ?? false;
+    !(frontmatter?.navbar ?? true) || themeConfig?.hideNavbar === 'always';
   const [sidebarData, setSidebarData] = useState<
     (ISidebarItem | NormalizedSidebarGroup)[]
   >(rawSidebarData.filter(Boolean).flat());
@@ -117,13 +117,13 @@ export function SideBar(props: Props) {
       className={`${styles.sidebar} rspress-sidebar ${
         isSidebarOpen ? styles.open : ''
       }`}
-      style={{
-        ...(hideNavbar ? { marginTop: 0 } : {}),
-      }}
     >
-      <div className={styles.navTitleMask}>
-        <NavBarTitle />
-      </div>
+      {hideNavbar ? null : (
+        <div className={styles.navTitleMask}>
+          <NavBarTitle />
+        </div>
+      )}
+
       <div className={`mt-1 ${styles.sidebarContent}`}>
         <div
           className="rspress-scrollbar"

--- a/packages/core/src/theme-default/layout/DocLayout/index.module.scss
+++ b/packages/core/src/theme-default/layout/DocLayout/index.module.scss
@@ -8,6 +8,8 @@
   overflow-y: auto;
   scrollbar-width: none;
   width: 0;
+  max-height: calc(100vh - (var(--rp-nav-height) + 32px));
+  overflow: 'scroll';
 }
 
 .aside-container::-webkit-scrollbar {

--- a/packages/core/src/theme-default/layout/DocLayout/index.tsx
+++ b/packages/core/src/theme-default/layout/DocLayout/index.tsx
@@ -93,8 +93,6 @@ export function DocLayout(props: DocLayoutProps) {
           <div
             className={styles.asideContainer}
             style={{
-              maxHeight: 'calc(100vh - (var(--rp-nav-height) + 32px))',
-              overflow: 'scroll',
               ...(disableNavbar
                 ? {
                     marginTop: 0,

--- a/packages/core/src/theme-default/layout/Layout/index.tsx
+++ b/packages/core/src/theme-default/layout/Layout/index.tsx
@@ -61,7 +61,7 @@ export const Layout: React.FC<LayoutProps> = props => {
   // Priority: frontmatter.navbar > themeConfig.hideNavbar
   // Always show sidebar by default
   const hideNavbar =
-    !(frontmatter?.navbar ?? true) || (themeConfig?.hideNavbar ?? false);
+    !(frontmatter?.navbar ?? true) || themeConfig?.hideNavbar === 'always';
   // Priority: front matter title > h1 title
   let title = (frontmatter?.title as string) ?? articleTitle;
   const mainTitle = siteData.title || localesData.title;

--- a/packages/core/src/theme-default/logic/useHiddenNav.ts
+++ b/packages/core/src/theme-default/logic/useHiddenNav.ts
@@ -1,30 +1,42 @@
 import { throttle } from 'lodash-es';
 import { useEffect, useRef, useState } from 'react';
-import { useLocation } from '@/runtime';
+import { useLocation, usePageData } from '@/runtime';
 
 export function useHiddenNav() {
+  const {
+    siteData: { themeConfig },
+  } = usePageData();
+  const hiddenBehaivor = themeConfig.hideNavbar ?? 'auto';
   const [hiddenNav, setHiddenNav] = useState(false);
   const { pathname } = useLocation();
   const lastScrollTop = useRef(0);
-  useEffect(() => {
-    setHiddenNav(false);
-    const onScrollListen = throttle(() => {
-      const { scrollTop } = document.documentElement;
-      if (scrollTop === lastScrollTop.current) {
-        return;
-      }
-      const shouldHidden =
-        lastScrollTop.current > 0 && scrollTop - lastScrollTop.current > 0;
-      setHiddenNav(shouldHidden);
-      lastScrollTop.current = scrollTop <= 0 ? 0 : scrollTop;
-    }, 200);
 
-    window.addEventListener('mousewheel', onScrollListen);
+  if (hiddenBehaivor === 'never') {
+    return false;
+  } else if (hiddenBehaivor === 'always') {
+    return true;
+  } else {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useEffect(() => {
+      setHiddenNav(false);
+      const onScrollListen = throttle(() => {
+        const { scrollTop } = document.documentElement;
+        if (scrollTop === lastScrollTop.current) {
+          return;
+        }
+        const shouldHidden =
+          lastScrollTop.current > 0 && scrollTop - lastScrollTop.current > 0;
+        setHiddenNav(shouldHidden);
+        lastScrollTop.current = scrollTop <= 0 ? 0 : scrollTop;
+      }, 200);
 
-    return () => {
-      window.removeEventListener('mousewheel', onScrollListen);
-    };
-  }, [pathname]);
+      window.addEventListener('mousewheel', onScrollListen);
 
-  return hiddenNav;
+      return () => {
+        window.removeEventListener('mousewheel', onScrollListen);
+      };
+    }, [pathname]);
+
+    return hiddenNav;
+  }
 }

--- a/packages/document/docs/en/api/config/config-theme.mdx
+++ b/packages/document/docs/en/api/config/config-theme.mdx
@@ -448,17 +448,19 @@ export default defineConfig({
 
 ## hideNavbar
 
-- Type: `boolean`
-- Default: `false`
+- Type: `"always" | "auto" | "never"`
+- Default: `auto`
 
-Whether to hide the navigation bar. For example:
+Control the behavior of the hidden navigation bar. By default, the navigation bar will automatically hide when the page scrolls down. You can set it to always to **hide the navigation bar at all times**, or set it to **never to always display the navigation bar**.
+
+For example:
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';
 
 export default defineConfig({
   themeConfig: {
-    hideNavbar: true,
+    hideNavbar: 'auto',
   },
 });
 ```

--- a/packages/document/docs/zh/api/config/config-theme.mdx
+++ b/packages/document/docs/zh/api/config/config-theme.mdx
@@ -433,21 +433,22 @@ export default defineConfig({
 
 ## hideNavbar
 
-- Type: `boolean`
-- Default: `false`
+- Type: `"always" | "auto" | "never"`
+- Default: `auto`
 
-用来隐藏导航栏。比如：
+控制隐藏导航栏行为。默认情况下，导航栏会在页面向下滚动时自动隐藏。你可以设置为 `always` 来始终**隐藏导航栏**，或者设置为 `never` 来总是**显示导航栏**。
+
+。比如：
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';
 
 export default defineConfig({
   themeConfig: {
-    hideNavbar: true,
+    hideNavbar: 'never',
   },
 });
 ```
-
 
 ## enableContentAnimation
 

--- a/packages/shared/src/types/defaultTheme.ts
+++ b/packages/shared/src/types/defaultTheme.ts
@@ -7,7 +7,7 @@ export interface Config {
   /**
    * Custom outline title in the aside component.
    *
-   * @default 'On this page'
+   * @default 'ON THIS PAGE'
    */
   outlineTitle?: string;
   /**
@@ -74,13 +74,9 @@ export interface Config {
    */
   search?: boolean;
   /**
-   * Whether to use back top
-   */
-  backTop?: boolean;
-  /**
    * Whether to hide the navbar
    */
-  hideNavbar?: boolean;
+  hideNavbar?: 'always' | 'auto' | 'never';
   /**
    * Whether to enable the animation for translation pages
    */


### PR DESCRIPTION
## Summary

Support `hideNavbar` behavior:

```ts
import { defineConfig } from 'rspress/config';

export default defineConfig({
  themeConfig: {
    hideNavbar: 'never' | 'auto' | 'always',
  },
});
```

Control the behavior of the hidden navigation bar. By default, the navigation bar will automatically hide when the page scrolls down. You can set it to always to **hide the navigation bar at all times**, or set it to **never to always display the navigation bar**.


## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

copilot:walkthrough

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
