### PR TITLE
style(Nav): fix styling issues for specific sizes

### DIFF
--- a/.changeset/shiny-dancers-kiss.md
+++ b/.changeset/shiny-dancers-kiss.md
@@ -1,0 +1,5 @@
+---
+'@rspress/theme-default': major
+---
+
+style(Nav): fix styling issues for specific sizes

--- a/packages/theme-default/src/components/Nav/index.module.scss
+++ b/packages/theme-default/src/components/Nav/index.module.scss
@@ -28,12 +28,20 @@
   display: none;
 }
 
+.singleItem {
+  word-break: keep-all;
+}
+
 .activeItem,
 .singleItem:hover {
   background-color: var(--rp-c-bg-soft);
   cursor: pointer;
   color: var(--rp-c-brand-dark);
   border-radius: 12px;
+}
+
+.navBarTitle {
+  flex-shrink: 0;
 }
 
 .navContainer :deep(*) {

--- a/packages/theme-default/src/components/Search/index.module.scss
+++ b/packages/theme-default/src/components/Search/index.module.scss
@@ -90,6 +90,7 @@
       margin-left: 5px;
       margin-right: 40px;
       font-weight: 500;
+      white-space: nowrap;
       color: var(--rp-c-text-2);
       transition: all 0.3s;
     }


### PR DESCRIPTION
## Summary
页面尺寸被压缩到一定宽度后，导航栏中，Logo图片会被挤压，搜索按钮和其他菜单项的文案会被挤压换行

![image](https://github.com/web-infra-dev/rspress/assets/152467263/042593bb-2f0d-4873-adf9-6bd1d200af80)


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
