### PR TITLE
fix(plugin-preview): fix demo id and avoid 404 in production

### DIFF
--- a/.changeset/curly-bottles-own.md
+++ b/.changeset/curly-bottles-own.md
@@ -2,4 +2,4 @@
 '@modern-js/plugin-rspress': patch
 ---
 
-support defaultRenderMode to keep same as preview
+feat: support defaultRenderMode to keep same as preview

--- a/.changeset/nice-masks-drum.md
+++ b/.changeset/nice-masks-drum.md
@@ -1,0 +1,5 @@
+---
+'@rspress/plugin-preview': patch
+---
+
+fix: fix demo id and avoid 404 in production

--- a/packages/plugin-preview/src/virtual-demo.tsx
+++ b/packages/plugin-preview/src/virtual-demo.tsx
@@ -8,8 +8,8 @@ import './virtual-demo.scss';
 export default function Demo(props: { iframePosition: string }) {
   // get the id from the pathname
   const { pathname } = useLocation();
-  const pureDemoPath = pathname.split('/').filter(Boolean).slice(1)?.join('/');
-  const normalizedId = normalizeId(pureDemoPath || '');
+  const id = pathname.split('/').filter(Boolean).pop();
+  const normalizedId = normalizeId(id || '');
   // get component from virtual-meta
   if (props.iframePosition === 'fixed') {
     const renderDemos = demos


### PR DESCRIPTION
## Summary
We can find that this logic was broken by https://github.com/web-infra-dev/rspress/pull/244/files#diff-9558abcf9793ab81c8610c64e732478c5ec3533d56a02a333e71fd38cfb843d7L11

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
