### PR TITLE
docs: integrate rsfamily nav icon

### DIFF
--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -18,13 +18,13 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "rspress": "workspace:*",
-    "ts-node": "^10.9.1",
-    "typescript": "^5",
-    "@types/react": "18.2.0",
     "@documate/documate": "^0.1.0",
     "@documate/react": "0.2.1",
-    "framer-motion": "10.16.4"
+    "@types/react": "18.2.0",
+    "framer-motion": "10.16.4",
+    "rspress": "workspace:*",
+    "ts-node": "^10.9.1",
+    "typescript": "^5"
   },
   "publishConfig": {
     "access": "public",
@@ -33,5 +33,8 @@
   },
   "files": [
     "docs"
-  ]
+  ],
+  "dependencies": {
+    "rsfamily-nav-icon": "^1.0.1"
+  }
 }

--- a/packages/document/theme/index.tsx
+++ b/packages/document/theme/index.tsx
@@ -1,6 +1,8 @@
 import Theme from 'rspress/theme';
 // import { NoSSR, useLang } from 'rspress/runtime';
 // import { Documate } from '@documate/react';
+import { RsfamilyNavIcon } from 'rsfamily-nav-icon';
+import 'rsfamily-nav-icon/dist/index.css';
 import '@documate/react/dist/style.css';
 import './index.css';
 
@@ -23,14 +25,15 @@ const Layout = () => {
   // const lang = useLang();
   return (
     <Theme.Layout
-    // afterNavTitle={
-    //   <NoSSR>
-    //     <Documate
-    //       endpoint={`${process.env.DOCUMATE_BACKEND_URL}/ask`}
-    //       predefinedQuestions={predefinedQuestions[lang as 'zh' | 'en']}
-    //     />
-    //   </NoSSR>
-    // }
+      beforeNavTitle={<RsfamilyNavIcon />}
+      // afterNavTitle={
+      //   <NoSSR>
+      //     <Documate
+      //       endpoint={`${process.env.DOCUMATE_BACKEND_URL}/ask`}
+      //       predefinedQuestions={predefinedQuestions[lang as 'zh' | 'en']}
+      //     />
+      //   </NoSSR>
+      // }
     />
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -586,6 +586,10 @@ importers:
         version: 5.0.4
 
   packages/document:
+    dependencies:
+      rsfamily-nav-icon:
+        specifier: ^1.0.1
+        version: 1.0.1
     devDependencies:
       '@documate/documate':
         specifier: ^0.1.0
@@ -12687,6 +12691,10 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
+
+  /rsfamily-nav-icon@1.0.1:
+    resolution: {integrity: sha512-TJdyzLpFfmEGfJiPAwZqn1TdXwoR7j/Y0j9ejovNk3zABzJ1FRQ6WZl7DVQQTHoJnABlRgXphMuxnAZ2UMePdQ==}
+    dev: false
 
   /rslog@1.1.0:
     resolution: {integrity: sha512-wtTijPuwUhyVG7YvnIVzlefhlto4qJ9vm42ewwJtqrOBP/vKdZCIyfiYm0odVCR3ajR1CIUqaloIzbqhlbyaZA==}


### PR DESCRIPTION
## Summary

Integrate rsfamily nav icon.

![image](https://github.com/web-infra-dev/rspress/assets/7237365/0ab7dcbd-1809-4f49-8d7a-67183360632f)

## Related Issue

https://github.com/rspack-contrib/rsfamily-nav-icon

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
