### PR TITLE
fix(plugin-preview): remove virtual demo and get it from pageData in Device

### DIFF
--- a/.changeset/wicked-rivers-bow.md
+++ b/.changeset/wicked-rivers-bow.md
@@ -1,0 +1,5 @@
+---
+'@rspress/plugin-preview': patch
+---
+
+fix(plugin-preview): remove virtual demo and get it from pageData in Device

--- a/packages/plugin-preview/src/index.ts
+++ b/packages/plugin-preview/src/index.ts
@@ -76,6 +76,9 @@ export function pluginPreview(options?: Options): RspressPlugin {
       config.markdown.mdxRs = false;
       return config;
     },
+    extendPageData(pageData) {
+      pageData.demoMeta = Object.values(demoMeta).flat();
+    },
     addPages(_config, _isProd) {
       return [
         {

--- a/packages/plugin-preview/static/global-components/Device.tsx
+++ b/packages/plugin-preview/static/global-components/Device.tsx
@@ -1,5 +1,4 @@
 import { usePageData, withBase } from '@rspress/core/runtime';
-import { demos } from 'virtual-meta';
 import { useCallback, useEffect, useState } from 'react';
 import { normalizeId } from '../../dist/utils';
 import MobileOperation from './common/mobile-operation';
@@ -18,8 +17,9 @@ export default () => {
   const pageName = `_${normalizeId(page.pagePath)}`;
   const url = `~demo/${pageName}`;
   const haveDemos =
-    demos.flat().filter(item => new RegExp(`${pageName}_\\d+`).test(item.id))
-      .length > 0;
+    ((page.demoMeta || []) as { id: string }[]).filter(item =>
+      new RegExp(`${pageName}_\\d+`).test(item.id),
+    ).length > 0;
   const initialInnerWidth =
     typeof window !== 'undefined' ? window.innerWidth : 0;
   const [asideWidth, setAsideWidth] = useState('0px');


### PR DESCRIPTION
## Summary
![image](https://github.com/web-infra-dev/rspress/assets/50694858/773b9e1f-3bb7-4c03-86e9-75e301f8d78b)

If we import virtual-meta in device, we will import all code demo, the global style may be overwrite by demo.
So we need remove it.

In fact, we can get demoMeta and add it to page by 'extendPageData', so I do it.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
