### PR TITLE
fix(theme): support format pre code when children is array

### DIFF
--- a/.changeset/popular-masks-bow.md
+++ b/.changeset/popular-masks-bow.md
@@ -1,0 +1,5 @@
+---
+'@rspress/theme-default': patch
+---
+
+fix: support format pre code when children is array

--- a/packages/theme-default/src/layout/DocLayout/docComponents/pre.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/pre.tsx
@@ -21,16 +21,20 @@ export function Pre({
 }: {
   children: React.ReactElement[] | React.ReactElement;
 }) {
-  if (Array.isArray(children)) {
-    return <pre>{children}</pre>;
-  }
+  const renderChildren = (children: React.ReactElement) => {
+    const { className, meta } = children.props as CodeProps;
+    const codeTitle = parseTitleFromMeta(meta);
+    return (
+      <div className={className || DEFAULT_LANGUAGE_CLASS}>
+        {codeTitle && <div className="rspress-code-title">{codeTitle}</div>}
+        <div className="rspress-code-content rspress-scrollbar">{children}</div>
+      </div>
+    );
+  };
 
-  const { className, meta } = children.props as CodeProps;
-  const codeTitle = parseTitleFromMeta(meta);
-  return (
-    <div className={className || DEFAULT_LANGUAGE_CLASS}>
-      {codeTitle && <div className="rspress-code-title">{codeTitle}</div>}
-      <div className="rspress-code-content rspress-scrollbar">{children}</div>
-    </div>
-  );
+  if (Array.isArray(children)) {
+    return <div>{children.map(child => renderChildren(child))}</div>;
+  } else {
+    return renderChildren(children);
+  }
 }


### PR DESCRIPTION
## Summary
When Use getCustomMDXComponent, pre code will not be rendered correctly. 
After #642 , we need support array in pre, too.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
