### PR TITLE
feat(core): support custom pageMeta in js mdx loader

### DIFF
--- a/.changeset/orange-falcons-mate.md
+++ b/.changeset/orange-falcons-mate.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': minor
+---
+
+feat: support custom pageMeta in js mdx loader

--- a/packages/core/src/node/mdx/loader.ts
+++ b/packages/core/src/node/mdx/loader.ts
@@ -153,7 +153,7 @@ export default async function mdxLoader(
         title: string;
       };
       pageMeta = {
-        toc: compilationMeta.toc,
+        ...compilationMeta,
         title: frontmatter.title || compilationMeta.title || '',
         frontmatter,
       } as PageMeta;

--- a/packages/core/src/runtime/App.tsx
+++ b/packages/core/src/runtime/App.tsx
@@ -54,10 +54,12 @@ export async function initPageData(routePath: string): Promise<PageData> {
       toc = [],
       title = '',
       frontmatter = {},
+      ...rest
     } = MDX_REGEXP.test(matchedRoute.filePath) ? meta : mod;
     return {
       siteData,
       page: {
+        ...rest,
         pagePath,
         ...extractPageInfo,
         pageType: frontmatter?.pageType || 'doc',


### PR DESCRIPTION
## Summary
We can add custom meta in mdx loader, and get it from `usePageData`

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
