### PR TITLE
fix(plugin-playground): fix spelling error which break render mode

### DIFF
--- a/.changeset/gentle-tomatoes-raise.md
+++ b/.changeset/gentle-tomatoes-raise.md
@@ -1,0 +1,5 @@
+---
+'@rspress/plugin-playground': patch
+---
+
+fix pure meta in code block which not effective

--- a/packages/plugin-playground/src/cli/remarkPlugin.ts
+++ b/packages/plugin-playground/src/cli/remarkPlugin.ts
@@ -24,7 +24,7 @@ function createPlaygroundNode(
 interface RemarkPluginProps {
   getRouteMeta: () => RouteMeta[];
   editorPosition: 'left' | 'right';
-  defaultRenderMode: 'pure' | 'preview';
+  defaultRenderMode: 'pure' | 'playground';
 }
 
 /**
@@ -75,14 +75,14 @@ export const remarkPlugin: Plugin<[RemarkPluginProps], Root> = ({
     visit(tree, 'code', node => {
       if (node.lang === 'jsx' || node.lang === 'tsx') {
         const hasPureMeta = node?.meta?.includes('pure');
-        const hasPreviewMeta = node?.meta?.includes('preview');
+        const hasPlaygroundMeta = node?.meta?.includes('playground');
 
         let noTransform;
         switch (defaultRenderMode) {
           case 'pure':
-            noTransform = !hasPreviewMeta;
+            noTransform = !hasPlaygroundMeta;
             break;
-          case 'preview':
+          case 'playground':
             noTransform = hasPureMeta;
             break;
           default:


### PR DESCRIPTION
## Summary


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
