### PR TITLE
fix: highlight error after building

### DIFF
--- a/.changeset/old-months-compete.md
+++ b/.changeset/old-months-compete.md
@@ -1,0 +1,5 @@
+---
+'@rspress/theme-default': major
+---
+
+fix highlight error after building

--- a/packages/rspress-theme-default/src/theme-default/layout/DocLayout/docComponents/code.tsx
+++ b/packages/rspress-theme-default/src/theme-default/layout/DocLayout/docComponents/code.tsx
@@ -1,4 +1,4 @@
-import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { PrismAsyncLight as SyntaxHighlighter } from 'react-syntax-highlighter';
 import languagesInfo from 'virtual-prism-languages';
 import copy from 'copy-to-clipboard';
 import { useRef } from 'react';


### PR DESCRIPTION
## Summary

I tried to use `PrismAsyncLight` instead of `PrismLight`, it works.  But [react-syntax-highlight](https://github.com/react-syntax-highlighter/react-syntax-highlighter#async-build) said **while code splits are loaded the code will show with line numbers but without highlighting.**, i worry if it will cause other bugs.

## Related Issue

<!--- Provide link of related issues -->https://github.com/web-infra-dev/rspress/issues/272

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
