### PR TITLE
fix: clear query text when search box opens again

### DIFF
--- a/.changeset/unlucky-lamps-wink.md
+++ b/.changeset/unlucky-lamps-wink.md
@@ -1,0 +1,5 @@
+---
+'@rspress/theme-default': minor
+---
+
+fix clear query text when search box opens again

--- a/packages/theme-default/src/components/Search/SearchPanel.tsx
+++ b/packages/theme-default/src/components/Search/SearchPanel.tsx
@@ -158,6 +158,8 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
       if (!pageSearcherRef.current) {
         initPageSearcher();
       }
+    } else {
+      setQuery('');
     }
   }, [focused]);
 


### PR DESCRIPTION
## Summary

![1704451737625](https://github.com/web-infra-dev/rspress/assets/44596995/d191bcfd-4078-4de6-a165-7f7e61954482)

If the search query text is not cleared and the search box is closed, `No result` is displayed when the search box is opened again.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
