### PR TITLE
fix: support for Korean language search

### DIFF
--- a/packages/theme-default/src/components/Search/logic/util.ts
+++ b/packages/theme-default/src/components/Search/logic/util.ts
@@ -1,6 +1,7 @@
 import { RemoteSearchIndexInfo, Header } from '@rspress/shared';
 
 const MAX_TITLE_LENGTH = 20;
+const kRegex = /[\u3131-\u314e|\u314f-\u3163|\uac00-\ud7a3]/u;
 
 export function backTrackHeaders(
   rawHeaders: Header[],
@@ -37,10 +38,11 @@ export function formatText(text: string) {
 }
 
 export function normalizeTextCase(text: string) {
-  return text
+  const result = text
     .toLowerCase()
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '');
+  return kRegex.test(text) ? result.normalize('NFC') : result;
 }
 
 export function removeDomain(url: string) {


### PR DESCRIPTION
## Summary
To make it searchable in Korean, the text that was normalized to NFD must be normalized to NFC.
so I changed it to NFC only if it is Korean.

## Reproducing
```js
const cjkRegex =
  /[\u3131-\u314e|\u314f-\u3163|\uac00-\ud7a3]|[\u4E00-\u9FCC\u3400-\u4DB5\uFA0E\uFA0F\uFA11\uFA13\uFA14\uFA1F\uFA21\uFA23\uFA24\uFA27-\uFA29]|[\ud840-\ud868][\udc00-\udfff]|\ud869[\udc00-\uded6\udf00-\udfff]|[\ud86a-\ud86c][\udc00-\udfff]|\ud86d[\udc00-\udf34\udf40-\udfff]|\ud86e[\udc00-\udc1d]|[\u3041-\u3096]|[\u30A1-\u30FA]/giu;
const kRegex = /[\u3131-\u314e|\u314f-\u3163|\uac00-\ud7a3]/u;

function originNormalizeTextCase(text) {
  return text
    .toLowerCase()
    .normalize('NFD')
    .replace(/[\u0300-\u036f]/g, '');
}

function fixedNormalizeTextCase(text) {
  const result = text
    .toLowerCase()
    .normalize('NFD')
    .replace(/[\u0300-\u036f]/g, '');
  return kRegex.test(text) ? result.normalize('NFC') : result;
}

const tokenize = (str) => {
  const cjkWords = [];
  let m = null;
  do {
    m = cjkRegex.exec(str);
    if (m) {
      cjkWords.push(m[0]);
    }
  } while (m);
  return cjkWords;
}

console.log(
  tokenize(originNormalizeTextCase('문서'))
); // []. This is an unexpected result.

console.log(
  tokenize(fixedNormalizeTextCase('문서'))
); // ['문', '서']. Works fine!
```

Instead of converting only Korean, you can also NFC normalize all of them.
In a quick check with Chinese and Japanese, it worked fine.

```js
function normalizeTextCase(text) {
  return text
    .toLowerCase()
    .normalize('NFD')
    .replace(/[\u0300-\u036f]/g, '')
    .normalize('NFC');
}
```

Which method is better?
I thought it would be easier to understand the intent by handling Korean separately.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
