### PR TITLE
fix(create-rspress): code style of template config file is not the same

### DIFF
--- a/packages/create-rspress/template/rspress.config.ts
+++ b/packages/create-rspress/template/rspress.config.ts
@@ -5,10 +5,10 @@ export default defineConfig({
   root: path.join(__dirname, 'docs'),
   title: <%= siteTitle %>,
   description: <%= siteDesc %>,
-  icon: "/rspress-icon.png",
+  icon: '/rspress-icon.png',
   logo: {
-    light: "/rspress-light-logo.png",
-    dark: "/rspress-dark-logo.png",
+    light: '/rspress-light-logo.png',
+    dark: '/rspress-dark-logo.png',
   },
   themeConfig: {
     socialLinks: [


### PR DESCRIPTION
## Summary

The code style of template config file is not the same.

## Related Issue

No

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
