### PR TITLE
fix(core): toc can collect strong and inline code from header, and judge if it is text type when collect value

### DIFF
--- a/.changeset/mean-parents-pull.md
+++ b/.changeset/mean-parents-pull.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+fix(core): parseToc support strong text

--- a/packages/core/src/node/mdx/remarkPlugins/toc.ts
+++ b/packages/core/src/node/mdx/remarkPlugins/toc.ts
@@ -13,7 +13,7 @@ export interface TocItem {
 }
 
 interface ChildNode {
-  type: 'link' | 'text' | 'inlineCode';
+  type: 'link' | 'text' | 'inlineCode' | 'strong';
   value: string;
   children?: ChildNode[];
 }
@@ -43,13 +43,20 @@ export const parseToc = (tree: Root) => {
       let customId = '';
       const text = node.children
         .map((child: ChildNode) => {
-          if (child.type === 'link') {
-            return child.children?.map(item => item.value).join('');
-          } else {
+          if (child.type === 'link' || child.type === 'strong') {
+            return child.children
+              ?.map(item => (item.type === 'text' ? item.value : ''))
+              .join('');
+          }
+          if (child.type === 'text') {
             const [textPart, idPart] = extractTextAndId(child.value);
             customId = idPart;
             return textPart;
           }
+          if (child.type === 'inlineCode') {
+            return child.value;
+          }
+          return '';
         })
         .join('');
       const id = customId ? customId : slugger.slug(text);


### PR DESCRIPTION
## Summary

When I write the following content:
```mdx
### button**test**
```
I will get a error:
![image](https://github.com/web-infra-dev/rspress/assets/50694858/7d98e428-2109-4fa9-a608-31c82129921a)
This PR fix the error and support inline code type too.
And I add a judge for the children type

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
