### PR TITLE
fix: remove useless overflow style, which cause api page width collapsed

### DIFF
--- a/.changeset/early-horses-itch.md
+++ b/.changeset/early-horses-itch.md
@@ -1,0 +1,5 @@
+---
+"@rspress/theme-default": patch
+---
+
+chore: remove useless overflow-hidden style

--- a/packages/theme-default/src/layout/DocLayout/index.tsx
+++ b/packages/theme-default/src/layout/DocLayout/index.tsx
@@ -74,7 +74,7 @@ export function DocLayout(props: DocLayoutProps) {
       <div
         className={`${styles.content} rspress-doc-container flex flex-shrink-0 mx-auto`}
       >
-        <div className="w-full">
+        <div className="w-full flex-1">
           {isOverviewPage ? (
             <Overview content={docContent} />
           ) : (

--- a/packages/theme-default/src/layout/DocLayout/index.tsx
+++ b/packages/theme-default/src/layout/DocLayout/index.tsx
@@ -74,7 +74,7 @@ export function DocLayout(props: DocLayoutProps) {
       <div
         className={`${styles.content} rspress-doc-container flex flex-shrink-0 mx-auto`}
       >
-        <div className="w-full overflow-hidden flex-1">
+        <div className="w-full">
           {isOverviewPage ? (
             <Overview content={docContent} />
           ) : (


### PR DESCRIPTION
## Summary

The `overflow-hidden` style cause the api page width collapsed. The preview after removing it:

![image](https://github.com/web-infra-dev/rspress/assets/39261479/13729407-c227-4e9e-9d25-e74b505e386c)

In the meantime, the expanding problem of doc content has been solved by #693 through setting an appropriate outline width:

![image](https://github.com/web-infra-dev/rspress/assets/39261479/2f045510-b470-48e3-ba83-f2a0bd167091)

## Related Issue

#643 

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
