### PR TITLE
docs: remove redundant 'cache' parameter from pnpm installation step.

### DIFF
--- a/packages/document/docs/en/guide/basic/deploy.mdx
+++ b/packages/document/docs/en/guide/basic/deploy.mdx
@@ -106,7 +106,6 @@ jobs:
       - uses: pnpm/action-setup@v2 # pnpm is optional but recommended, you can also use npm / yarn
         with:
           version: 6
-          cache: pnpm
       - name: Setup Node
         uses: actions/setup-node@v3
         with:

--- a/packages/document/docs/zh/guide/basic/deploy.mdx
+++ b/packages/document/docs/zh/guide/basic/deploy.mdx
@@ -106,7 +106,6 @@ jobs:
       - uses: pnpm/action-setup@v2 # pnpm is optional but recommended, you can also use npm / yarn
         with:
           version: 6
-          cache: pnpm
       - name: Setup Node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
## Summary

When following the steps in the documentation, GitHub Actions displays a warning about an unexpected input 'cache'.

![image](https://github.com/web-infra-dev/rspress/assets/3841747/a48a1112-20d8-4632-8814-12f1e9d6dbc0)

This pull request removes this input to prevent the warning from appearing.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
