### PR TITLE
fix: ensure frontmatter exists during parsing mdx content

### DIFF
--- a/packages/plugin-auto-nav-sidebar/src/utils.ts
+++ b/packages/plugin-auto-nav-sidebar/src/utils.ts
@@ -28,16 +28,21 @@ export async function detectFilePath(rawPath: string) {
 export async function extractH1Title(
   filePath: string,
   rootDir: string,
+  /** prefer using the title declared in frontmatter rather than file content */
+  preferFrontMatter = true,
 ): Promise<string> {
   try {
     const realPath = await detectFilePath(filePath);
     const content = await fs.readFile(realPath, 'utf-8');
+    const { frontmatter } = loadFrontMatter(content, filePath, rootDir);
+    if (frontmatter.title && preferFrontMatter) {
+      return frontmatter.title;
+    }
     const fileNameWithoutExt = path.basename(realPath, path.extname(realPath));
     const h1RegExp = /^#\s+(.*)$/m;
     const match = content.match(h1RegExp);
     if (!match) {
-      const { frontmatter } = loadFrontMatter(content, filePath, rootDir);
-      return frontmatter.title || fileNameWithoutExt;
+      return fileNameWithoutExt;
     } else {
       return match[1] || fileNameWithoutExt;
     }


### PR DESCRIPTION
## Summary

TODO: write here til pr finished

## Related Issue

closes #534 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
