### PR TITLE
fix: sidebar walk excludes node_modules

### DIFF
--- a/packages/plugin-auto-nav-sidebar/src/walk.ts
+++ b/packages/plugin-auto-nav-sidebar/src/walk.ts
@@ -150,8 +150,9 @@ export async function walk(workDir: string, routePrefix = '/') {
     }
   });
   // find the `_meta.json` file in the subdirectory
-  const subDirs = (await fs.readdir(workDir)).filter(v =>
-    fs.statSync(path.join(workDir, v)).isDirectory(),
+  const subDirs = (await fs.readdir(workDir)).filter(
+    v =>
+      fs.statSync(path.join(workDir, v)).isDirectory() && v !== 'node_modules',
   );
   // Every sub dir will represent a group of sidebar
   const sidebarConfig: Sidebar = {};


### PR DESCRIPTION
## Summary
If someone sets rspress as the root directory for special purposes, it will read the node_modules directory at the same level.

I know it's recommended to designate a separate directory as root.
but, My special-purpose case is when I choose to place my .mdx files in the same place as my script files, like .stories.js, .styles.js, or .test.js, for greater cohesion.

`rspress.config.ts`

```
{
  root: path.join(__dirname, '..', 'my-rspress'),
  ...
}
```

This causes a lot of unnecessary navigation and warnings, which is not comfortable.
(The warnings are proportional to the number of packages installed.)

```
warn    Can't find the file: /Users/haydnhkim/my-rspress/node_modules/abort-controller/LICENSE, please check it in "/Users/haydnhkim/my-rspress/node_modules/abort-controller/_meta.json".
warn    Can't find the file: /Users/haydnhkim/my-rspress/node_modules/agentkeepalive/LICENSE, please check it in "/Users/haydnhkim/my-rspress/node_modules/agentkeepalive/_meta.json".
warn    Can't find the file: /Users/haydnhkim/my-rspress/node_modules/dayjs/LICENSE, please check it in "/Users/haydnhkim/my-rspress/node_modules/dayjs/_meta.json".
warn    Can't find the file: /Users/haydnhkim/my-rspress/node_modules/dequal/license, please check it in "/Users/haydnhkim/my-rspress/node_modules/dequal/_meta.json".
...
```

To solve this problem, I exceptioned node_modules.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
