### PR TITLE
fix: reserve existed extension in normalizeHref

### DIFF
--- a/.changeset/stupid-rats-glow.md
+++ b/.changeset/stupid-rats-glow.md
@@ -1,0 +1,5 @@
+---
+'@rspress/shared': patch
+---
+
+fix: reserve existed extension in normalizeHref

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -242,7 +242,9 @@ export function normalizeHref(url?: string, cleanUrls = false) {
     return url;
   }
 
-  if (!cleanUrls && !cleanUrl.endsWith('.html')) {
+  const hasExt = cleanUrl.split('/').pop()?.includes('.');
+
+  if (!cleanUrls && !cleanUrl.endsWith('.html') && !hasExt) {
     if (cleanUrl.endsWith('/')) {
       cleanUrl += 'index.html';
     } else {


### PR DESCRIPTION
## Summary


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
