### PR TITLE
fix: frontmatter.title priority is higher than h1 title

### DIFF
--- a/.changeset/weak-papayas-stare.md
+++ b/.changeset/weak-papayas-stare.md
@@ -1,0 +1,5 @@
+---
+"@rspress/plugin-auto-nav-sidebar": patch
+---
+
+fix: frontmatter.title priority is higher than h1 title

--- a/biome.json
+++ b/biome.json
@@ -25,7 +25,8 @@
       "compiled/**/*",
       "node_modules/**/*",
       "create-rspress/template/rspress.config.ts",
-      ".history/**/*"
+      ".history/**/*",
+      "coverage/**/*"
     ],
     "ignoreUnknown": true
   },

--- a/packages/plugin-auto-nav-sidebar/src/utils.ts
+++ b/packages/plugin-auto-nav-sidebar/src/utils.ts
@@ -38,12 +38,8 @@ export async function extractH1Title(
   const fileNameWithoutExt = path.basename(realPath, path.extname(realPath));
   const h1RegExp = /^#\s+(.*)$/m;
   const match = content.match(h1RegExp);
-  if (!match) {
-    const { frontmatter } = loadFrontMatter(content, filePath, rootDir);
-    return frontmatter.title || fileNameWithoutExt;
-  } else {
-    return match[1] || fileNameWithoutExt;
-  }
+  const { frontmatter } = loadFrontMatter(content, filePath, rootDir);
+  return frontmatter.title || match?.[1] || fileNameWithoutExt;
 }
 
 export function combineWalkResult(


### PR DESCRIPTION
## Summary
Fix the priority problem of frontmatter.title and h1 heading. 

## Related Issue

#710 

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
