### PR TITLE
fix: rspress-doc-container margin css style

### DIFF
--- a/.changeset/mean-moons-buy.md
+++ b/.changeset/mean-moons-buy.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+fix: rspress-doc-container margin css style

--- a/packages/core/src/theme-default/layout/DocLayout/index.tsx
+++ b/packages/core/src/theme-default/layout/DocLayout/index.tsx
@@ -81,7 +81,7 @@ export function DocLayout(props: DocLayoutProps) {
       {beforeDoc}
       {hasSidebar ? <SideMenu /> : null}
       <div
-        className={`${styles.content} rspress-doc-container flex flex-shrink-0 m-auto`}
+        className={`${styles.content} rspress-doc-container flex flex-shrink-0 mx-auto`}
       >
         <div className="w-full">
           {isOverviewPage ? (


### PR DESCRIPTION
## Summary

closes: #255 

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

copilot:summary

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

copilot:walkthrough

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
