### PR TITLE
fix: private import not work in production

### DIFF
--- a/.changeset/orange-cooks-pay.md
+++ b/.changeset/orange-cooks-pay.md
@@ -1,0 +1,5 @@
+---
+"@rspress/theme-default": patch
+---
+
+fix(theme-default): private import not work in production

--- a/packages/theme-default/package.json
+++ b/packages/theme-default/package.json
@@ -104,15 +104,8 @@
     "./src/styles/index.ts"
   ],
   "files": [
-    "bin",
     "dist",
-    "src/runtime",
-    "src/theme-default",
-    "src/shared",
-    "index.html",
-    "runtime.ts",
-    "theme.ts",
-    "loader.cjs"
+    "src"
   ],
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Summary

When we use `#theme/logic` to redirect to the module in `@rspress/theme-default/src/logic`, we cannot resolve the path because the src modules missed in production.

![img_v3_0287_059adf62-3073-44b6-889d-a8f890476dcg](https://github.com/web-infra-dev/rspress/assets/39261479/1be3851c-5803-46b7-886a-bd035f30c8f6)


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
