### PR TITLE
feat: set min time of initing search index as 1s

### DIFF
--- a/.changeset/wise-rivers-deny.md
+++ b/.changeset/wise-rivers-deny.md
@@ -1,0 +1,5 @@
+---
+"@rspress/theme-default": patch
+---
+
+feat: set search index initing min time

--- a/packages/theme-default/src/components/Search/SearchPanel.tsx
+++ b/packages/theme-default/src/components/Search/SearchPanel.tsx
@@ -74,7 +74,10 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
       extractGroupName,
     });
     pageSearcherRef.current = pageSearcher;
-    await pageSearcherRef.current.init();
+    await Promise.all([
+      pageSearcherRef.current.init(),
+      new Promise(resolve => setTimeout(resolve, 1000)),
+    ]);
     setIniting(false);
     const query = searchInputRef.current?.value;
     if (query) {


### PR DESCRIPTION
## Summary


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
