### PR TITLE
fix(style): keep overview h1 size same as other pages

### DIFF
--- a/.changeset/cuddly-cars-worry.md
+++ b/.changeset/cuddly-cars-worry.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+fix(style): keep overview h1 size same as other pages

--- a/packages/core/src/theme-default/components/Overview/index.module.scss
+++ b/packages/core/src/theme-default/components/Overview/index.module.scss
@@ -3,16 +3,15 @@
   h2,
   h3 {
     font-weight: 600;
+  }
+
+  h2,
+  h3 {
     line-height: 1;
   }
 
-  h1,
   h2 {
     letter-spacing: -0.02em;
-  }
-
-  h1 {
-    font-size: 38px;
   }
 
   h2 {

--- a/packages/core/src/theme-default/components/Overview/index.tsx
+++ b/packages/core/src/theme-default/components/Overview/index.tsx
@@ -3,7 +3,12 @@ import { Header, NormalizedSidebarGroup, SidebarItem } from '@rspress/shared';
 import { useSidebarData } from '../../logic';
 import { Link } from '../Link';
 import styles from './index.module.scss';
-import { usePageData, normalizeHrefInRuntime as normalizeHref, withBase, isEqualPath } from '@/runtime';
+import {
+  usePageData,
+  normalizeHrefInRuntime as normalizeHref,
+  withBase,
+  isEqualPath,
+} from '@/runtime';
 
 interface GroupItem {
   text?: string;
@@ -85,7 +90,7 @@ export function Overview() {
   return (
     <div className="overview-index mx-auto px-8">
       <div className="flex items-center justify-between">
-        <h1>Overview</h1>
+        <h1 className="text-3xl leading-10 tracking-tight">Overview</h1>
       </div>
 
       {groups.map(group => (


### PR DESCRIPTION
## Summary

Keep overview h1 size same as other pages.

Before:

![image](https://github.com/web-infra-dev/rspress/assets/7237365/5dd1bc48-0fb9-45ff-b2b7-7a41ad9c2e3e)

After:

![image](https://github.com/web-infra-dev/rspress/assets/7237365/cd805df4-7164-41d3-bac6-c3034142be38)


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
