### PR TITLE
fix: outline hidden style when headers is empty

### DIFF
--- a/.changeset/ten-rocks-poke.md
+++ b/.changeset/ten-rocks-poke.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+fix: outline hidden style when headers is empty

--- a/packages/core/src/theme-default/layout/DocLayout/index.tsx
+++ b/packages/core/src/theme-default/layout/DocLayout/index.tsx
@@ -47,10 +47,7 @@ export function DocLayout(props: DocLayoutProps) {
     // if in iframe, default value is false
     const defaultHasAside =
       typeof window === 'undefined' ? true : window.top === window.self;
-    return (
-      (frontmatter?.outline ?? themeConfig?.outline ?? defaultHasAside) &&
-      headers.length > 0
-    );
+    return frontmatter?.outline ?? themeConfig?.outline ?? defaultHasAside;
   };
   const [hasAside, setHasAside] = useState(getHasAside());
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

copilot:summary

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

copilot:walkthrough

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
