### PR TITLE
fix(api-docgen): add opitional chaining operator when read apiDocMap

### DIFF
--- a/.changeset/fluffy-jobs-vanish.md
+++ b/.changeset/fluffy-jobs-vanish.md
@@ -1,0 +1,5 @@
+---
+'@rspress/plugin-api-docgen': patch
+---
+
+fix(api-docgen): add opitional chaining operator when read apiDocMap

--- a/packages/plugin-api-docgen/static/global-components/API.tsx
+++ b/packages/plugin-api-docgen/static/global-components/API.tsx
@@ -10,7 +10,9 @@ export default (props: { moduleName: string }) => {
   const { moduleName } = props;
   // some api doc have two languages.
   const apiDocMap = page.apiDocMap as Record<string, string>;
-  const apiDoc = apiDocMap[moduleName] || apiDocMap[`${moduleName}-${lang}`];
+  // avoid error when no page data
+  const apiDoc =
+    apiDocMap?.[moduleName] || apiDocMap?.[`${moduleName}-${lang}`];
   return (
     <ReactMarkdown
       remarkPlugins={[[remarkGfm]]}


### PR DESCRIPTION
## Summary
related #518

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
