### PR TITLE
fix: replaceLang should handle the url ends with a slash

### DIFF
--- a/.changeset/smart-owls-care.md
+++ b/.changeset/smart-owls-care.md
@@ -1,0 +1,5 @@
+---
+'@rspress/shared': patch
+---
+
+fix: replaceLang should handle the url ends with a slash

--- a/packages/shared/src/utils/index.test.ts
+++ b/packages/shared/src/utils/index.test.ts
@@ -95,6 +95,24 @@ describe('test shared utils', () => {
 
       expect(result).toEqual('/index.html');
     });
+
+    test('should correctly handle the url that ends with a slash', () => {
+      const rawUrl = '/zh/';
+      const lang = {
+        current: 'zh',
+        target: 'en',
+        default: 'en',
+      };
+      const version = {
+        current: 'v1',
+        default: 'v1',
+      };
+      const base = '';
+
+      const result = replaceLang(rawUrl, lang, version, base);
+
+      expect(result).toEqual('/index.html');
+    });
   });
 
   describe('replaceVersion', () => {

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -109,6 +109,11 @@ export function replaceLang(
   if (!url) {
     url = '/index.html';
   }
+
+  if (url.endsWith('/')) {
+    url += 'index.html';
+  }
+
   let versionPart = '';
   let langPart = '';
   let purePathPart = '';


### PR DESCRIPTION
## Summary

Fix #343 

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
