### PR TITLE
fix(theme-default): Homehero comp crashes when hero field value is undefined

### DIFF
--- a/.changeset/angry-impalas-mix.md
+++ b/.changeset/angry-impalas-mix.md
@@ -2,4 +2,4 @@
 '@rspress/theme-default': patch
 ---
 
-fix: HomeHero Comp crashes when some hero fields' value is undefined
+fix: Homehero comp crashes when hero field value is undefined

--- a/.changeset/angry-impalas-mix.md
+++ b/.changeset/angry-impalas-mix.md
@@ -1,0 +1,5 @@
+---
+'@rspress/theme-default': patch
+---
+
+fix: HomeHero Comp crashes when some hero fields' value is undefined

--- a/packages/theme-default/src/logic/utils.ts
+++ b/packages/theme-default/src/logic/utils.ts
@@ -3,7 +3,7 @@ import React from 'react';
 import htmr from 'htmr';
 import isHtml from 'is-html';
 import { isEqualPath } from '@rspress/runtime';
-import { isNull, isNumber } from 'lodash-es';
+import { isNumber } from 'lodash-es';
 
 export function isActive(
   currentPath: string,
@@ -42,8 +42,11 @@ export function isMobileDevice() {
   return window.innerWidth < 768;
 }
 
-export function renderHtmlOrText(str: string | number | null) {
-  if (isNull(str) || isNumber(str)) {
+export function renderHtmlOrText(str?: string | number | null) {
+  if (!str) {
+    return '';
+  }
+  if (isNumber(str)) {
     return str;
   }
 


### PR DESCRIPTION
## Summary
This PR solves the issue as the title states

The root cause is if `hero.xx` does not exist, the `renderHtmlOrText` function will receive `undefined` as its parameter, and later bypass it to `htmr()`, which makes the whole page crash

<img width="705" alt="image" src="https://github.com/web-infra-dev/rspress/assets/73387709/fcbb19e5-b761-4732-8636-31d8144079cb">

Repro steps:

1. `pnpm create rspress@latest`
2.  replace `docs/index.md` with
```markdown
---
pageType: home
hero:
  name: hello
---
```
3. `pnpm run dev`, and the app goes white screen

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
