### PR TITLE
fix: ensure afterBuild executed after dev compile done

### DIFF
--- a/.changeset/five-avocados-cheat.md
+++ b/.changeset/five-avocados-cheat.md
@@ -1,0 +1,5 @@
+---
+"@rspress/core": patch
+---
+
+fix: ensure afterBuild executed after dev compile done

--- a/packages/core/src/node/dev.ts
+++ b/packages/core/src/node/dev.ts
@@ -34,12 +34,21 @@ export async function dev(options: DevOptions): Promise<ServerInstance> {
       false,
       extraBuilderConfig,
     );
+    builder.addPlugins([
+      {
+        name: 'rspress:afterBuild',
+        setup(api) {
+          api.onDevCompileDone(async () => {
+            await pluginDriver.afterBuild();
+          });
+        },
+      },
+    ]);
     const { server } = await builder.startDevServer({
       // We will support the following options in the future
       getPortSilently: true,
     });
 
-    await pluginDriver.afterBuild();
     return server;
   } finally {
     await writeSearchIndex(config);

--- a/packages/core/src/node/dev.ts
+++ b/packages/core/src/node/dev.ts
@@ -34,16 +34,9 @@ export async function dev(options: DevOptions): Promise<ServerInstance> {
       false,
       extraBuilderConfig,
     );
-    builder.addPlugins([
-      {
-        name: 'rspress:afterBuild',
-        setup(api) {
-          api.onDevCompileDone(async () => {
-            await pluginDriver.afterBuild();
-          });
-        },
-      },
-    ]);
+    builder.onDevCompileDone(async () => {
+      await pluginDriver.afterBuild();
+    });
     const { server } = await builder.startDevServer({
       // We will support the following options in the future
       getPortSilently: true,


### PR DESCRIPTION
## Summary

In rsbuild, when we called `builder.startDevServer`, the compile process doesn't finished. So we should execute `afterBuild` hook of Rspress in the `onDevCompileDone` hook of Rsbuild to ensure the compile process done.
## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
