### PR TITLE
fix: add explicit height to social link icons, which is needed on Safari

### DIFF
--- a/packages/theme-default/src/components/SocialLinks/index.module.scss
+++ b/packages/theme-default/src/components/SocialLinks/index.module.scss
@@ -1,6 +1,6 @@
 .social-links-icon {
   width: 24px;
-  height: 100%;
+  height: 24px;
   display: flex;
   fill: currentColor;
   margin-left: 0.5rem;


### PR DESCRIPTION
## Summary


## Related Issue

<!--- Provide link of related issues -->

Mobile/Safari:
![image](https://github.com/web-infra-dev/rspress/assets/105919/47f63b31-9865-4f2c-bda7-638ebde300ed)

PC/Safari:
![image](https://github.com/web-infra-dev/rspress/assets/105919/3715729f-26f5-4e8a-8d1a-7c4b66ea316a)

The alternative way to fix the issue is add width/height to the SVG files.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
