### PR TITLE
fix(create-rspress): should depend on rspress v1

### DIFF
--- a/.changeset/eighty-apes-help.md
+++ b/.changeset/eighty-apes-help.md
@@ -1,0 +1,5 @@
+---
+'create-rspress': patch
+---
+
+fix(create-rspress): should depend on rspress v1

--- a/packages/create-rspress/template/package.json
+++ b/packages/create-rspress/template/package.json
@@ -8,9 +8,9 @@
     "preview": "rspress preview"
   },
   "dependencies": {
-    "rspress": "^0.1.1"
+    "rspress": "^1.0.0"
   },
   "devDependencies": {
-    "@types/node": "^14"
+    "@types/node": "^16"
   }
 }


### PR DESCRIPTION
## Summary

The new project should depend on rspress v1.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
