### PR TITLE
patch(code.css): fix website overflow because of ` code `

### DIFF
--- a/packages/theme-default/src/styles/code.css
+++ b/packages/theme-default/src/styles/code.css
@@ -29,6 +29,7 @@
   padding: 4px 8px;
   color: var(--rp-c-text-code);
   background-color: var(--rp-c-bg-mute);
+  overflow-wrap: break-word;
 }
 
 .rspress-doc h1 > code,


### PR DESCRIPTION
## Summary

# after 
> Ik it may broke some words but it would fix extra overflow

![Screenshot_2024-02-10-00-11-16-27_4d38fce200f96aeac5e860e739312e76](https://github.com/web-infra-dev/rspress/assets/69188140/fde294f9-3d37-4065-842b-1084710c6422)


# before  (overflown on mobile)
![Screenshot_2024-02-10-00-04-03-28_40deb401b9ffe8e1df2f1cc5ba480b12](https://github.com/web-infra-dev/rspress/assets/69188140/c4389285-499b-4a9f-9963-8a8d58b5ef1e)


## Related Issue
https://rspress.dev/zh/guide/basic/deploy
<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
