### PR TITLE
docs: fix types in `useI18n` hook

### DIFF
--- a/packages/document/docs/en/fragments/useI18n.mdx
+++ b/packages/document/docs/en/fragments/useI18n.mdx
@@ -4,7 +4,7 @@ The framework provides `useI18n` this hook to get the internationalized text, th
 import { useI18n } from 'rspress/runtime';
 
 const MyComponent = () => {
-  const { t } = useI18n();
+  const t = useI18n();
 
   return <div>{t('getting-started')}</div>;
 };
@@ -28,7 +28,7 @@ Then use it like this in the component:
 import { useI18n } from 'rspress/runtime';
 
 const MyComponent = () => {
-  const { t } = useI18n<keyof typeof import('i18n')>();
+  const t = useI18n<typeof import('i18n')>();
 
   return <div>{t('getting-started')}</div>;
 };

--- a/packages/document/docs/zh/fragments/useI18n.mdx
+++ b/packages/document/docs/zh/fragments/useI18n.mdx
@@ -4,7 +4,7 @@
 import { useI18n } from 'rspress/runtime';
 
 const MyComponent = () => {
-  const { t } = useI18n();
+  const t = useI18n();
 
   return <div>{t('getting-started')}</div>;
 };
@@ -28,7 +28,7 @@ const MyComponent = () => {
 import { useI18n } from 'rspress/runtime';
 
 const MyComponent = () => {
-  const { t } = useI18n<keyof typeof import('i18n')>();
+  const t = useI18n<typeof import('i18n')>();
 
   return <div>{t('getting-started')}</div>;
 };


### PR DESCRIPTION
## Summary


```ts
export declare function useI18n<T = Record<string, Record<string, string>>>(): (key: keyof T) => any;
```


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
