### PR TITLE
fix(plugin-playground): add defaultRenderMode to remark plugin

### DIFF
--- a/.changeset/warm-keys-live.md
+++ b/.changeset/warm-keys-live.md
@@ -1,0 +1,5 @@
+---
+'@rspress/plugin-playground': patch
+---
+
+fix(plugin-playground): add defaultRenderMode to remark plugin

--- a/packages/plugin-playground/src/cli/index.ts
+++ b/packages/plugin-playground/src/cli/index.ts
@@ -240,7 +240,9 @@ export function pluginPlayground(
       },
     },
     markdown: {
-      remarkPlugins: [[remarkPlugin, { getRouteMeta, editorPosition }]],
+      remarkPlugins: [
+        [remarkPlugin, { getRouteMeta, editorPosition, defaultRenderMode }],
+      ],
       globalComponents: [
         render
           ? render


### PR DESCRIPTION
## Summary


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
