### PR TITLE
fix(plugin-preview): Convert isMobileMode variable to boolean

### DIFF
--- a/.changeset/violet-falcons-listen.md
+++ b/.changeset/violet-falcons-listen.md
@@ -1,0 +1,5 @@
+---
+'@rspress/plugin-preview': patch
+---
+
+Support external demo to specific isMobile prop

--- a/packages/plugin-preview/src/codeToDemo.ts
+++ b/packages/plugin-preview/src/codeToDemo.ts
@@ -131,11 +131,24 @@ export const remarkCodeToDemo: Plugin<
         const src = node.attributes.find(
           (attr: { name: string; value: string }) => attr.name === 'src',
         )?.value;
-        const isMobileMode =
-          node.attributes.find(
-            (attr: { name: string; value: boolean }) =>
-              attr.name === 'isMobile',
-          )?.value ?? isMobile;
+        let isMobileMode = node.attributes.find(
+          (attr: { name: string; value: boolean }) => attr.name === 'isMobile',
+        )?.value;
+        if (isMobileMode === undefined) {
+          // isMobile is not specified, eg: <code />
+          isMobileMode = isMobile;
+        } else if (isMobileMode === null) {
+          // true by default, eg: <code isMobile />
+          isMobileMode = true;
+        } else if (typeof isMobileMode === 'object') {
+          // jsx value, isMobileMode.value now must be string, even if input is
+          // any complex struct rather than primitive type
+          // eg: <code isMobile={ anyOfOrOther([true, false, 'true', 'false', {}]) } />
+          isMobileMode = isMobileMode.value !== 'false';
+        } else {
+          // string value, eg: <code isMobile="true" />
+          isMobileMode = isMobileMode !== 'false';
+        }
         if (!src) {
           return;
         }

--- a/packages/plugin-preview/static/global-styles/web.css
+++ b/packages/plugin-preview/static/global-styles/web.css
@@ -1,4 +1,4 @@
-:root .preview-code div[class*='language-'] {
+:root .rspress-preview-code div[class*='language-'] {
   margin: 0;
   border-radius: 0;
   height: 100%;


### PR DESCRIPTION
When use html code element with isMobile prop, it renders wrongly because the `isMobileMode` variable should be boolean but is an object. This commit forcibly convert `isMobileMode` to boolean type.

## Summary


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
