### PR TITLE
fix(plugin-preview): add defaultRenderMode to remark plugin

### DIFF
--- a/.changeset/thick-birds-care.md
+++ b/.changeset/thick-birds-care.md
@@ -1,0 +1,5 @@
+---
+'@rspress/plugin-preview': patch
+---
+
+fix(plugin-preview): add defaultRenderMode to remark plugin

--- a/packages/plugin-preview/src/codeToDemo.ts
+++ b/packages/plugin-preview/src/codeToDemo.ts
@@ -27,10 +27,11 @@ export const remarkCodeToDemo: Plugin<
       isMobile: boolean;
       getRouteMeta: () => RouteMeta[];
       iframePosition: 'fixed' | 'follow';
+      defaultRenderMode: 'pure' | 'preview';
     },
   ],
   Root
-> = ({ isMobile, getRouteMeta, iframePosition }) => {
+> = ({ isMobile, getRouteMeta, iframePosition, defaultRenderMode }) => {
   const routeMeta = getRouteMeta();
 
   return (tree, vfile) => {
@@ -153,10 +154,23 @@ export const remarkCodeToDemo: Plugin<
       if (node.lang === 'jsx' || node.lang === 'tsx') {
         const value = injectDemoBlockImport(node.value, demoBlockComponentPath);
 
-        const isPure = node?.meta?.includes('pure');
+        const hasPureMeta = node?.meta?.includes('pure');
+        const hasPreviewMeta = node?.meta?.includes('preview');
 
-        // do nothing for pure mode
-        if (isPure) {
+        let noTransform;
+        switch (defaultRenderMode) {
+          case 'pure':
+            noTransform = !hasPreviewMeta;
+            break;
+          case 'preview':
+            noTransform = hasPureMeta;
+            break;
+          default:
+            break;
+        }
+
+        // do not anything for pure mode
+        if (noTransform) {
           return;
         }
 

--- a/packages/plugin-preview/src/index.ts
+++ b/packages/plugin-preview/src/index.ts
@@ -278,7 +278,10 @@ import Demo from ${JSON.stringify(demoComponentPath)}
     },
     markdown: {
       remarkPlugins: [
-        [remarkCodeToDemo, { isMobile, getRouteMeta, iframePosition }],
+        [
+          remarkCodeToDemo,
+          { isMobile, getRouteMeta, iframePosition, defaultRenderMode },
+        ],
       ],
       globalComponents: [
         join(staticPath, 'global-components', 'Container.tsx'),


### PR DESCRIPTION
## Summary
When we set defaultRenderMode, we still process the code block in remark plugin, this fix it.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
