### PR TITLE
fix: doc fragment hmr invalid

### DIFF
--- a/.changeset/short-rats-happen.md
+++ b/.changeset/short-rats-happen.md
@@ -1,0 +1,5 @@
+---
+"@rspress/core": patch
+---
+
+fix: doc fragment hmr invalid

--- a/packages/core/src/node/mdx/loader.ts
+++ b/packages/core/src/node/mdx/loader.ts
@@ -106,10 +106,15 @@ export default async function mdxLoader(
     true,
   );
 
-  // preprocessor
-  const preprocessedContent = escapeMarkdownHeadingIds(
-    await flattenMdxContent(content, filepath, alias as Record<string, string>),
+  const { flattenContent, deps } = await flattenMdxContent(
+    content,
+    filepath,
+    alias as Record<string, string>,
   );
+  // preprocessor
+  const preprocessedContent = escapeMarkdownHeadingIds(flattenContent);
+
+  deps.forEach(dep => context.addDependency(dep));
 
   let enableMdxRs;
   const mdxRs = config?.markdown?.mdxRs ?? true;

--- a/packages/core/src/node/runtimeModule/siteData/extractPageData.ts
+++ b/packages/core/src/node/runtimeModule/siteData/extractPageData.ts
@@ -53,7 +53,7 @@ export async function extractPageData(
         }
       });
 
-      const flattenContent = await flattenMdxContent(
+      const { flattenContent } = await flattenMdxContent(
         applyReplaceRules(strippedFrontMatter, replaceRules),
         route.absolutePath,
         alias,


### PR DESCRIPTION
## Summary

Fix doc fragment hmr invalid.

## Related Issue

#727 


<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
