### PR TITLE
fix: jsx tag missed in document

### DIFF
--- a/.changeset/friendly-boxes-peel.md
+++ b/.changeset/friendly-boxes-peel.md
@@ -1,0 +1,5 @@
+---
+'@rspress/docs': patch
+---
+
+fix: jsx tag missed in document

--- a/packages/document/docs/en/plugin/official-plugins/preview.mdx
+++ b/packages/document/docs/en/plugin/official-plugins/preview.mdx
@@ -35,7 +35,7 @@ After adding this plugin, please set `markdown.mdxRs` to `false`, otherwise it w
 
 The component code of internal components is declared in the mdx file. You can declare the following code block in the mdx file:
 
-````md
+````mdx
 ```tsx
 function App() {
   return <div>Hello World</div>;
@@ -49,7 +49,7 @@ It's worth noting that you need to export the component as default, and Rspress 
 
 But if you want to keep the style of the code block instead of rendering it as a component, you can add the `pure` identifier to specify, the usage is as follows:
 
-````md pure
+````mdx
 ```tsx pure
 function App() {
   return <div>Hello World</div>;
@@ -116,6 +116,7 @@ The effect of `fixed` mode is as follows:
 **experimental feature** that enables opening demos in Codesandbox. Currently not supported when `iframePosition` is set to `fixed`.
 
 There are still some limitations with this feature:
+
 - You cannot customize sandbox dependencies: Default dependencies will be only `react`, `react-dom`, and `self`. This means you cannot import other dependencies in your demo,
-and you need to ensure that `self` is published to npm, which is suitable for projects that are modular in nature.
+  and you need to ensure that `self` is published to npm, which is suitable for projects that are modular in nature.
 - You cannot customize files: This means you cannot import other files in your demo.

--- a/packages/document/docs/zh/plugin/official-plugins/preview.mdx
+++ b/packages/document/docs/zh/plugin/official-plugins/preview.mdx
@@ -33,10 +33,14 @@ export default defineConfig({
 
 内部组件的组件代码声明在 mdx 文件内。你可以在 mdx 文件中声明如下的代码块：
 
-````md
+````mdx
 ```tsx
 function App() {
-  return <div>Hello World</div>;
+  return (
+    <div>
+      <span>Hello World</span>
+    </div>
+  );
 }
 
 export default App;
@@ -47,7 +51,7 @@ export default App;
 
 但是如果你想保留代码块的样式，而不是将其作为组件渲染，你可以添加 `pure` 标识符来指定，使用方式如下：
 
-````md pure
+````mdx
 ```tsx pure
 function App() {
   return <div>Hello World</div>;
@@ -114,6 +118,7 @@ interface PreviewOptions {
 **试验性功能**，支持在 Codesandbox 打开 Demo，目前不支持 iframePosition 为 fixed 的情况。
 
 此功能，仍有一些使用上的限制：
+
 - 不能自定义 sandbox 依赖：默认仅会声明 react、react-dom、self 三个依赖，这意味着你无法在 demo 里引用其他依赖，
-同时，你需要确保 self 已经发包至 npm，这适用于模块类型的项目。
+  同时，你需要确保 self 已经发包至 npm，这适用于模块类型的项目。
 - 不能自定义文件：这意味着你无法在 demo 里引用其他文件。


### PR DESCRIPTION
## Summary

Fix #287 

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
