### PR TITLE
fix(tab-list):overflown tabs not showing on mobile fixed

### DIFF
--- a/.changeset/sweet-zoos-boil.md
+++ b/.changeset/sweet-zoos-boil.md
@@ -1,0 +1,5 @@
+---
+"@rspress/theme-default": patch
+---
+
+fix(tab-list):overflown tabs not showing on mobile fixed

--- a/packages/theme-default/src/components/Tabs/index.module.scss
+++ b/packages/theme-default/src/components/Tabs/index.module.scss
@@ -5,6 +5,7 @@
 
   :global(div[class*='language-']) {
     margin: 6px 0;
+
     code {
       background-color: var(--rp-c-bg);
     }
@@ -16,11 +17,12 @@
   padding-top: 4px;
   display: flex;
   min-width: 100%;
+  overflow-x: scroll;
 }
 
 .tab {
   color: var(--rp-c-text-2);
-  border-bottom: 1px solid transparent;
+  border-bottom: 2px solid transparent;
   box-sizing: border-box;
   margin-right: 10px;
   padding: 6px 12px;
@@ -42,4 +44,13 @@
 .selected {
   color: var(--rp-c-brand-dark);
   border-color: var(--rp-c-brand-dark);
+}
+
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+.no-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
 }

--- a/packages/theme-default/src/components/Tabs/index.tsx
+++ b/packages/theme-default/src/components/Tabs/index.tsx
@@ -77,7 +77,7 @@ export function Tabs(props: TabsProps): ReactElement {
       <div className={tabContainerClassName}>
         {tabValues.length ? (
           <div
-            className={styles.tabList}
+            className={`${styles.tabList} ${styles.noScrollbar}`}
             style={{
               justifyContent:
                 tabPosition === 'center' ? 'center' : 'flex-start',


### PR DESCRIPTION
## Summary

### after scrollable, yet scrollbar invisible for associability 
![image](https://github.com/web-infra-dev/rspress/assets/69188140/4a4e8461-07d5-4c28-9a57-7ba527576829)

### before (not scrollbar nor visible)
![image](https://github.com/web-infra-dev/rspress/assets/69188140/d1bbbb29-9cc8-43f6-aa24-15b408d6ec60)

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
