### PR TITLE
fix(doc-components): change code children to string

### DIFF
--- a/.changeset/brown-actors-brake.md
+++ b/.changeset/brown-actors-brake.md
@@ -1,0 +1,5 @@
+---
+'@rspress/theme-default': patch
+---
+
+fix(doc-components): change code children to string

--- a/packages/theme-default/src/layout/DocLayout/docComponents/code/PrismSytaxHighlighter.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/code/PrismSytaxHighlighter.tsx
@@ -67,7 +67,7 @@ export function PrismSyntaxHighlighter(
         };
       }}
     >
-      {props.children.trim()}
+      {String(props.children).trim()}
     </SyntaxHighlighter>
   );
 }


### PR DESCRIPTION
## Summary
https://github.com/remarkjs/react-markdown?tab=readme-ov-file#use-custom-components-syntax-highlight
Fix `props.children.trim` is not a function

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
