### PR TITLE
fix: avoid pushing to history when clicking on the same current link

### DIFF
--- a/.changeset/pink-falcons-wink.md
+++ b/.changeset/pink-falcons-wink.md
@@ -1,0 +1,5 @@
+---
+'@rspress/theme-default': major
+---
+
+fix avoid pushing to history when clicking on the current link

--- a/packages/theme-default/src/components/Link/index.tsx
+++ b/packages/theme-default/src/components/Link/index.tsx
@@ -60,7 +60,7 @@ export function Link(props: LinkProps) {
     }
 
     // handle normal link
-    if (!process.env.__SSR__) {
+    if (!process.env.__SSR__ && !inCurrentPage) {
       const matchedRoutes = matchRoutes(
         routes,
         normalizeRoutePath(withBaseUrl),


### PR DESCRIPTION
## Summary

Clicking on the same current internal link of sidebar item or navBar title multiple times, will cause `navigate` to trigger multiple times, which normally shouldn't be triggered.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
