### PR TITLE
fix: fix the activation status update error after clicking on the right navigation bar

### DIFF
--- a/.changeset/wild-tigers-sip.md
+++ b/.changeset/wild-tigers-sip.md
@@ -1,0 +1,5 @@
+---
+'@rspress/theme-default': patch
+---
+
+fix: fix the activation status update error after clicking on the right navigation bar

--- a/packages/theme-default/src/logic/sideEffects.ts
+++ b/packages/theme-default/src/logic/sideEffects.ts
@@ -21,7 +21,7 @@ export function scrollToTarget(
   // Only scroll smoothly in page header anchor
   window.scrollTo({
     left: 0,
-    top: targetTop,
+    top: Math.round(targetTop),
     ...(isSmooth ? { behavior: 'smooth' } : {}),
   });
 }


### PR DESCRIPTION
## Summary
The calculation of `scrollTop` after clicking the bar on the right will produce decimals due to `target.getBoundingClientRect().top`. 

However, when calculating the activation status of bar, there is no decimal because offsetTop is used.

```js
if (scrollTop >= currentAnchorTop && scrollTop < nextAnchorTop) {
      activate(links, i);
      break;
}
```

So, round `scrollTop`.

## Related Issue
#335 

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
