### PR TITLE
feat(core): support custom meta in tsx file

### DIFF
--- a/.changeset/six-pandas-behave.md
+++ b/.changeset/six-pandas-behave.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+feat(core): support custom meta in tsx file


### PR DESCRIPTION
## Summary
mdx loader will generate __RSPRESS_PAGE_META, if the filePath don't match it, we can get meta from j(t)sx if we customize it.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
