### PR TITLE
fix: fix right aside nav item doesn't highlight automatically while opening in a new tab

### DIFF
--- a/.changeset/pretty-points-develop.md
+++ b/.changeset/pretty-points-develop.md
@@ -1,0 +1,5 @@
+---
+'@rspress/theme-default': patch
+---
+
+fix: fix right aside nav item doesn't highlight automatically while opening in a new tab

--- a/packages/theme-default/src/logic/sideEffects.ts
+++ b/packages/theme-default/src/logic/sideEffects.ts
@@ -159,6 +159,8 @@ export function bindingAsideScroll() {
 
   window.addEventListener('scroll', throttledSetLink);
 
+  setActiveLink();
+
   // eslint-disable-next-line consistent-return
   return () => {
     window.removeEventListener('scroll', throttledSetLink);


### PR DESCRIPTION

## Summary


## Related Issue
#257 

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
