### PR TITLE
fix: `-c` unknown option in rspress cli

### DIFF
--- a/.changeset/fuzzy-bulldogs-know.md
+++ b/.changeset/fuzzy-bulldogs-know.md
@@ -1,0 +1,6 @@
+---
+'@rspress/core': patch
+'rspress': patch
+---
+
+fix: `-c` unknown option in rspress cli

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,7 +23,7 @@ const setNodeEnv = (env: 'development' | 'production') => {
   process.env.NODE_ENV = env;
 };
 
-cli.option('--config [config]', 'Specify the path to the config file');
+cli.option('-c,--config [config]', 'Specify the path to the config file');
 
 cli
   .command('[root]', 'start dev server') // default command
@@ -104,27 +104,23 @@ cli
     },
   );
 
-cli
-  .command('build [root]')
-  .option('-c --config <config>', 'specify config file')
-  .action(async (root, options) => {
-    setNodeEnv('production');
-    const cwd = process.cwd();
-    const config = await loadConfigFile(options.config);
-    if (root) {
-      config.root = path.join(cwd, root);
-    }
-    await build({
-      appDirectory: cwd,
-      docDirectory: config.root || path.join(cwd, root ?? 'docs'),
-      config,
-    });
+cli.command('build [root]').action(async (root, options) => {
+  setNodeEnv('production');
+  const cwd = process.cwd();
+  const config = await loadConfigFile(options.config);
+  if (root) {
+    config.root = path.join(cwd, root);
+  }
+  await build({
+    appDirectory: cwd,
+    docDirectory: config.root || path.join(cwd, root ?? 'docs'),
+    config,
   });
+});
 
 cli
   .command('preview')
   .alias('serve')
-  .option('-c --config <config>', 'specify config file')
   .option('--port [port]', 'port number')
   .option('--host [host]', 'hostname')
   .action(


### PR DESCRIPTION
## Summary

Fix #524 

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
