### PR TITLE
perf: use stream to serve search index

### DIFF
--- a/.changeset/clever-ladybugs-suffer.md
+++ b/.changeset/clever-ladybugs-suffer.md
@@ -1,0 +1,5 @@
+---
+"@rspress/core": patch
+---
+
+perf: use stream to serve search index file.

--- a/packages/core/src/node/searchIndex.ts
+++ b/packages/core/src/node/searchIndex.ts
@@ -70,7 +70,7 @@ export function serveSearchIndexMiddleware(config: UserConfig): RequestHandler {
       res.setHeader('Content-Type', 'application/json');
       // Get search index name from request url
       const searchIndexFile = req.url?.split('/').pop();
-      const searchIndex = fs.readFileSync(
+      fs.createReadStream(
         path.join(
           process.cwd(),
           config?.outDir || OUTPUT_DIR,
@@ -78,8 +78,7 @@ export function serveSearchIndexMiddleware(config: UserConfig): RequestHandler {
           searchIndexFile,
         ),
         'utf-8',
-      );
-      res.end(searchIndex);
+      ).pipe(res, { end: true });
     } else {
       next?.();
     }


### PR DESCRIPTION
## Summary

The use of `fs.readFileSync` in middleware to read a local file and then send it to the client using `res.end` can potentially lead to performance issues.

The `fs.readFileSync` function is a synchronous operation, which means it will block the Node.js event loop until the file read operation is complete. If the file is large or the file system is slow, this can significantly delay the response time of your server, and during this time, your server will not be able to handle any other requests. This can lead to poor performance and scalability issues, especially under high load.

A better approach would be to use the asynchronous version of the function, `fs.readFile`, which does not block the event loop. Or even better, you can use `fs.createReadStream` to read the file as a stream and pipe it directly to the response. This way, the file can be sent to the client in chunks, without having to wait for the entire file to be read into memory first. This can significantly improve the performance and scalability of your server.

As the `searchIndex` grows, this change ensures efficient data processing and mitigates potential performance issues.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
