### PR TITLE
feat: markdown hightlight default support bash syntax

### DIFF
--- a/.changeset/nice-buttons-exercise.md
+++ b/.changeset/nice-buttons-exercise.md
@@ -1,0 +1,6 @@
+---
+'@rspress/core': major
+'@rspress/docs': minor
+---
+
+bash syntax highlighting is supported by default

--- a/packages/core/src/node/runtimeModule/prismLanguages.ts
+++ b/packages/core/src/node/runtimeModule/prismLanguages.ts
@@ -15,6 +15,7 @@ const DEFAULT_LANGUAGES = [
   'yaml',
   ['md', 'markdown'],
   ['mdx', 'tsx'],
+  'bash',
 ];
 
 export async function prismLanguageVMPlugin(context: FactoryContext) {

--- a/packages/document/docs/en/api/config/config-build.mdx
+++ b/packages/document/docs/en/api/config/config-build.mdx
@@ -167,7 +167,7 @@ Please set `markdown.mdxRs` to `false` when configuring `globalComponents`, othe
 
 - Type: `(string | [string, string])[]`
 
-Register the languages that need to be highlighted. The default supported languages include `js`, `jsx`, `ts`, `tsx`, `json`, `css`, `scss`, `less`, `xml`, `diff`, `yaml`, `md`, `mdx`. You can extend based on these languages. For example:
+Register the languages that need to be highlighted. The default supported languages include `js`, `jsx`, `ts`, `tsx`, `json`, `css`, `scss`, `less`, `xml`, `diff`, `yaml`, `md`, `mdx`, `bash`. You can extend based on these languages. For example:
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';

--- a/packages/document/docs/zh/api/config/config-build.mdx
+++ b/packages/document/docs/zh/api/config/config-build.mdx
@@ -167,7 +167,7 @@ export default defineConfig({
 
 - Type: `(string | [string, string])[]`
 
-注册需要高亮的语言。默认支持的语言包括`js`、`jsx`、`ts`、`tsx`、`json`、`css`、`scss`、`less`、`xml`、`diff`、`yaml`、`md`、`mdx`，你可以在这些语言的基础上进行扩展。比如：
+注册需要高亮的语言。默认支持的语言包括`js`、`jsx`、`ts`、`tsx`、`json`、`css`、`scss`、`less`、`xml`、`diff`、`yaml`、`md`、`mdx`、`bash`，你可以在这些语言的基础上进行扩展。比如：
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';


### PR DESCRIPTION
## Summary

markdown hightlight default support bash syntax


## Related Issue

https://github.com/web-infra-dev/rspress/issues/272

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
