### PR TITLE
fix(theme): update nav when resize

### DIFF
--- a/.changeset/mean-rings-cover.md
+++ b/.changeset/mean-rings-cover.md
@@ -1,0 +1,5 @@
+---
+'@rspress/theme-default': patch
+---
+
+fix: update nav when resize

--- a/packages/theme-default/src/components/Nav/index.tsx
+++ b/packages/theme-default/src/components/Nav/index.tsx
@@ -38,9 +38,15 @@ export function Nav(props: NavProps) {
   const socialLinks = siteData.themeConfig.socialLinks || [];
   const hasSocialLinks = socialLinks.length > 0;
   const langs = localeLanguages.map(item => item.lang || '') || [];
-
-  useEffect(() => {
+  const updateIsMobile = () => {
     setIsMobile(isMobileDevice());
+  };
+  useEffect(() => {
+    window.addEventListener('resize', updateIsMobile);
+    setIsMobile(isMobileDevice());
+    return () => {
+      window.removeEventListener('resize', updateIsMobile);
+    };
   }, []);
 
   const NavMenu = ({ menuItems }: { menuItems: NavItem[] }) => {


### PR DESCRIPTION
## Summary
update isMobile when resize to keep the same behavior.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
