### PR TITLE
fix: make outline have a well width

### DIFF
--- a/.changeset/shy-eagles-laugh.md
+++ b/.changeset/shy-eagles-laugh.md
@@ -1,0 +1,5 @@
+---
+"@rspress/theme-default": patch
+---
+
+fix(theme-default): make outline have a well width again

--- a/packages/theme-default/src/layout/DocLayout/index.module.scss
+++ b/packages/theme-default/src/layout/DocLayout/index.module.scss
@@ -104,9 +104,11 @@
     padding: 48px 0 72px 0;
     :global(.rspress-doc),
     :global(.rspress-doc-footer) {
-      padding: 0 24px;
+      padding: 0 48px;
       box-sizing: border-box;
       width: calc(100vw - var(--rp-sidebar-width) - var(--rp-aside-width));
+      max-width: calc(960px + 48px * 2);
+      margin: auto;
     }
   }
 }

--- a/packages/theme-default/src/layout/DocLayout/index.module.scss
+++ b/packages/theme-default/src/layout/DocLayout/index.module.scss
@@ -106,7 +106,7 @@
     :global(.rspress-doc-footer) {
       padding: 0 48px;
       box-sizing: border-box;
-      width: 100%;
+      width: calc(100vw - var(--rp-sidebar-width) - var(--rp-aside-width));
     }
   }
 }
@@ -120,16 +120,9 @@
   .content {
     :global(.rspress-doc),
     :global(.rspress-doc-footer) {
-      box-sizing: content-box;
+      box-sizing: border-box;
       width: calc(100vw - var(--rp-sidebar-width) - var(--rp-aside-width));
-      padding: 0
-        max(
-          48px,
-          calc(
-            (100vw - var(--rp-sidebar-width) - var(--rp-aside-width) - 960px) /
-              2
-          )
-        );
+      padding: 0 48px;
       max-width: 960px;
       margin: auto;
     }

--- a/packages/theme-default/src/layout/DocLayout/index.module.scss
+++ b/packages/theme-default/src/layout/DocLayout/index.module.scss
@@ -104,7 +104,7 @@
     padding: 48px 0 72px 0;
     :global(.rspress-doc),
     :global(.rspress-doc-footer) {
-      padding: 0 48px;
+      padding: 0 24px;
       box-sizing: border-box;
       width: calc(100vw - var(--rp-sidebar-width) - var(--rp-aside-width));
     }
@@ -123,7 +123,7 @@
       box-sizing: border-box;
       width: calc(100vw - var(--rp-sidebar-width) - var(--rp-aside-width));
       padding: 0 48px;
-      max-width: 960px;
+      max-width: calc(960px + 48px * 2);
       margin: auto;
     }
   }

--- a/packages/theme-default/src/layout/DocLayout/index.tsx
+++ b/packages/theme-default/src/layout/DocLayout/index.tsx
@@ -74,7 +74,7 @@ export function DocLayout(props: DocLayoutProps) {
       <div
         className={`${styles.content} rspress-doc-container flex flex-shrink-0 mx-auto`}
       >
-        <div className="w-full">
+        <div className="w-full overflow-hidden">
           {isOverviewPage ? (
             <Overview content={docContent} />
           ) : (

--- a/packages/theme-default/src/layout/DocLayout/index.tsx
+++ b/packages/theme-default/src/layout/DocLayout/index.tsx
@@ -74,7 +74,7 @@ export function DocLayout(props: DocLayoutProps) {
       <div
         className={`${styles.content} rspress-doc-container flex flex-shrink-0 mx-auto`}
       >
-        <div className="w-full overflow-hidden">
+        <div className="w-full overflow-hidden flex-1">
           {isOverviewPage ? (
             <Overview content={docContent} />
           ) : (

--- a/packages/theme-default/src/styles/vars.css
+++ b/packages/theme-default/src/styles/vars.css
@@ -4,7 +4,7 @@
 :root {
   --rp-nav-height: 72px;
   --rp-sidebar-width: 320px;
-  --rp-aside-width: 368px;
+  --rp-aside-width: 268px;
 }
 
 :root {


### PR DESCRIPTION
## Summary

This PR adds style `overflow-hidden` to the doc container to ensure the code block scrolls correctly when there is no wrap.

## Related Issue

<!--- Provide link of related issues -->

https://github.com/web-infra-dev/rspress/pull/677#issuecomment-1971280511

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
