### PR TITLE
fix: devServer use searchIndexMiddleware first.

### DIFF
--- a/.changeset/soft-days-film.md
+++ b/.changeset/soft-days-film.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+fix: devServer use searchIndexMiddleware first.

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -96,10 +96,10 @@ async function createInternalBuildConfig(
       setupMiddlewares: [
         middlewares => {
           if (isPublicDirExist) {
-            middlewares.push(sirv(publicDir));
+            middlewares.unshift(sirv(publicDir));
           }
 
-          middlewares.push(serveSearchIndexMiddleware(config));
+          middlewares.unshift(serveSearchIndexMiddleware(config));
         },
       ],
     },


### PR DESCRIPTION
## Summary

the middleware order is [unshift]->[internal]->[push].  If [push] is used, the request ends with 404.
The proposed change prioritizes the handling of public resources and search index data. 

Please review the changes and let me know if any further modifications are required.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
