### PR TITLE
fix: search index file not found when i18n is not set

### DIFF
--- a/.changeset/dirty-apples-promise.md
+++ b/.changeset/dirty-apples-promise.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+fix: search index file not found when i18n is not set

--- a/packages/core/src/node/runtimeModule/siteData/index.ts
+++ b/packages/core/src/node/runtimeModule/siteData/index.ts
@@ -72,7 +72,10 @@ export async function siteDataVMPlugin(context: FactoryContext) {
       indexHashByLang[lang] = indexHash;
       await fs.ensureDir(TEMP_DIR);
       await fs.writeFile(
-        path.join(TEMP_DIR, `${SEARCH_INDEX_NAME}.${lang}.${indexHash}.json`),
+        path.join(
+          TEMP_DIR,
+          `${SEARCH_INDEX_NAME}${lang ? `.${lang}` : ''}.${indexHash}.json`,
+        ),
         stringfiedIndex,
       );
     }),

--- a/packages/core/src/node/searchIndex.ts
+++ b/packages/core/src/node/searchIndex.ts
@@ -7,10 +7,6 @@ import { UserConfig, isSCM, SEARCH_INDEX_NAME } from '@rspress/shared';
 import { logger } from '@rspress/shared/logger';
 import { isProduction, OUTPUT_DIR, TEMP_DIR } from './constants';
 
-export function getSearchIndexFilename(indexHash: string) {
-  return `${SEARCH_INDEX_NAME}.${indexHash}.json`;
-}
-
 export async function writeSearchIndex(config: UserConfig) {
   if (config?.search === false) {
     return;


### PR DESCRIPTION
## Summary

Fix #501 

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
