### PR TITLE
feat: add bodyScrollLock when sideBar is open

### DIFF
--- a/.changeset/neat-snails-confess.md
+++ b/.changeset/neat-snails-confess.md
@@ -1,0 +1,5 @@
+---
+'@rspress/theme-default': minor
+---
+
+feat bodyScrollLock when sidebar is open

--- a/packages/theme-default/src/components/Sidebar/index.tsx
+++ b/packages/theme-default/src/components/Sidebar/index.tsx
@@ -7,6 +7,7 @@ import {
 } from '@rspress/shared';
 import { routes } from 'virtual-routes';
 import { matchRoutes, useLocation, removeBase } from '@rspress/runtime';
+import { disableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock';
 import {
   isActive,
   useDisableNav,
@@ -108,6 +109,14 @@ export function SideBar(props: Props) {
     newSidebarData.forEach(traverse);
     setSidebarData(newSidebarData);
   }, [rawSidebarData, pathname]);
+
+  useEffect(() => {
+    isSidebarOpen &&
+      disableBodyScroll(document.body, { reserveScrollBarGap: true });
+    return () => {
+      clearAllBodyScrollLocks();
+    };
+  }, [isSidebarOpen]);
 
   const removeLangPrefix = (path: string) => {
     return path.replace(langRoutePrefix, '');


### PR DESCRIPTION
## Summary

Add bodyScrollLock when sideBar is open.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
