### PR TITLE
feat(repress-hero-actions): better visibility on mobile/small screens!

### DIFF
--- a/packages/theme-default/src/components/HomeHero/index.tsx
+++ b/packages/theme-default/src/components/HomeHero/index.tsx
@@ -57,7 +57,7 @@ export function HomeHero({ frontmatter }: { frontmatter: FrontMatterMeta }) {
             {renderHtmlOrText(hero.tagline)}
           </p>
           {hero.actions?.length && (
-            <div className="flex flex-wrap justify-center gap-3 m--1.5 pt-6 sm:pt-8 z-10">
+            <div className="grid md:flex md:flex-wrap justify-center gap-3 m--1.5 pt-6 sm:pt-8 z-10">
               {hero.actions.map(action => (
                 <div className="flex flex-shrink-0 p-1" key={action.link}>
                   <Button
@@ -65,6 +65,7 @@ export function HomeHero({ frontmatter }: { frontmatter: FrontMatterMeta }) {
                     text={renderHtmlOrText(action.text)}
                     href={normalizeHref(action.link)}
                     theme={action.theme}
+                    className="w-full"
                   />
                 </div>
               ))}


### PR DESCRIPTION
## Summary
This would have to get better visibility of hero actions on smaller screen, and looks better than before, proper padding and uniformity


## After 
![Screenshot_2024-02-08-00-07-53-57_4d38fce200f96aeac5e860e739312e76](https://github.com/web-infra-dev/rspress/assets/69188140/b7eccef1-21b1-4713-81da-5a4ce5a6e6fa)



### Before
![Screenshot_2024-02-08-00-09-57-88_4d38fce200f96aeac5e860e739312e76](https://github.com/web-infra-dev/rspress/assets/69188140/9792d4de-d640-4a6e-8e94-6349e8e43668)


## Related Issue

<!--- Provide link of related issues -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
