### PR TITLE
fix(theme-default): update theme when change storage

### DIFF
--- a/.changeset/thick-shrimps-agree.md
+++ b/.changeset/thick-shrimps-agree.md
@@ -1,0 +1,5 @@
+---
+'@rspress/theme-default': patch
+---
+
+fix: update theme when change storage

--- a/packages/theme-default/src/components/SwitchAppearance/index.tsx
+++ b/packages/theme-default/src/components/SwitchAppearance/index.tsx
@@ -2,16 +2,32 @@ import { useContext, useEffect } from 'react';
 import { ThemeContext } from '@rspress/runtime';
 import SunSvg from '../../assets/sun.svg';
 import MoonSvg from '../../assets/moon.svg';
-import { getToggle, isDarkMode } from '../../logic/useAppearance';
+import {
+  getToggle,
+  isDarkMode,
+  updateUserPreferenceFromStorage,
+} from '../../logic/useAppearance';
 
 export function SwitchAppearance({ onClick }: { onClick?: () => void }) {
   const { theme, setTheme } = useContext(ThemeContext);
   const toggleAppearance = getToggle();
+  const updateAppearanceAndTheme = () => {
+    const isDark = updateUserPreferenceFromStorage();
+    setTheme(isDark ? 'dark' : 'light');
+  };
 
   useEffect(() => {
     if (isDarkMode()) {
       setTheme('dark');
     }
+    if (typeof window !== 'undefined') {
+      window.addEventListener('storage', updateAppearanceAndTheme);
+    }
+    return () => {
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('storage', updateAppearanceAndTheme);
+      }
+    };
   }, []);
 
   return (

--- a/packages/theme-default/src/logic/useAppearance.ts
+++ b/packages/theme-default/src/logic/useAppearance.ts
@@ -28,11 +28,16 @@ const updateAppearance = (): void => {
   if (disableDarkMode) {
     return;
   }
+  updateUserPreferenceFromStorage();
+};
+
+export const updateUserPreferenceFromStorage = () => {
   const userPreference = localStorage.getItem(APPEARANCE_KEY) || 'auto';
   query = window.matchMedia('(prefers-color-scheme: dark)');
-  setClass(
-    userPreference === 'auto' ? query.matches : userPreference === 'dark',
-  );
+  const isDark =
+    userPreference === 'auto' ? query.matches : userPreference === 'dark';
+  setClass(isDark);
+  return isDark;
 };
 
 if (typeof window !== 'undefined' && typeof localStorage !== 'undefined') {
@@ -45,9 +50,6 @@ if (typeof window !== 'undefined' && typeof localStorage !== 'undefined') {
 export const isDarkMode = () => classList?.contains('dark');
 
 export const getToggle = () => {
-  if (typeof window !== 'undefined') {
-    window.addEventListener('storage', updateAppearance);
-  }
   return () => {
     const isDark = isDarkMode();
     if (typeof window !== 'undefined' && typeof localStorage !== 'undefined') {


### PR DESCRIPTION
## Summary
When we open two tab in browser, found:
1. Change dark mode in one tab.
2. In another tab, appearance is changed, but component theme is not changed.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
