### PR TITLE
perf(core): reduce polyfills by adjusting browserslist

### DIFF
--- a/.changeset/early-books-share.md
+++ b/.changeset/early-books-share.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+perf(core): reduce polyfills by adjusting browserslist

--- a/packages/core/src/node/createBuilder.ts
+++ b/packages/core/src/node/createBuilder.ts
@@ -80,13 +80,7 @@ async function createInternalBuildConfig(
   // Using latest browserslist in development to improve build performance
   const browserslist = {
     web: isProduction()
-      ? [
-          'chrome >= 61',
-          'edge >= 16',
-          'firefox >= 60',
-          'safari >= 11',
-          'ios_saf >= 11',
-        ]
+      ? ['chrome >= 87', 'edge >= 88', 'firefox >= 78', 'safari >= 14']
       : [
           'last 1 chrome version',
           'last 1 firefox version',
@@ -168,13 +162,6 @@ async function createInternalBuildConfig(
             }),
           );
         }
-      },
-      rspack: {
-        // This config can be removed after upgrading Rspack v0.4
-        // https://github.com/web-infra-dev/rspack/issues/3096
-        optimization: {
-          chunkIds: isProduction() ? 'deterministic' : 'named',
-        },
       },
       bundlerChain(chain) {
         chain.module


### PR DESCRIPTION
## Summary

Align the default browserslist with anther community tools.

- before: `lib-polyfill.js` —— 231.8 kB minified, 69.6 kB gzipped
- after: `lib-polyfill.js` —— 161.7 kB minified, 45.9 kB gzipped

Note that the polyfill size will be greatly reduced after Rsbuild supports `polyfill: 'usage';

The `optimization.chunkIds` is removed because it is the default config of Modern.js Builder now.

## Related Issue

https://github.com/web-infra-dev/rspress/issues/62

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
