### PR TITLE
types: export PluginShikiOptions type

### DIFF
--- a/.changeset/thirty-maps-remember.md
+++ b/.changeset/thirty-maps-remember.md
@@ -1,0 +1,5 @@
+---
+'@rspress/plugin-shiki': patch
+---
+
+types: export PluginShikiOptions type

--- a/packages/plugin-shiki/src/shiki/pluginShiki.ts
+++ b/packages/plugin-shiki/src/shiki/pluginShiki.ts
@@ -1,12 +1,12 @@
 import { join } from 'path';
 import type { RspressPlugin } from '@rspress/shared';
 import { DEFAULT_HIGHLIGHT_LANGUAGES } from '@rspress/shared';
-import { Lang } from 'shiki';
+import type { Lang } from 'shiki';
 import { getHighlighter } from './highlighter';
 import { rehypePluginShiki } from './rehypePlugin';
-import { ITransformer } from './types';
+import type { ITransformer } from './types';
 
-interface PluginShikiOptions {
+export interface PluginShikiOptions {
   /**
    * The theme of shiki.
    */


### PR DESCRIPTION
## Summary

Export PluginShikiOptions type from `@rspress/plugin-shiki`.

```ts
import type { PluginShikiOptions } from '@rspress/plugin-shiki';
```

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
