### PR TITLE
feat(theme-default): Updated codeblock - fix copyBtn Icons && updated wordWrapBtn animations for equality between both buttons

### DIFF
--- a/.changeset/khaki-olives-confess.md
+++ b/.changeset/khaki-olives-confess.md
@@ -1,0 +1,5 @@
+---
+"@rspress/theme-default": patch
+---
+
+Updated codeblock - fix copyBtn Icons && updated wordWrapBtn animations for equality between both buttons

--- a/packages/theme-default/src/assets/copy.svg
+++ b/packages/theme-default/src/assets/copy.svg
@@ -1,1 +1,1 @@
-<svg width="32" height="32" viewBox="0 0 32 32"><path fill="currentColor" d="M28 10v18H10V10h18m0-2H10a2 2 0 0 0-2 2v18a2 2 0 0 0 2 2h18a2 2 0 0 0 2-2V10a2 2 0 0 0-2-2Z"/><path fill="currentColor" d="M4 18H2V4a2 2 0 0 1 2-2h14v2H4Z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 30 30"><path fill="currentColor" d="M28 10v18H10V10h18m0-2H10a2 2 0 0 0-2 2v18a2 2 0 0 0 2 2h18a2 2 0 0 0 2-2V10a2 2 0 0 0-2-2Z"/><path fill="currentColor" d="M4 18H2V4a2 2 0 0 1 2-2h14v2H4Z"/></svg>

--- a/packages/theme-default/src/assets/success.svg
+++ b/packages/theme-default/src/assets/success.svg
@@ -1,1 +1,1 @@
-<svg width="32" height="32" viewBox="0 0 32 32"><path fill="#49cd37" d="m13 24l-9-9l1.414-1.414L13 21.171L26.586 7.586L28 9L13 24z"/></svg>
+<svg width="32" height="32" viewBox="0 0 30 30"><path fill="#49cd37" d="m13 24l-9-9l1.414-1.414L13 21.171L26.586 7.586L28 9L13 24z"/></svg>

--- a/packages/theme-default/src/layout/DocLayout/docComponents/code/index.module.scss
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/code/index.module.scss
@@ -1,6 +1,6 @@
 :global(.rspress-code-content):hover {
   .code-button-group {
-    > button {
+    >button {
       opacity: 1;
     }
   }
@@ -13,7 +13,8 @@
   z-index: 10;
   display: flex;
   gap: 10px;
-  > button {
+
+  >button {
     position: relative;
     display: flex;
     justify-content: center;
@@ -27,6 +28,7 @@
     height: 20px;
     transition: all 0.2s ease;
     color: var(--rp-c-text-3);
+
     &:hover {
       color: var(--rp-c-text-2);
     }
@@ -49,7 +51,31 @@
     transform: scale(0.33);
     opacity: 0;
   }
+
   .icon-success {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 1;
+    transition-delay: 0.075s;
+  }
+}
+
+.icon-wrapped {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0);
+  opacity: 0;
+  color: #00d600;
+}
+
+
+.wrapped-btn {
+  .icon-wrap {
+    transform: scale(0.33);
+    opacity: 0;
+  }
+
+  .icon-wrapped {
     transform: translate(-50%, -50%) scale(1);
     opacity: 1;
     transition-delay: 0.075s;

--- a/packages/theme-default/src/layout/DocLayout/docComponents/code/index.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/code/index.tsx
@@ -16,6 +16,7 @@ export function Code(props: CodeProps) {
   const { siteData } = usePageData();
   const { defaultWrapCode, codeHighlighter } = siteData.markdown;
   const [codeWrap, setCodeWrap] = useState(defaultWrapCode);
+  const wrapButtonRef = useRef<HTMLButtonElement>(null);
   const codeBlockRef = useRef<HTMLDivElement>();
 
   const { className } = props;
@@ -25,7 +26,12 @@ export function Code(props: CodeProps) {
     return <code {...props}></code>;
   }
 
-  const toggleCodeWrap = () => {
+  const toggleCodeWrap = (wrapButtonElement: HTMLButtonElement) => {
+    if (codeWrap) {
+      wrapButtonElement?.classList.remove(styles.wrappedBtn);
+    } else {
+      wrapButtonElement?.classList.add(styles.wrappedBtn);
+    }
     setCodeWrap(!codeWrap);
   };
 
@@ -50,12 +56,13 @@ export function Code(props: CodeProps) {
       {/* Use prism.js to highlight code by default */}
       <div ref={codeBlockRef}>{getHighlighter()}</div>
       <div className={styles.codeButtonGroup}>
-        <button className={styles.codeWrapButton} onClick={toggleCodeWrap}>
-          {codeWrap ? (
-            <IconWrapped className={styles.iconWrapped} />
-          ) : (
-            <IconWrap className={styles.iconWrap} />
-          )}
+        <button
+          ref={wrapButtonRef}
+          className={styles.codeWrapButton}
+          onClick={() => toggleCodeWrap(wrapButtonRef.current)}
+        >
+          <IconWrapped className={styles.iconWrapped} />
+          <IconWrap className={styles.iconWrap} />
         </button>
         <CopyCodeButton codeBlockRef={codeBlockRef} />
       </div>


### PR DESCRIPTION
## Summary
https://github.com/web-infra-dev/rspress/assets/69188140/f2426fd8-caad-45e7-af85-f19eb5e03d3b

## Related Issue
resolves #612 
<!--- Provide link of related issues -->



## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
