### PR TITLE
fix(style): overview links margin not work

### DIFF
--- a/.changeset/breezy-pugs-guess.md
+++ b/.changeset/breezy-pugs-guess.md
@@ -1,0 +1,5 @@
+---
+"@rspress/theme-default": patch
+---
+
+fix(style): overview links margin not work

--- a/packages/theme-default/src/components/Overview/index.module.scss
+++ b/packages/theme-default/src/components/Overview/index.module.scss
@@ -82,6 +82,7 @@
 }
 
 .overview-groups a {
+  display: block;
   font-size: 15px;
   font-weight: 500;
   line-height: 1.6;


### PR DESCRIPTION
## Summary

Fix overview links margin not work as `display: block` of a tag has been removed in https://github.com/web-infra-dev/rspress/commit/7c3cd1593c7b40dd8d103ddd5971852d241f703e.

- main branch: 

<img width="1005" alt="Screenshot 2024-02-29 at 15 06 25" src="https://github.com/web-infra-dev/rspress/assets/7237365/77cde073-a4f4-4e7d-b79f-a29d59417a6a">

- expected:

![image](https://github.com/web-infra-dev/rspress/assets/7237365/cd3843f5-5517-4703-a0f3-5f617e1c4e20)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
