### PR TITLE
feat: pass through HTMLAnchorElement props to Link component.

### DIFF
--- a/.changeset/orange-beans-matter.md
+++ b/.changeset/orange-beans-matter.md
@@ -1,0 +1,5 @@
+---
+"@rspress/theme-default": patch
+---
+
+feat: pass through HTMLAnchorElement props to Link component.

--- a/packages/theme-default/src/components/Link/index.tsx
+++ b/packages/theme-default/src/components/Link/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ComponentProps } from 'react';
 import {
   matchRoutes,
   useLocation,
@@ -14,7 +14,7 @@ import { isExternalUrl } from '@rspress/shared';
 import styles from './index.module.scss';
 import { scrollToTarget } from '#theme/logic';
 
-export interface LinkProps {
+export interface LinkProps extends ComponentProps<'a'> {
   href?: string;
   children?: React.ReactNode;
   className?: string;
@@ -24,7 +24,7 @@ export interface LinkProps {
 nprogress.configure({ showSpinner: false });
 
 export function Link(props: LinkProps) {
-  const { href = '/', children, className = '', onNavigate } = props;
+  const { href = '/', children, className = '', onNavigate, ...rest } = props;
   const isExternal = isExternalUrl(href);
   const target = isExternal ? '_blank' : '';
   const rel = isExternal ? 'noopener noreferrer' : undefined;
@@ -81,6 +81,7 @@ export function Link(props: LinkProps) {
   if (!isExternal) {
     return (
       <a
+        {...rest}
         className={`${styles.link} ${className} cursor-pointer`}
         rel={rel}
         target={target}
@@ -93,6 +94,7 @@ export function Link(props: LinkProps) {
   } else {
     return (
       <a
+        {...rest}
         href={withBaseUrl}
         target={target}
         rel={rel}

--- a/packages/theme-default/src/layout/DocLayout/docComponents/link.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/link.tsx
@@ -1,6 +1,6 @@
 import { ComponentProps } from 'react';
-import { Link } from '../../../components/Link';
 import styles from './index.module.scss';
+import { Link } from '#theme/components/Link';
 import { usePathUtils } from '#theme/logic';
 
 export const A = (props: ComponentProps<'a'>) => {


### PR DESCRIPTION
## Summary

This pr will pass through HTMLAnchorElement props to Link component. To use props like `title` in `<Link />`

```jsx
function Example() {
  return (
    <Link href="https://rspress.dev/" title="A Great Static Site Generator" />
  )
}
```

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
