### PR TITLE
fix(modern-plugin): add useModuleSidebar to plugin option

### DIFF
--- a/.changeset/ninety-carrots-yawn.md
+++ b/.changeset/ninety-carrots-yawn.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/plugin-rspress': patch
+---
+
+fix(modern-plugin): add useModuleSidebar to plugin option

--- a/packages/modern-plugin-rspress/src/types.ts
+++ b/packages/modern-plugin-rspress/src/types.ts
@@ -14,6 +14,7 @@ export type PluginOptions = Pick<
   | 'apiParseTool'
   | 'parseToolOptions'
   | 'iframePosition'
+  | 'useModuleSidebar'
 >;
 
 export type Options = {


### PR DESCRIPTION
## Summary


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
