### PR TITLE
fix: require module error in next rspack version

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -9,7 +9,6 @@
     "directory": "packages/runtime"
   },
   "license": "MIT",
-  "type": "module",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

fix rspack-ecosystem-ci problem: require module error
![img_v3_027l_0ed2e5f8-8769-48de-9817-5bd6179c05ag](https://github.com/web-infra-dev/rspress/assets/22373761/1239e3f2-0823-4b36-9434-5cca9a3bb253)

https://github.com/web-infra-dev/rspack-ecosystem-ci/actions/runs/7737817821/job/21097458012

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
