### PR TITLE
feat: allow table scrolling to avoid breaking work

### DIFF
--- a/.changeset/curly-ravens-tap.md
+++ b/.changeset/curly-ravens-tap.md
@@ -1,0 +1,5 @@
+---
+"@rspress/theme-default": patch
+---
+
+feat: allow table scrolling to avoid breaking work

--- a/packages/theme-default/src/layout/DocLayout/docComponents/table.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/table.tsx
@@ -4,10 +4,7 @@ export const Table = (props: ComponentProps<'table'>) => {
   return (
     <table
       {...props}
-      className="table border-collapse text-base my-5 overflow-x-auto leading-7 border-gray-light-2"
-      style={{
-        wordBreak: 'break-word',
-      }}
+      className="block border-collapse text-base my-5 overflow-x-auto leading-7 border-gray-light-2"
     />
   );
 };


### PR DESCRIPTION
## Summary

Allow table scrolling to avoid breaking work. Breaking a word can cause difficulty reading the word.

such as:

![image](https://github.com/web-infra-dev/rspress/assets/7237365/f3fb27d7-ad3b-41dd-8180-ef87b5fbcc67)

## Related Issue

https://rsbuild.dev/guide/start/features

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
