### PR TITLE
fix(plugin-playground): remove preview plugin when use playground

### DIFF
--- a/.changeset/young-tables-occur.md
+++ b/.changeset/young-tables-occur.md
@@ -1,0 +1,5 @@
+---
+'@rspress/plugin-playground': patch
+---
+
+fix(plugin-playground): remove preview plugin when use playground

--- a/packages/plugin-playground/src/cli/index.ts
+++ b/packages/plugin-playground/src/cli/index.ts
@@ -66,9 +66,11 @@ export function pluginPlayground(
 
   return {
     name: '@rspress/plugin-playground',
-    config(config) {
+    config(config, { removePlugin }) {
       config.markdown = config.markdown || {};
       config.markdown.mdxRs = false;
+      // The preview and playground plugin are mutually conflicting.
+      removePlugin('@rspress/plugin-preview');
       return config;
     },
     async routeGenerated(routes: RouteMeta[]) {


### PR DESCRIPTION
## Summary
The two plugins are mutually conflicting.
So we need in playground remove another plugin.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
