### PR TITLE
fix(modern-plugin): modernjs plugin alias problem in iframe

### DIFF
--- a/.changeset/lucky-cooks-admire.md
+++ b/.changeset/lucky-cooks-admire.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-rspress': patch
+'@rspress/plugin-preview': patch
+---
+
+fix: modernjs plugin alias problem in iframe

--- a/packages/modern-plugin-rspress/src/lanchDoc.ts
+++ b/packages/modern-plugin-rspress/src/lanchDoc.ts
@@ -156,6 +156,10 @@ export async function launchDoc({
           alias: {
             'rspress/runtime': '@rspress/core/runtime',
             'rspress/theme': '@rspress/core/theme',
+            '@rspress/core': join(
+              require.resolve('@rspress/core/package.json'),
+              '..',
+            ),
           },
         },
       },

--- a/packages/plugin-preview/src/index.ts
+++ b/packages/plugin-preview/src/index.ts
@@ -97,6 +97,7 @@ export function pluginPreview(options?: Options): RspressPlugin {
             printFileSize: false,
           },
           source: {
+            alias: config?.builderConfig?.source?.alias,
             entry: sourceEntry,
           },
           output: {


### PR DESCRIPTION
## Summary
Fix that can not resolve @rspress/core/theme.css when use modern plugin

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
