### PR TITLE
fix: inline image data url start with slash prefix.

### DIFF
--- a/.changeset/dirty-rice-accept.md
+++ b/.changeset/dirty-rice-accept.md
@@ -1,0 +1,6 @@
+---
+'@rspress/runtime': patch
+'@rspress/shared': patch
+---
+
+fix: inline image data url start with slash prefix.

--- a/packages/runtime/src/utils.ts
+++ b/packages/runtime/src/utils.ts
@@ -8,6 +8,7 @@ import {
   withBase as rawWithBase,
   removeBase as rawRemoveBase,
   isExternalUrl,
+  isDataUrl,
   removeHash,
 } from '@rspress/shared';
 
@@ -39,7 +40,10 @@ export function normalizeHrefInRuntime(a: string) {
 
 export function normalizeImagePath(imagePath: string) {
   const isProd = isProduction();
-  if (isExternalUrl(imagePath) || !isProd) {
+  if (!isProd) {
+    return imagePath;
+  }
+  if (isExternalUrl(imagePath) || isDataUrl(imagePath)) {
     return imagePath;
   }
 

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -108,6 +108,10 @@ export function isExternalUrl(url = '') {
   );
 }
 
+export function isDataUrl(url = '') {
+  return /^\s*data:/i.test(url);
+}
+
 export function replaceLang(
   rawUrl: string,
   lang: {


### PR DESCRIPTION
## Summary

When building with `pnpm run build`, ssg incorrectly adds a slash at the beginning of inline image resources in the generated HTML.

![image](https://github.com/web-infra-dev/rspress/assets/3841747/76cc9529-d5c6-4860-bcac-01974471c669)

This pull request addresses this issue by checking if the URL is a data URL. If it is, the URL will be returned as is, without adding a slash.

This should ensure that inline image resources are correctly referenced in the generated HTML. Please review and provide any feedback.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
