### PR TITLE
fix: memoize the callback in `useI18n` hook

### DIFF
--- a/.changeset/eleven-tomatoes-collect.md
+++ b/.changeset/eleven-tomatoes-collect.md
@@ -1,0 +1,5 @@
+---
+"@rspress/runtime": patch
+---
+
+fix: memoize the callback in `useI18n` hook

--- a/packages/runtime/src/hooks.ts
+++ b/packages/runtime/src/hooks.ts
@@ -1,6 +1,7 @@
 import {
   ReactElement,
   createContext,
+  useCallback,
   useContext,
   useLayoutEffect,
   useState,
@@ -52,7 +53,7 @@ export function useDark() {
 export function useI18n<T = Record<string, Record<string, string>>>() {
   const lang = useLang();
 
-  return (key: keyof T) => i18nTextData[key][lang];
+  return useCallback((key: keyof T) => i18nTextData[key][lang], [lang]);
 }
 
 declare global {


### PR DESCRIPTION
## Summary

This makes it possible to use in hook dependencies, works with ESLint, and to avoid unnecessary re-render.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
