### PR TITLE
feat(create_rspress): support cancel operation

### DIFF
--- a/.changeset/perfect-chairs-fold.md
+++ b/.changeset/perfect-chairs-fold.md
@@ -1,0 +1,5 @@
+---
+'create-rspress': patch
+---
+
+feat(create_rspress): support cancel operation

--- a/packages/create-rspress/src/index.ts
+++ b/packages/create-rspress/src/index.ts
@@ -9,6 +9,7 @@ import {
   formatTargetDir,
   getPkgManager,
   renderFile,
+  cancelPrompt,
 } from './utils';
 import { CustomPromptObject } from './types';
 
@@ -45,7 +46,7 @@ cli.command('', 'Create a new rspress site').action(async () => {
           targetDir = formatTargetDir(state.value) || defaultProjectName;
         },
       },
-    ]);
+    ], { onCancel: cancelPrompt });
 
   await promptProjectDir();
   let root = path.resolve(process.cwd(), targetDir);

--- a/packages/create-rspress/src/utils.ts
+++ b/packages/create-rspress/src/utils.ts
@@ -109,5 +109,10 @@ export function initSitePrompts(options: CustomPromptObject[]) {
   // init formatFn and assign value
   options.forEach(initOptionEvent);
 
-  return prompts(options);
+  return prompts(options, { onCancel: cancelPrompt });
 }
+
+export const cancelPrompt = () => {
+  console.log("Operation cancelled.");
+  process.exit(0);
+};


### PR DESCRIPTION
## Summary

Hi~ I noticed that create-rspress cannot exit during creation. I hope this could help.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
