### PR TITLE
fix(theme-default): Fix collapsed space between last updated text and time

### DIFF
--- a/.changeset/late-kangaroos-do.md
+++ b/.changeset/late-kangaroos-do.md
@@ -1,0 +1,5 @@
+---
+"@rspress/theme-default": patch
+---
+
+fix(theme-default): Fix collapsed space between last updated text and time

--- a/packages/theme-default/src/components/LastUpdated/index.tsx
+++ b/packages/theme-default/src/components/LastUpdated/index.tsx
@@ -15,8 +15,9 @@ export function LastUpdated() {
 
   return (
     <div className="flex text-sm text-text-2 leading-6 sm:leading-8 font-medium">
-      <p>{lastUpdatedText}: </p>
-      <span>{lastUpdatedTime}</span>
+      <p>
+        {lastUpdatedText}: <span>{lastUpdatedTime}</span>
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

To fix the collapsed space, I moved the last updated time `<span>` element into the paragraph that contains the text, so that the space is _shown_.

### Example

<img width="1440" alt="Screenshot 2024-02-22 at 08 06 41" src="https://github.com/web-infra-dev/rspress/assets/17132927/59baee9e-e129-428c-b81c-ac3265113b85">

## Related Issue

Closes #645 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.