### PR TITLE
perf: using polyfill usage mode to reduce bundle size

### DIFF
--- a/.changeset/perfect-tomatoes-dance.md
+++ b/.changeset/perfect-tomatoes-dance.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+perf: using polyfill usage mode to reduce bundle size

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -100,8 +100,6 @@ async function createInternalBuildConfig(
         root: path.isAbsolute(outDir) ? path.relative(cwd, outDir) : outDir,
         html: 'html',
       },
-      // TODO: switch to 'usage' if Rspack supports it
-      polyfill: 'entry',
       // Disable production source map, it is useless for doc site
       disableSourceMap: isProduction(),
       overrideBrowserslist: browserslist,


### PR DESCRIPTION
## Summary

Using polyfill `usage` mode to reduce bundle size. 

Rsbuild use `usage` mode by default, so we do not need any extra configurations.

## New Project Size

before:

<img width="704" alt="Screenshot 2023-11-06 at 10 31 56" src="https://github.com/web-infra-dev/rspress/assets/7237365/b82f8910-472f-47cb-83cc-8ef7aeb46461">

after:

<img width="713" alt="Screenshot 2023-11-06 at 10 32 41" src="https://github.com/web-infra-dev/rspress/assets/7237365/1515da31-3bb7-4ec7-a66b-93b6ab3b56a9">

## Related Issue

https://github.com/web-infra-dev/rspress/issues/62

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
