### PR TITLE
fix: fix some theme style issues.

### DIFF
--- a/.changeset/early-pots-act.md
+++ b/.changeset/early-pots-act.md
@@ -1,5 +1,6 @@
 ---
 "@rspress/theme-default": patch
+"@rspress/plugin-preview": patch
 ---
 
-fix(theme-default): fix theme style issues.
+fix: fix theme style issues.

--- a/.changeset/early-pots-act.md
+++ b/.changeset/early-pots-act.md
@@ -1,0 +1,5 @@
+---
+"@rspress/theme-default": patch
+---
+
+fix(theme-default): fix theme style issues.

--- a/packages/plugin-preview/static/global-components/Device.tsx
+++ b/packages/plugin-preview/static/global-components/Device.tsx
@@ -66,7 +66,7 @@ export default () => {
       } else {
         node?.removeAttribute('style');
       }
-      style.setProperty('--rp-aside-width', '0');
+      style.setProperty('--rp-aside-width', '0px');
     } else {
       node?.removeAttribute('style');
       style.setProperty('--rp-aside-width', asideWidth);

--- a/packages/theme-default/src/components/Sidebar/index.module.scss
+++ b/packages/theme-default/src/components/Sidebar/index.module.scss
@@ -11,7 +11,6 @@
   bottom: 0;
   left: 0;
   z-index: var(--rp-z-index-sidebar);
-  padding: 0 12px 96px 0;
   width: calc(100vw - 64px);
   max-width: 320px;
   opacity: 0;
@@ -20,6 +19,10 @@
     opacity 0.5s,
     transform 0.25s ease;
   background: var(--rp-c-bg);
+}
+
+.sidebarContainer {
+  padding: 0 12px 96px 0;
 }
 
 .sidebarContent {
@@ -55,8 +58,11 @@
 
 @media (min-width: 1440px) {
   .sidebar {
-    padding-left: 0;
     width: var(--rp-sidebar-width);
+  }
+
+  .sidebarContainer {
+    padding-left: 0;
   }
 }
 

--- a/packages/theme-default/src/components/Sidebar/index.tsx
+++ b/packages/theme-default/src/components/Sidebar/index.tsx
@@ -127,52 +127,54 @@ export function SideBar(props: Props) {
         isSidebarOpen ? styles.open : ''
       }`}
     >
-      {!uiSwitch.showNavbar ? null : (
-        <div className={styles.navTitleMask}>
-          <NavBarTitle />
-        </div>
-      )}
-      <div className={`mt-1 ${styles.sidebarContent}`}>
-        <div
-          className="rspress-scrollbar"
-          style={{
-            maxHeight: 'calc(100vh - var(--rp-nav-height) - 8px)',
-            overflow: 'auto',
-          }}
-        >
-          <nav className="pb-2">
-            {beforeSidebar}
-            {sidebarData.map(
-              (
-                item: NormalizedSidebarGroup | ISidebarItem | ISidebarDivider,
-                index: number,
-              ) =>
-                'dividerType' in item ? (
-                  <SidebarDivider
-                    // eslint-disable-next-line react/no-array-index-key
-                    key={index}
-                    depth={0}
-                    dividerType={item.dividerType}
-                  />
-                ) : (
-                  <SidebarItem
-                    id={String(index)}
-                    item={item}
-                    depth={0}
-                    activeMatcher={activeMatcher}
-                    // The siderbarData is stable, so it's safe to use index as key
-                    // eslint-disable-next-line react/no-array-index-key
-                    key={index}
-                    collapsed={
-                      (item as NormalizedSidebarGroup).collapsed ?? true
-                    }
-                    setSidebarData={setSidebarData}
-                    preloadLink={preloadLink}
-                  />
-                ),
-            )}
-            {afterSidebar}
-          </nav>
+      <div className={`${styles.sidebarContainer}`}>
+        {!uiSwitch.showNavbar ? null : (
+          <div className={styles.navTitleMask}>
+            <NavBarTitle />
+          </div>
+        )}
+        <div className={`mt-1 ${styles.sidebarContent}`}>
+          <div
+            className="rspress-scrollbar"
+            style={{
+              maxHeight: 'calc(100vh - var(--rp-nav-height) - 8px)',
+              overflow: 'auto',
+            }}
+          >
+            <nav className="pb-2">
+              {beforeSidebar}
+              {sidebarData.map(
+                (
+                  item: NormalizedSidebarGroup | ISidebarItem | ISidebarDivider,
+                  index: number,
+                ) =>
+                  'dividerType' in item ? (
+                    <SidebarDivider
+                      // eslint-disable-next-line react/no-array-index-key
+                      key={index}
+                      depth={0}
+                      dividerType={item.dividerType}
+                    />
+                  ) : (
+                    <SidebarItem
+                      id={String(index)}
+                      item={item}
+                      depth={0}
+                      activeMatcher={activeMatcher}
+                      // The siderbarData is stable, so it's safe to use index as key
+                      // eslint-disable-next-line react/no-array-index-key
+                      key={index}
+                      collapsed={
+                        (item as NormalizedSidebarGroup).collapsed ?? true
+                      }
+                      setSidebarData={setSidebarData}
+                      preloadLink={preloadLink}
+                    />
+                  ),
+              )}
+              {afterSidebar}
+            </nav>
+          </div>
         </div>
       </div>
     </aside>

--- a/packages/theme-default/src/layout/DocLayout/index.module.scss
+++ b/packages/theme-default/src/layout/DocLayout/index.module.scss
@@ -81,7 +81,7 @@
 
   .content {
     width: calc(100% - var(--rp-sidebar-width));
-    padding: 48px 48px 72px 0;
+    padding: 48px 48px 72px max(0px, calc(48px - var(--rp-sidebar-width)));
 
     :global(.rspress-doc),
     :global(.rspress-doc-footer) {

--- a/packages/theme-default/src/layout/DocLayout/index.module.scss
+++ b/packages/theme-default/src/layout/DocLayout/index.module.scss
@@ -8,7 +8,7 @@
   overflow-y: auto;
   scrollbar-width: none;
   width: 0;
-  max-height: calc(100vh - (var(--rp-nav-height) + 32px));
+  max-height: calc(100vh - var(--rp-nav-height) + 32px);
 }
 
 .aside-container::-webkit-scrollbar {

--- a/packages/theme-default/src/layout/DocLayout/index.module.scss
+++ b/packages/theme-default/src/layout/DocLayout/index.module.scss
@@ -105,6 +105,7 @@
     :global(.rspress-doc),
     :global(.rspress-doc-footer) {
       padding: 0 48px;
+      box-sizing: border-box;
       width: calc(100vw - var(--rp-aside-width) - var(--rp-sidebar-width));
     }
   }
@@ -119,6 +120,7 @@
   .content {
     :global(.rspress-doc),
     :global(.rspress-doc-footer) {
+      box-sizing: content-box;
       width: calc(100vw - var(--rp-sidebar-width) - var(--rp-aside-width));
       padding: 0
         max(

--- a/packages/theme-default/src/layout/DocLayout/index.module.scss
+++ b/packages/theme-default/src/layout/DocLayout/index.module.scss
@@ -105,7 +105,6 @@
     :global(.rspress-doc),
     :global(.rspress-doc-footer) {
       padding: 0 48px;
-      box-sizing: content-box;
       width: calc(100vw - var(--rp-aside-width) - var(--rp-sidebar-width));
     }
   }
@@ -120,7 +119,6 @@
   .content {
     :global(.rspress-doc),
     :global(.rspress-doc-footer) {
-      box-sizing: content-box;
       width: calc(100vw - var(--rp-sidebar-width) - var(--rp-aside-width));
       padding: 0
         max(

--- a/packages/theme-default/src/logic/useUISwitch.ts
+++ b/packages/theme-default/src/logic/useUISwitch.ts
@@ -67,11 +67,11 @@ export function useUISwitch(): UISwitchResult {
     }
 
     if (sidebar === QueryStatus.Hide) {
-      document.documentElement.style.setProperty('--rp-sidebar-width', '0');
+      document.documentElement.style.setProperty('--rp-sidebar-width', '0px');
     }
 
     if (aside === QueryStatus.Hide) {
-      document.documentElement.style.setProperty('--rp-aside-width', '0');
+      document.documentElement.style.setProperty('--rp-aside-width', '0px');
     }
 
     if (footer === QueryStatus.Hide) {


### PR DESCRIPTION
## Summary

This pr fix theme style issues when navbar or outline not display.

1. change css variable `--rp-aside-width` and `--rp-sidebar-width` from `0` to `0px` 
![image](https://github.com/web-infra-dev/rspress/assets/3841747/baac1f53-f91a-40c3-9624-cc1bdfb2a5fd)
while chrome tract `calc(100% - 0px)` as invalid property value

2. move sidebar padding property to a sub container
![image](https://github.com/web-infra-dev/rspress/assets/3841747/3311dc78-7560-4d7c-94e2-57a352bcf20a)
while sidebar width set to 0 still has padding-right remind.

3. `.rspress-doc` and `.rspress-doc-footer` change `box-sizing: content-box` to `box-sizing:border-box` in screen 1280px because of `content-width + padding > 100vw`

4. increase outline `max-height` for reduce the gap between outline bottom and page bottom.
![image](https://github.com/web-infra-dev/rspress/assets/3841747/b62210e0-857e-4385-aa05-cf325f8a9dcb)



## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
