### PR TITLE
fix(core): stringify global components path

### DIFF
--- a/.changeset/weak-fishes-sparkle.md
+++ b/.changeset/weak-fishes-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+fix(core): stringify global compoennts path

--- a/packages/core/src/node/runtimeModule/globalUIComponents.ts
+++ b/packages/core/src/node/runtimeModule/globalUIComponents.ts
@@ -13,11 +13,11 @@ export async function globalUIComponentsVMPlugin(context: FactoryContext) {
     .map(source => {
       const name = `Comp_${index}`;
       if (Array.isArray(source)) {
-        return `import ${name} from '${source[0]}';
+        return `import ${name} from ${JSON.stringify(source[0])};
 const Props_${index++} = ${JSON.stringify(source[1])};\n`;
       } else {
         index++;
-        return `import ${name} from '${source}';\n`;
+        return `import ${name} from ${JSON.stringify(source)};\n`;
       }
     })
     .concat(


### PR DESCRIPTION
## Summary
If we use `globalUIComponents` in windows, we will get a error:
![image](https://github.com/web-infra-dev/rspress/assets/50694858/54914af6-cfdd-455a-bc1d-af89e8a0330b)
This change will fix it.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
