### PR TITLE
fix(modern-plugin): remove the limit to enable darkmode

### DIFF
--- a/.changeset/nine-bulldogs-wait.md
+++ b/.changeset/nine-bulldogs-wait.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/plugin-rspress': patch
+---
+
+fix(modern-plugin): remove the limit to enable darkmode

--- a/packages/modern-plugin-rspress/src/features/lanchDoc.ts
+++ b/packages/modern-plugin-rspress/src/features/lanchDoc.ts
@@ -132,7 +132,6 @@ export async function launchDoc({
         'index.css',
       ),
       themeConfig: {
-        // TODO: support dark mode in code block
         darkMode: false,
         sidebar: useModuleSidebar ? await getAutoSidebar() : undefined,
         locales,

--- a/packages/modern-plugin-rspress/src/utils.ts
+++ b/packages/modern-plugin-rspress/src/utils.ts
@@ -16,11 +16,6 @@ export const mergeModuleDocConfig = <T>(...configs: T[]): T =>
         return source ?? target;
       }
 
-      // can not enable darkMode.
-      if (key === 'darkMode' && target === false) {
-        return false;
-      }
-
       if (pair.some(_.isArray)) {
         return [..._.castArray(target), ..._.castArray(source)];
       }


### PR DESCRIPTION
## Summary
The code block have supported dark mode, we can remove the limit about it.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
