### PR TITLE
fix: reset prevActiveLink when unbinding AsideScrol

### DIFF
--- a/.changeset/few-walls-dress.md
+++ b/.changeset/few-walls-dress.md
@@ -1,0 +1,5 @@
+---
+'@rspress/theme-default': patch
+---
+
+fix: reset prevActiveLink when unbinding AsideScrol

--- a/packages/theme-default/src/logic/sideEffects.ts
+++ b/packages/theme-default/src/logic/sideEffects.ts
@@ -163,6 +163,9 @@ export function bindingAsideScroll() {
 
   // eslint-disable-next-line consistent-return
   return () => {
+    if (prevActiveLink) {
+      prevActiveLink.classList.remove('aside-active');
+    }
     window.removeEventListener('scroll', throttledSetLink);
   };
 }


### PR DESCRIPTION
## Summary
#377 

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
