### PR TITLE
fix(documentation)!!: tried to configure 404 page on netlify hosting 

### DIFF
--- a/.changeset/hungry-kangaroos-compare.md
+++ b/.changeset/hungry-kangaroos-compare.md
@@ -1,0 +1,5 @@
+---
+"@rspress/docs": patch
+---
+
+fix(404): tried to configure 404 page on netlify hosting for rspress docs

--- a/packages/document/docs/404.mdx
+++ b/packages/document/docs/404.mdx
@@ -2,6 +2,6 @@
 pageType: custom
 ---
 
-import {NotFoundLayout} from "@theme"
+import { NotFoundLayout } from "@theme"
 
 <NotFoundLayout />

--- a/packages/document/docs/404.mdx
+++ b/packages/document/docs/404.mdx
@@ -1,0 +1,7 @@
+---
+pageType: custom
+---
+
+import {NotFoundLayout} from "@theme"
+
+<NotFoundLayout />

--- a/packages/document/public/netlify.toml
+++ b/packages/document/public/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+from = "/*"
+to = "/404.html"
+status = 404
+force = true

--- a/packages/document/public/netlify.toml
+++ b/packages/document/public/netlify.toml
@@ -2,4 +2,3 @@
 from = "/*"
 to = "/404.html"
 status = 404
-force = true

--- a/packages/document/rspress.config.ts
+++ b/packages/document/rspress.config.ts
@@ -15,6 +15,12 @@ export default defineConfig({
   },
   icon: 'https://lf3-static.bytednsdoc.com/obj/eden-cn/uhbfnupenuhf/rspress/rspress-logo.png',
   builderConfig: {
+    server: {
+      publicDir: {
+        name: 'public',
+        copyOnBuild: true,
+      },
+    },
     dev: {
       startUrl: false,
     },


### PR DESCRIPTION

![image](https://github.com/web-infra-dev/rspress/assets/69188140/a3b46de0-597a-4e36-87d7-442a306862ee)

## Summary
followed https://docs.netlify.com/routing/redirects/redirect-options/#custom-404-page-handling for csutom 404 solution

## Related Issue
resolves #621 
<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
