### PR TITLE
feat: extract all CSS into a single file

### DIFF
--- a/.changeset/flat-suns-tap.md
+++ b/.changeset/flat-suns-tap.md
@@ -1,0 +1,5 @@
+---
+"@rspress/core": patch
+---
+
+feat: extract all CSS into a single file

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -143,6 +143,21 @@ async function createInternalBuildConfig(
     performance: {
       // No need to print the server bundles size
       printFileSize: !isSSR,
+      chunkSplit: {
+        override: {
+          cacheGroups: {
+            // extract all CSS into a single file
+            // ensure CSS in async chunks can be loaded for SSG
+            styles: {
+              name: 'styles',
+              minSize: 0,
+              chunks: 'all',
+              test: /\.(?:css|less|sass|scss)$/,
+              priority: 99,
+            },
+          },
+        },
+      },
     },
     tools: {
       bundlerChain(chain, { CHAIN_ID }) {


### PR DESCRIPTION
## Summary

Extract all CSS into a single file, ensure CSS in async chunks can be loaded for SSG.

The same as docusaurus and vuepress:

- https://github.com/facebook/docusaurus/blob/0589b1475d56b0b541348aa56f201ec7c56c56d5/packages/docusaurus/src/webpack/base.ts#L182-L189
- https://github.com/vuejs/vuepress/blob/087f8a199de4436366aba8f8bf44571117612e53/packages/%40vuepress/core/lib/node/webpack/createBaseConfig.js#L293-L306

Fix styles in SSG pages, such as https://modernjs.dev/en/guides/get-started/introduction.html

![image](https://github.com/web-infra-dev/rspress/assets/7237365/3bd61b01-1923-4e54-ab8f-7e0689486f4d)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
