### PR TITLE
feat: reuse logger from Rsbuild

### DIFF
--- a/.changeset/pretty-hornets-battle.md
+++ b/.changeset/pretty-hornets-battle.md
@@ -1,0 +1,5 @@
+---
+'@rspress/shared': patch
+---
+
+feat: reuse logger from Rsbuild

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -54,7 +54,6 @@
     "@rsbuild/core": "0.3.1",
     "unified": "10.1.2",
     "chalk": "4.1.2",
-    "rslog": "^1.1.0",
     "execa": "5.1.1",
     "fs-extra": "11.2.0",
     "gray-matter": "4.0.3"

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -1,1 +1,1 @@
-export { logger } from 'rslog';
+export { logger } from '@rsbuild/core';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -1093,9 +1093,6 @@ importers:
       gray-matter:
         specifier: 4.0.3
         version: 4.0.3
-      rslog:
-        specifier: ^1.1.0
-        version: 1.1.0
       unified:
         specifier: 10.1.2
         version: 10.1.2


### PR DESCRIPTION
## Summary

Reuse logger from Rsbuild. Rsbuild now provides logger as a public API see: https://rsbuild.dev/api/javascript-api/core#logger.

This change can also upgrade rslog to latest version (v1.2.0) and fix some bug, see https://github.com/rspack-contrib/rslog/releases

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
