### PR TITLE
feat(core): beautify <Tab> sytle when using with code title on defaul…

### DIFF
--- a/.changeset/selfish-jeans-tap.md
+++ b/.changeset/selfish-jeans-tap.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+feat(core): beautify <Tab> sytle when using with code title on default theme

--- a/packages/core/src/theme-default/components/Tabs/index.module.scss
+++ b/packages/core/src/theme-default/components/Tabs/index.module.scss
@@ -16,7 +16,6 @@
   padding-top: 4px;
   display: flex;
   min-width: 100%;
-  background-color: var(--rp-code-title-bg);
 }
 
 .tab {


### PR DESCRIPTION
…t theme

## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

copilot:summary

## Details

Before:
<img width="662" alt="image" src="https://github.com/web-infra-dev/rspress/assets/16858738/cdde8196-b815-440f-b12f-06848e213012">

After:
<img width="669" alt="image" src="https://github.com/web-infra-dev/rspress/assets/16858738/f2ebb131-fb5d-4eee-9189-53761eb42294">

Other case:

with code but no title:
<img width="649" alt="image" src="https://github.com/web-infra-dev/rspress/assets/16858738/ec63fc88-5ea5-4f59-8958-df5774b7cb35">

with text:
<img width="664" alt="image" src="https://github.com/web-infra-dev/rspress/assets/16858738/c1883e20-f7a8-4ce8-832c-98f24b57c917">


copilot:walkthrough

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
