### PR TITLE
fix(modern-plugin): support auto sidebar when is bilingual

### DIFF
--- a/.changeset/neat-tools-give.md
+++ b/.changeset/neat-tools-give.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/plugin-rspress': patch
+---
+
+fix(modern-plugin): support auto sidebar when is bilingual

--- a/packages/modern-plugin-rspress/src/features/lanchDoc.ts
+++ b/packages/modern-plugin-rspress/src/features/lanchDoc.ts
@@ -98,16 +98,25 @@ export async function launchDoc({
 
       return [...fileItems, ...directoryItems];
     };
-    return {
-      '': [
-        {
-          text: 'Module List',
-          link: `/index`,
-          collapsible: false,
-          items: await traverse(base),
-        },
-      ],
+
+    const sidebarGroup = [
+      {
+        text: 'Module List',
+        link: `/index`,
+        collapsible: false,
+        items: await traverse(base),
+      },
+    ];
+    const sidebar: Sidebar = {
+      '/': sidebarGroup,
     };
+
+    // support auto sidebar when is bilingual
+    if (languages.length === 2) {
+      const path = `/${languages[1]}/`;
+      sidebar[path] = sidebarGroup;
+    }
+    return sidebar;
   };
 
   const modernDocConfig = mergeModuleDocConfig<UserConfig>(


### PR DESCRIPTION
## Summary
It still exists problems in module plugin when autoSidebar.
This is the impactful way.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
