### PR TITLE
feat: support nested dir without _meta.json

### DIFF
--- a/.changeset/new-papayas-complain.md
+++ b/.changeset/new-papayas-complain.md
@@ -1,0 +1,5 @@
+---
+'@rspress/plugin-auto-nav-sidebar': patch
+---
+
+feat: support nest dir without \_meta.json


### PR DESCRIPTION
## Summary

In current _meta.json parse logic, we assume that the directory without `_meta.json` only has md/mdx files, but in fact we can allow this kinds of directory has both sub directory and md/mdx files.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

copilot:walkthrough

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
