### PR TITLE
fix: remove unuse css that is not recognized by browsers.

### DIFF
--- a/.changeset/forty-onions-shout.md
+++ b/.changeset/forty-onions-shout.md
@@ -1,0 +1,5 @@
+---
+'@rspress/theme-default': patch
+---
+
+fix: remove unuse css that is not recognized by browsers.

--- a/packages/theme-default/src/layout/DocLayout/index.module.scss
+++ b/packages/theme-default/src/layout/DocLayout/index.module.scss
@@ -9,7 +9,6 @@
   scrollbar-width: none;
   width: 0;
   max-height: calc(100vh - (var(--rp-nav-height) + 32px));
-  overflow: 'scroll';
 }
 
 .aside-container::-webkit-scrollbar {


### PR DESCRIPTION
## Summary

CSS values wrapped in quotes are not recognized by browsers.

![image](https://github.com/web-infra-dev/rspress/assets/3841747/65f1b822-43f2-4675-881f-fd6f01af5d07)


```scss
& {
  overflow: 'scroll';
}
```

The changes in this MR remove these unrecognizable CSS values to prevent devtools warning.

Please review and provide any feedback.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
