### PR TITLE
fix: When using strict equality comparison for absolute paths, smooth the path separators of different systems.

### DIFF
--- a/packages/plugin-playground/src/cli/remarkPlugin.ts
+++ b/packages/plugin-playground/src/cli/remarkPlugin.ts
@@ -1,4 +1,4 @@
-import path, { join } from 'path';
+import { dirname, join, resolve } from 'path';
 import { visit } from 'unist-util-visit';
 import fs from '@rspress/shared/fs-extra';
 import type { RouteMeta } from '@rspress/shared';
@@ -39,7 +39,7 @@ export const remarkPlugin: Plugin<[RemarkPluginProps], Root> = ({
 
   return (tree, vfile) => {
     const route = routeMeta.find(
-      meta => meta.absolutePath === (vfile.path || vfile.history[0]),
+      meta => resolve(meta.absolutePath) === resolve((vfile.path || vfile.history[0])),
     );
     if (!route) {
       return;
@@ -52,7 +52,7 @@ export const remarkPlugin: Plugin<[RemarkPluginProps], Root> = ({
         if (!src) {
           return;
         }
-        const demoPath = join(path.dirname(route.absolutePath), src);
+        const demoPath = join(dirname(route.absolutePath), src);
         if (!fs.existsSync(demoPath)) {
           return;
         }


### PR DESCRIPTION
## Summary
@rspress/plugin-playground 插件在windows系统下不能正常的工作，排查原因为: windows系统下getRouteMeta() 与 remarkPlugin 中得到的绝对路径使用不同的路径分隔符导致。
当两个路径比较时，须要抹平不同系统之间的差异。 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
