### PR TITLE
fix(plugin-auto-nav-sidebar): use logical OR instead of nullish coalescing when label is empty

### DIFF
--- a/.changeset/rare-rice-smoke.md
+++ b/.changeset/rare-rice-smoke.md
@@ -1,0 +1,5 @@
+---
+'@rspress/plugin-auto-nav-sidebar': patch
+---
+
+fix: use logical OR instead of nullish coalescing when label is empty

--- a/packages/plugin-auto-nav-sidebar/src/walk.ts
+++ b/packages/plugin-auto-nav-sidebar/src/walk.ts
@@ -81,7 +81,7 @@ export async function scanSideMeta(
         } = metaItem;
         if (type === 'file') {
           const title =
-            label ??
+            label ||
             (await extractH1Title(path.resolve(workDir, name), rootDir));
           return {
             text: title,


### PR DESCRIPTION
## Summary
When use `type: 'file'` in _meta.json, can not extract h1 title 

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
