### PR TITLE
fix(core): Fix background of HiddenLinks to support dark theme

### DIFF
--- a/.changeset/nine-moose-rush.md
+++ b/.changeset/nine-moose-rush.md
@@ -2,4 +2,4 @@
 '@rspress/core': patch
 ---
 
-fi(core): Fix background of HiddenLinks to support dark theme
+fix(core): Fix background of HiddenLinks to support dark theme

--- a/.changeset/nine-moose-rush.md
+++ b/.changeset/nine-moose-rush.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+fi(core): Fix background of HiddenLinks to support dark theme

--- a/packages/core/src/theme-default/components/SocialLinks/HiddenLinks.tsx
+++ b/packages/core/src/theme-default/components/SocialLinks/HiddenLinks.tsx
@@ -14,8 +14,9 @@ export const HiddenLinks = (props: IHiddenLinksProps) => {
         boxShadow: 'var(--rp-shadow-3)',
         marginRight: '-2px',
         border: '1px solid var(--rp-c-divider-light)',
+        background: 'var(--rp-c-bg)',
       }}
-      className="absolute top-8 right-0 z-1 p-3 w-32 rounded-2xl bg-white flex flex-wrap gap-4"
+      className="absolute top-8 right-0 z-1 p-3 w-32 rounded-2xl flex flex-wrap gap-4"
     >
       {links.map(item => (
         <LinkContent


### PR DESCRIPTION
## Summary

### Before
<img width="384" alt="image" src="https://github.com/web-infra-dev/rspress/assets/8295888/c8e6160a-489d-42f9-9f51-c7cc8f15a264">


### After
<img width="376" alt="image" src="https://github.com/web-infra-dev/rspress/assets/8295888/f1bd130c-0601-484a-bcf4-cfec6cdbb86a">


## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

copilot:walkthrough

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
