### PR TITLE
chore(workflow): remove copilot summary from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,5 @@
 ## Summary
 
-<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
-<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->
-
-copilot:summary
-
-## Details
-
-<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
-<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->
-
-copilot:walkthrough
 
 ## Related Issue
 


### PR DESCRIPTION
## Summary

Copilot PR has not been enabled in the Rspress repo and the current template is a bit confusing, so we should remove the copilot summary from the PR template.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
