### PR TITLE
feat: serve publicDir via Rsbuild

### DIFF
--- a/.changeset/wise-carpets-tie.md
+++ b/.changeset/wise-carpets-tie.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+feat: serve publicDir via Rsbuild

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -96,7 +96,6 @@
     "remark-parse": "^10.0.1",
     "remark-rehype": "^10.1.0",
     "rspack-plugin-virtual-module": "0.1.12",
-    "sirv": "^2.0.2",
     "source-map": "0.7.4",
     "string-replace-loader": "^3.1.0",
     "unified": "^10.1.2",

--- a/packages/core/src/node/build.ts
+++ b/packages/core/src/node/build.ts
@@ -19,7 +19,6 @@ import {
   META_GENERATOR,
   HTML_START_TAG,
   BODY_START_TAG,
-  PUBLIC_DIR,
   TEMP_DIR,
 } from './constants';
 import { initRsbuild } from './initRsbuild';
@@ -82,11 +81,6 @@ export async function bundle(
         false,
       );
       await clientBuilder.build();
-    }
-    // Copy public dir to output folder
-    const publicDir = join(docDirectory, PUBLIC_DIR);
-    if (await fs.pathExists(publicDir)) {
-      await fs.copy(publicDir, outputDir);
     }
   } finally {
     await writeSearchIndex(config);

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -9,7 +9,6 @@ import {
 } from '@rspress/shared';
 import fs from '@rspress/shared/fs-extra';
 import type { RsbuildInstance, RsbuildConfig } from '@rsbuild/core';
-import sirv from 'sirv';
 import { tailwindConfig } from '../../tailwind.config';
 import {
   CLIENT_ENTRY,
@@ -52,8 +51,6 @@ async function createInternalBuildConfig(
   const checkDeadLinks = (config?.markdown?.checkDeadLinks && !isSSR) ?? false;
   const base = config?.base ?? '';
 
-  const publicDir = path.join(userDocRoot, 'public');
-  const isPublicDirExist = await fs.pathExists(publicDir);
   // In production, we need to add assetPrefix in asset path
   const assetPrefix = isProduction()
     ? removeTrailingSlash(config?.builderConfig?.output?.assetPrefix ?? base)
@@ -93,16 +90,15 @@ async function createInternalBuildConfig(
       printUrls: ({ urls }) => {
         return urls.map(url => `${url}/${removeLeadingSlash(base)}`);
       },
+      publicDir: {
+        name: path.join(userDocRoot, PUBLIC_DIR),
+      },
     },
     dev: {
       progressBar: false,
       // Serve static files
       setupMiddlewares: [
         middlewares => {
-          if (isPublicDirExist) {
-            middlewares.unshift(sirv(publicDir));
-          }
-
           middlewares.unshift(serveSearchIndexMiddleware(config));
         },
       ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,9 +447,6 @@ importers:
       rspack-plugin-virtual-module:
         specifier: 0.1.12
         version: 0.1.12
-      sirv:
-        specifier: ^2.0.2
-        version: 2.0.2
       source-map:
         specifier: 0.7.4
         version: 0.7.4
@@ -4916,10 +4913,6 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
-
-  /@polka/url@1.0.0-next.21:
-    resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
-    dev: false
 
   /@rc-component/context@1.4.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-kFcNxg9oLRMoL3qki0OMxK+7g5mypjgaaJp/pkOis/6rVxma9nJBF/8kCIuTYHUQNr0ii7MxqE33wirPZLJQ2w==}
@@ -10820,11 +10813,6 @@ packages:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
 
-  /mrmime@1.0.1:
-    resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
-    engines: {node: '>=10'}
-    dev: false
-
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
@@ -12915,15 +12903,6 @@ packages:
       is-arrayish: 0.3.2
     dev: false
 
-  /sirv@2.0.2:
-    resolution: {integrity: sha512-4Qog6aE29nIjAOKe/wowFTxOdmbEZKb+3tsLljaBRzJwtqto0BChD2zzH0LhgCSXiI+V7X+Y45v14wBZQ1TK3w==}
-    engines: {node: '>= 10'}
-    dependencies:
-      '@polka/url': 1.0.0-next.21
-      mrmime: 1.0.1
-      totalist: 3.0.1
-    dev: false
-
   /sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
     dev: true
@@ -13476,11 +13455,6 @@ packages:
 
   /toggle-selection@1.0.6:
     resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
-
-  /totalist@3.0.1:
-    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
-    engines: {node: '>=6'}
-    dev: false
 
   /tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}


### PR DESCRIPTION
## Summary

Rsbuild provides `server.publicDir` to serve the public folder, Rspress can use it and do not need to depend on `sirv`.

Tested in `e2e/fixtures/production`.

## Related Issue

https://rsbuild.dev/config/server/public-dir

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
