### PR TITLE
fix: remove dark mode script during build when disabled in config

### DIFF
--- a/.changeset/tidy-geckos-taste.md
+++ b/.changeset/tidy-geckos-taste.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+fix: disable dark mode script when darkMode is false in config

--- a/packages/core/src/node/build.ts
+++ b/packages/core/src/node/build.ts
@@ -177,7 +177,7 @@ export async function renderPages(
                   helmet?.link?.toString(),
                   helmet?.style?.toString(),
                   helmet?.script?.toString(),
-                  config.themeConfig.darkMode !== false
+                  config.themeConfig?.darkMode !== false
                     ? CHECK_DARK_LIGHT_SCRIPT
                     : '',
                 ])

--- a/packages/core/src/node/build.ts
+++ b/packages/core/src/node/build.ts
@@ -177,7 +177,9 @@ export async function renderPages(
                   helmet?.link?.toString(),
                   helmet?.style?.toString(),
                   helmet?.script?.toString(),
-                  CHECK_DARK_LIGHT_SCRIPT,
+                  config.themeConfig.darkMode !== false
+                    ? CHECK_DARK_LIGHT_SCRIPT
+                    : '',
                 ])
                 .join(''),
             );


### PR DESCRIPTION
## Summary

Fixes the final build ignoring the user config setting `themeConfig.darkMode: false` (whereas it was previously respected in dev mode).

## Related Issue

https://github.com/web-infra-dev/rspress/issues/372
