### PR TITLE
feat: improve errors outputted to console

### DIFF
--- a/.changeset/slimy-deers-prove.md
+++ b/.changeset/slimy-deers-prove.md
@@ -1,0 +1,5 @@
+---
+'@rspress/plugin-auto-nav-sidebar': patch
+---
+
+feat: improve error logs if missing locales config

--- a/packages/plugin-auto-nav-sidebar/src/index.ts
+++ b/packages/plugin-auto-nav-sidebar/src/index.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import { RspressPlugin, addTrailingSlash } from '@rspress/shared';
+import { logger } from '@rspress/shared/logger';
 import { combineWalkResult } from './utils';
 import { walk } from './walk';
 
@@ -190,6 +191,7 @@ export function pluginAutoNavSidebar(): RspressPlugin {
         config.themeConfig.locales || config.locales || [];
       const langs = config.themeConfig.locales.map(locale => locale.lang);
       const hasLocales = langs.length > 0;
+      const hasLang = Boolean(config.lang);
       const versions = config.multiVersion?.versions || [];
       const defaultLang = config.lang || '';
       const { default: defaultVersion = '' } = config.multiVersion || {};
@@ -208,6 +210,15 @@ export function pluginAutoNavSidebar(): RspressPlugin {
           }),
         );
       } else {
+        if (hasLang) {
+          logger.error(
+            `\`lang\` is configured but \`locales\` not, ` +
+              `thus \`@rspress/plugin-auto-nav-sidebar\` can not auto generate ` +
+              `navbar level config correctly!\n` +
+              `please check your config file`,
+          );
+          return config;
+        }
         const walks = versions.length
           ? await Promise.all(
               versions.map(version => {


### PR DESCRIPTION
## Summary
The error in #453 was caused by the `@rspress/plugin-auto-nav-sidebar`, which can't generate configs correctly if `locales` are not configured. [Promise here](https://github.com/web-infra-dev/rspress/blob/main/packages/plugin-auto-nav-sidebar/src/walk.ts#L56-L118) is rejected because the value of the name field is `undefined`
<img width="680" alt="image" src="https://github.com/web-infra-dev/rspress/assets/73387709/d614245e-e38d-40df-8a2d-ba6d1c3901da">

Not sure if we should add this to the suitable part of the documentation and where the "suitable part" is

## Related Issue

#453 
<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
