### PR TITLE
fix-cli-string-escape 修复cli字符串转义漏洞

### DIFF
--- a/.changeset/pretty-adults-sort.md
+++ b/.changeset/pretty-adults-sort.md
@@ -1,0 +1,5 @@
+---
+'create-rspress': major
+---
+
+fix cli string escape

--- a/packages/create-rspress/src/index.ts
+++ b/packages/create-rspress/src/index.ts
@@ -66,8 +66,8 @@ cli.command('', 'Create a new rspress site').action(async () => {
   const filesToInterpret = ['docs/index.md', 'rspress.config.ts'];
   const siteData = siteOptions.reduce((prev: Record<string, any>, cur) => {
     prev[cur.name as string] = cur.value
-      .replace('\\', '\\\\')
-      .replace("'", "\\'");
+      .replace(/\\/g, '\\\\')
+      .replace(/'/g, "\\'");
     return prev;
   }, {});
   for (const file of filesToInterpret) {

--- a/packages/create-rspress/src/index.ts
+++ b/packages/create-rspress/src/index.ts
@@ -65,7 +65,9 @@ cli.command('', 'Create a new rspress site').action(async () => {
 
   const filesToInterpret = ['docs/index.md', 'rspress.config.ts'];
   const siteData = siteOptions.reduce((prev: Record<string, any>, cur) => {
-    prev[cur.name as string] = cur.value;
+    prev[cur.name as string] = cur.value
+      .replace('\\', '\\\\')
+      .replace("'", "\\'");
     return prev;
   }, {});
   for (const file of filesToInterpret) {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

修复cli字符串转移漏洞

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

如果在命令行初始化的时候输入带有`'`字符的内容，就会在`rspress.config.ts'中错误生成字符串，从而导致项目不能通过编译

![image](https://github.com/web-infra-dev/rspress/assets/61567130/8c3fb446-56a8-4493-b9af-37e634198f29)

```ts
import * as path from 'path';
import { defineConfig } from 'rspress/config';

export default defineConfig({
  root: path.join(__dirname, 'docs'),
  title: 'I'm good',
  description: 'You're good',
  icon: "/rspress-icon.png",
  logo: {
    light: "/rspress-light-logo.png",
    dark: "/rspress-dark-logo.png",
  },
  themeConfig: {
    socialLinks: [
      { icon: 'github', mode: 'link', content: 'https://github.com/web-infra-dev/rspress' },
    ],
  },
});
```
但是在修复转义字符之后，就可以正确显示了
```ts
import * as path from 'path';
import { defineConfig } from 'rspress/config';

export default defineConfig({
  root: path.join(__dirname, 'docs'),
  title: 'I\'m good',
  description: 'You\'re good',
  icon: "/rspress-icon.png",
  logo: {
    light: "/rspress-light-logo.png",
    dark: "/rspress-dark-logo.png",
  },
  themeConfig: {
    socialLinks: [
      { icon: 'github', mode: 'link', content: 'https://github.com/web-infra-dev/rspress' },
    ],
  },
});
```

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
