### PR TITLE
feat: use config.title as html title.

### DIFF
--- a/.changeset/giant-gorillas-visit.md
+++ b/.changeset/giant-gorillas-visit.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+feat: use config.title as html title.

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -104,6 +104,7 @@ async function createInternalBuildConfig(
       ],
     },
     html: {
+      title: config?.title,
       favicon: normalizeIcon(config?.icon),
       template: path.join(PACKAGE_ROOT, 'index.html'),
     },


### PR DESCRIPTION
## Summary

This pull request addresses an issue where the page title displays as "Rsbuild App" during page load when not in static site generation (SSG) mode. 
The proposed change sets the default page title to the current site's title attribute. 
This should provide a more accurate and user-friendly title during page load.
 Please review and provide any feedback.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
