### PR TITLE
fix: custom theme not working

### DIFF
--- a/.changeset/kind-penguins-burn.md
+++ b/.changeset/kind-penguins-burn.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+fix: use theme alias path

--- a/packages/core/src/runtime/App.tsx
+++ b/packages/core/src/runtime/App.tsx
@@ -13,7 +13,7 @@ import globalComponents from 'virtual-global-components';
 import 'virtual-global-styles';
 
 // eslint-disable-next-line import/no-commonjs
-const { default: Theme } = require('@rspress/theme-default');
+const { default: Theme } = require('@theme');
 
 type RspressPageMeta = Record<
   string,


### PR DESCRIPTION
## Summary

Change runtime code require theme alias path `@theme` instead of `@rspress/theme-default`.

## Related Issue

https://github.com/web-infra-dev/rspress/issues/310

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
