### PR TITLE
fix: publicDir mkdir conflict

### DIFF
--- a/.changeset/twenty-points-remember.md
+++ b/.changeset/twenty-points-remember.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+fix: publicDir repeat mkdir conflict

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -90,9 +90,11 @@ async function createInternalBuildConfig(
       printUrls: ({ urls }) => {
         return urls.map(url => `${url}/${removeLeadingSlash(base)}`);
       },
-      publicDir: {
-        name: path.join(userDocRoot, PUBLIC_DIR),
-      },
+      publicDir: isSSR
+        ? false
+        : {
+            name: path.join(userDocRoot, PUBLIC_DIR),
+          },
     },
     dev: {
       progressBar: false,


### PR DESCRIPTION
## Summary

publicDir mkdir conflict when repeat call build with promise.all

<img width="788" alt="image" src="https://github.com/web-infra-dev/rspress/assets/22373761/8f14d483-0416-4e15-bd76-1d66806eb0c2">


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
