### PR TITLE
fix(document): style duplicating issue of rspress.dev #551

### DIFF
--- a/packages/core/src/node/PluginDriver.ts
+++ b/packages/core/src/node/PluginDriver.ts
@@ -4,6 +4,7 @@ import type {
   RspressPlugin,
   RouteMeta,
 } from '@rspress/shared';
+import { isDebugMode } from '@rspress/shared';
 import { pluginContainerSyntax } from '@rspress/plugin-container-syntax';
 
 export class PluginDriver {
@@ -57,6 +58,20 @@ export class PluginDriver {
 
     // Support the container syntax in markdown/mdx, such as :::tip
     this.addPlugin(pluginContainerSyntax());
+
+    if (isDebugMode()) {
+      const SourceBuildPlugin = await import(
+        // @ts-expect-error need moduleResolution: Node16, NodeNext or Bundler to get type declerations work
+        '@rspress/theme-default/node/source-build-plugin.js'
+      ).then(
+        r => r.SourceBuildPlugin,
+        () => null as never,
+      );
+
+      if (SourceBuildPlugin) {
+        this.addPlugin(SourceBuildPlugin());
+      }
+    }
 
     (config.plugins || []).forEach(plugin => {
       this.addPlugin(plugin);

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -4,12 +4,10 @@ import {
   removeLeadingSlash,
   MDX_REGEXP,
   RSPRESS_TEMP_DIR,
-  isDebugMode,
   removeTrailingSlash,
 } from '@rspress/shared';
 import fs from '@rspress/shared/fs-extra';
 import type { RsbuildInstance, RsbuildConfig } from '@rsbuild/core';
-import { tailwindConfig } from '../../tailwind.config';
 import {
   CLIENT_ENTRY,
   SSR_ENTRY,
@@ -147,28 +145,6 @@ async function createInternalBuildConfig(
       printFileSize: !isSSR,
     },
     tools: {
-      postcss(config) {
-        // In debug mode, we should use tailwindcss to build the theme source code
-        if (isDebugMode()) {
-          try {
-            config.postcssOptions.plugins.push(
-              require('tailwindcss')({
-                config: {
-                  ...tailwindConfig,
-                  content: [
-                    path.resolve(
-                      PACKAGE_ROOT,
-                      '../theme-default/src/**/*.{ts,tsx}',
-                    ),
-                  ],
-                },
-              }),
-            );
-          } catch (e) {
-            // if require tailwindcss failed, skip
-          }
-        }
-      },
       bundlerChain(chain, { CHAIN_ID }) {
         const swcLoaderOptions = chain.module
           .rule(CHAIN_ID.RULE.JS)
@@ -253,7 +229,9 @@ export async function initRsbuild(
   const rsbuild = await createRsbuild({
     rsbuildConfig: mergeRsbuildConfig(
       internalRsbuildConfig,
-      ...(config?.plugins?.map(plugin => plugin.builderConfig ?? {}) || []),
+      ...(pluginDriver
+        .getPlugins()
+        ?.map(plugin => plugin.builderConfig ?? {}) || []),
       config?.builderConfig || {},
       extraRsbuildConfig || {},
     ),

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -156,7 +156,10 @@ async function createInternalBuildConfig(
                 config: {
                   ...tailwindConfig,
                   content: [
-                    path.join(PACKAGE_ROOT, 'src', 'theme-default', '**/*'),
+                    path.resolve(
+                      PACKAGE_ROOT,
+                      '../theme-default/src/**/*.{ts,tsx}',
+                    ),
                   ],
                 },
               }),

--- a/packages/document/rspress.config.ts
+++ b/packages/document/rspress.config.ts
@@ -1,6 +1,12 @@
 import path from 'path';
 import { defineConfig } from 'rspress/config';
 
+const alias: Record<string, string | string[]> = {};
+
+if (process.env.DOC_DEBUG) {
+  alias['rspress/theme'] = path.resolve(__dirname, '../theme-default/src');
+}
+
 export default defineConfig({
   markdown: {
     checkDeadLinks: true,
@@ -25,9 +31,7 @@ export default defineConfig({
           process.env.DOCUMATE_BACKEND_URL,
         ),
       },
-      alias: {
-        '@/logic': path.join(__dirname, '../theme-default/src/logic'),
-      },
+      alias,
     },
     html: {
       tags: [

--- a/packages/document/rspress.config.ts
+++ b/packages/document/rspress.config.ts
@@ -1,11 +1,4 @@
-import path from 'path';
 import { defineConfig } from 'rspress/config';
-
-const alias: Record<string, string | string[]> = {};
-
-if (process.env.DOC_DEBUG) {
-  alias['rspress/theme'] = path.resolve(__dirname, '../theme-default/src');
-}
 
 export default defineConfig({
   markdown: {
@@ -31,7 +24,6 @@ export default defineConfig({
           process.env.DOCUMATE_BACKEND_URL,
         ),
       },
-      alias,
     },
     html: {
       tags: [

--- a/packages/document/tsconfig.json
+++ b/packages/document/tsconfig.json
@@ -5,10 +5,9 @@
     "paths": {
       "i18n": ["./i18n.json"],
       "@/assets/*": ["./docs/public/*"],
-      "@/*": ["../theme-default/src/*", "./*"],
+      "@/components/*": ["./components/*"],
       "@zh/*": ["./docs/zh/*"],
       "@en/*": ["./docs/en/*"],
-      "rspress/theme": ["../theme-default/src/index.ts"]
     }
   },
   "include": [

--- a/packages/theme-default/modern.config.ts
+++ b/packages/theme-default/modern.config.ts
@@ -74,5 +74,16 @@ export default defineConfig({
         },
       },
     },
+    {
+      buildType: 'bundle',
+      input: { 'source-build-plugin': './src/node/source-build-plugin.ts' },
+      format: 'esm',
+      target: 'es2020',
+      outDir: 'dist/node',
+      platform: 'node',
+      sourceMap: true,
+      dts: {},
+      externals: ['tailwindcss'],
+    },
   ],
 });

--- a/packages/theme-default/package.json
+++ b/packages/theme-default/package.json
@@ -13,11 +13,15 @@
   "jsnext:source": "./src/index.ts",
   "types": "./dist/bundle.d.ts",
   "main": "./dist/index.js",
+  "imports": {
+    "#theme/*": "./src/*"
+  },
   "exports": {
     ".": {
       "types": "./dist/bundle.d.ts",
       "default": "./dist/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "dev": "modern build -w",

--- a/packages/theme-default/package.json
+++ b/packages/theme-default/package.json
@@ -21,6 +21,7 @@
       "types": "./dist/bundle.d.ts",
       "default": "./dist/index.js"
     },
+    "./node/*": "./dist/node/*",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/theme-default/src/components/Aside/index.tsx
+++ b/packages/theme-default/src/components/Aside/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { Header } from '@rspress/shared';
 import { bindingAsideScroll, scrollToTarget, useHiddenNav } from '../../logic';
-import { DEFAULT_NAV_HEIGHT } from '@/logic/sideEffects';
+import { DEFAULT_NAV_HEIGHT } from '#theme/logic/sideEffects';
 import './index.css';
 
 export function Aside(props: { headers: Header[]; outlineTitle: string }) {

--- a/packages/theme-default/src/components/HomeFeatures/index.tsx
+++ b/packages/theme-default/src/components/HomeFeatures/index.tsx
@@ -1,6 +1,6 @@
 import { FrontMatterMeta, Feature } from '@rspress/shared';
 import styles from './index.module.scss';
-import { renderHtmlOrText } from '@/logic';
+import { renderHtmlOrText } from '#theme/logic';
 
 const GRID_PREFIX = 'grid-';
 

--- a/packages/theme-default/src/components/Link/index.tsx
+++ b/packages/theme-default/src/components/Link/index.tsx
@@ -12,7 +12,7 @@ import nprogress from 'nprogress';
 import { routes } from 'virtual-routes';
 import { isExternalUrl } from '@rspress/shared';
 import styles from './index.module.scss';
-import { scrollToTarget } from '@/logic';
+import { scrollToTarget } from '#theme/logic';
 
 export interface LinkProps {
   href?: string;

--- a/packages/theme-default/src/components/Nav/NavBarTitle.tsx
+++ b/packages/theme-default/src/components/Nav/NavBarTitle.tsx
@@ -6,7 +6,7 @@ import {
   withBase,
 } from '@rspress/runtime';
 import styles from './index.module.scss';
-import { getLogoUrl, useLocaleSiteData } from '@/logic';
+import { getLogoUrl, useLocaleSiteData } from '#theme/logic';
 
 export const NavBarTitle = () => {
   const { siteData } = usePageData();

--- a/packages/theme-default/src/components/Nav/index.tsx
+++ b/packages/theme-default/src/components/Nav/index.tsx
@@ -12,7 +12,7 @@ import styles from './index.module.scss';
 import { NavBarTitle } from './NavBarTitle';
 import { NavTranslations } from './NavTranslations';
 import { NavVersions } from './NavVersions';
-import { useNavData } from '@/logic/useNav';
+import { useNavData } from '#theme/logic/useNav';
 
 export interface NavProps {
   beforeNav?: React.ReactNode;

--- a/packages/theme-default/src/components/NavScreen/index.tsx
+++ b/packages/theme-default/src/components/NavScreen/index.tsx
@@ -12,7 +12,7 @@ import {
 } from '../Nav/menuDataHooks';
 import { NavScreenMenuGroup } from './NavScreenMenuGroup';
 import styles from './index.module.scss';
-import { useNavData } from '@/logic/useNav';
+import { useNavData } from '#theme/logic/useNav';
 
 interface Props {
   isScreenOpen: boolean;

--- a/packages/theme-default/src/components/Search/index.tsx
+++ b/packages/theme-default/src/components/Search/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import SearchSvg from './assets/search.svg';
 import styles from './index.module.scss';
 import { SearchPanel } from './SearchPanel';
-import { useLocaleSiteData } from '@/logic';
+import { useLocaleSiteData } from '#theme/logic';
 
 export function Search() {
   const [focused, setFocused] = useState(false);

--- a/packages/theme-default/src/components/Toc/index.tsx
+++ b/packages/theme-default/src/components/Toc/index.tsx
@@ -1,6 +1,6 @@
 import { Header } from '@rspress/shared';
 import { usePageData } from '@rspress/runtime';
-import { scrollToTarget } from '@/theme-default';
+import { scrollToTarget } from '#theme/logic';
 import './index.css';
 
 const TocItem = (header: Header) => {

--- a/packages/theme-default/src/global.d.ts
+++ b/packages/theme-default/src/global.d.ts
@@ -27,7 +27,7 @@ declare module 'virtual-search-hooks' {
     OnSearch,
     AfterSearch,
     RenderSearchFunction,
-  } from '@/components/Search/logic/types';
+  } from '#theme/components/Search/logic/types';
 
   export const beforeSearch: BeforeSearch;
   export const onSearch: OnSearch;

--- a/packages/theme-default/src/layout/DocLayout/docComponents/link.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/link.tsx
@@ -1,7 +1,7 @@
 import { ComponentProps } from 'react';
 import { Link } from '../../../components/Link';
 import styles from './index.module.scss';
-import { usePathUtils } from '@/logic';
+import { usePathUtils } from '#theme/logic';
 
 export const A = (props: ComponentProps<'a'>) => {
   const { href = '', className = '' } = props;

--- a/packages/theme-default/src/layout/Layout/index.tsx
+++ b/packages/theme-default/src/layout/Layout/index.tsx
@@ -7,7 +7,7 @@ import { usePageData, Content, removeBase, withBase } from '@rspress/runtime';
 import { DocLayout, DocLayoutProps } from '../DocLayout';
 import { HomeLayoutProps } from '../HomeLayout';
 import type { NavProps } from '../../components/Nav';
-import { useDisableNav, useLocaleSiteData } from '@/logic';
+import { useDisableNav, useLocaleSiteData } from '#theme/logic';
 
 export enum QueryStatus {
   Show = '1',

--- a/packages/theme-default/src/node/source-build-plugin.ts
+++ b/packages/theme-default/src/node/source-build-plugin.ts
@@ -1,0 +1,38 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+import { RspressPlugin } from '@rspress/shared';
+import { tailwindConfig } from '../../tailwind.config';
+
+const require = createRequire(import.meta.url);
+const RootDir = fileURLToPath(new URL('../..', import.meta.url).href);
+
+/**
+ * @internal it is for debug changes on `theme-default` with other internal projects like `document`.
+ */
+export function SourceBuildPlugin(): RspressPlugin {
+  return {
+    name: 'theme-default:source-build',
+    builderConfig: {
+      source: {
+        alias: {
+          'rspress/theme': path.resolve(RootDir, './src'),
+        },
+      },
+      tools: {
+        postcss: (_, { addPlugins }) => {
+          addPlugins(
+            require('tailwindcss')({
+              config: {
+                ...tailwindConfig,
+                content: tailwindConfig.content.map(item =>
+                  path.resolve(RootDir, item),
+                ),
+              },
+            }),
+          );
+        },
+      },
+    },
+  };
+}

--- a/packages/theme-default/tailwind.config.ts
+++ b/packages/theme-default/tailwind.config.ts
@@ -1,6 +1,6 @@
-import { Config } from 'tailwindcss';
+import { type Config } from 'tailwindcss';
 
-export const tailwindConfig: Config = {
+export const tailwindConfig = {
   content: ['./src/**/*.{js,ts,jsx,tsx}'],
   darkMode: 'class',
   theme: {
@@ -66,4 +66,4 @@ export const tailwindConfig: Config = {
       },
     },
   },
-};
+} satisfies Config;

--- a/packages/theme-default/tsconfig.json
+++ b/packages/theme-default/tsconfig.json
@@ -12,8 +12,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "paths": {
-      "@/*": ["./*"],
-      "@/theme-default": ["./"]
+      "#theme/*": ["./*"]
     }
   },
   "include": [


### PR DESCRIPTION
## Summary

1. use bundled theme-default files for document production build
3. fix tailwind config for document dev(`DOC_DEBUG`)
4. refactor: move `DOC_DEBUG`-related codes to standalone rspress plugin in `theme-default`

## Related Issue

fixes #551 

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`: only DOC_DEBUG and rspress.dev document related change, so no new version is required for this change
- [x] I have updated the documentation: no need
- [x] I have added tests to cover my changes: rarely need - covered by existing tests
