### PR TITLE
fix(plugin-auto-nav-sidebar): avoid error which caught by type divider

### DIFF
--- a/.changeset/mighty-pets-occur.md
+++ b/.changeset/mighty-pets-occur.md
@@ -1,0 +1,5 @@
+---
+'@rspress/plugin-auto-nav-sidebar': patch
+---
+
+fix: avoid error which caught by type divider

--- a/packages/plugin-auto-nav-sidebar/src/walk.ts
+++ b/packages/plugin-auto-nav-sidebar/src/walk.ts
@@ -80,7 +80,8 @@ export async function scanSideMeta(
           tag,
           dashed,
         } = metaItem;
-        const pureLink = `${relativePath}/${name.replace(/\.mdx?$/, '')}`;
+        // when type is divider, name maybe undefined, and link is not used
+        const pureLink = `${relativePath}/${name?.replace(/\.mdx?$/, '')}`;
         if (type === 'file') {
           const title =
             label ||


### PR DESCRIPTION
## Summary


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
