### PR TITLE
feat: close nav screen when route changed

### DIFF
--- a/.changeset/fluffy-jars-jump.md
+++ b/.changeset/fluffy-jars-jump.md
@@ -1,0 +1,5 @@
+---
+'@rspress/theme-default': patch
+---
+
+feat: close nav screen when route changed

--- a/packages/theme-default/src/logic/useNav.ts
+++ b/packages/theme-default/src/logic/useNav.ts
@@ -1,9 +1,11 @@
-import { useState } from 'react';
-import { useVersion } from '@rspress/runtime';
+import { useEffect, useState } from 'react';
+import { useLocation, useVersion } from '@rspress/runtime';
 import { useLocaleSiteData } from './useLocaleSiteData';
 
 export function useNavScreen() {
+  const { pathname } = useLocation();
   const [isScreenOpen, setIsScreenOpen] = useState(false);
+
   function openScreen() {
     setIsScreenOpen(true);
     window.addEventListener('resize', closeScreenOnTabletWindow);
@@ -21,6 +23,10 @@ export function useNavScreen() {
       openScreen();
     }
   }
+
+  useEffect(() => {
+    closeScreen();
+  }, [pathname]);
 
   /**
    * Close screen when the user resizes the window wider than tablet size.


### PR DESCRIPTION
## Summary

Close nav screen when route changed, so that users do not need to manually close nav after navigation.

https://github.com/web-infra-dev/rspress/assets/7237365/639c368d-5971-4ca3-9be3-c8044a2d3c11

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
