### PR TITLE
fix(nav_screen): visibility on docs layout for smaller screens

### DIFF
--- a/packages/theme-default/src/components/NavScreen/index.module.scss
+++ b/packages/theme-default/src/components/NavScreen/index.module.scss
@@ -5,7 +5,7 @@
   right: 0;
   bottom: 0;
   left: 0;
-  padding: 0 32px;
+  padding: 32px;
   width: 100%;
   background-color: var(--rp-c-bg);
   overflow-y: auto;


### PR DESCRIPTION
## Summary

# After
![image](https://github.com/web-infra-dev/rspress/assets/69188140/cb4db3cf-b624-496f-b3d7-3c2ff5e10a98)

# Before 
![image](https://github.com/web-infra-dev/rspress/assets/69188140/2935aa96-03ec-4e78-b12f-7a21e448a942)


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
