### PR TITLE
chore(nx): enable inputs of dependencies

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,51 +1,37 @@
 {
-
+  "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "tasksRunnerOptions": {
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {
-        "cacheableOperations": [
-          "dev",
-          "build",
-          "test"
-        ],
+        "cacheableOperations": ["dev", "build", "test"],
         "cacheDirectory": ".nx-cache"
       }
     }
   },
+  "namedInputs": {
+    "default": [
+      "{projectRoot}/src/**/*",
+      "{projectRoot}/tsconfig.json",
+      "{projectRoot}/package.json",
+      "{projectRoot}/modern.config.*"
+    ],
+    "dev": ["default"],
+    "build": ["default"],
+    "test": ["default"]
+  },
   "targetDefaults": {
     "dev": {
-      "dependsOn": [
-        "^build"
-      ],
-      "inputs": [
-        "{projectRoot}/src/**/*",
-        "{projectRoot}/tsconfig.json",
-        "{projectRoot}/package.json",
-        "{projectRoot}/modern.config.*"
-      ]
+      "dependsOn": ["^build"],
+      "inputs": ["dev", "^dev"]
     },
     "build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "outputs": [
-        "{projectRoot}/dist"
-      ],
-      "inputs": [
-        "{projectRoot}/src/**/*",
-        "{projectRoot}/tsconfig.json",
-        "{projectRoot}/package.json",
-        "{projectRoot}/modern.config.*"
-      ]
+      "dependsOn": ["^build"],
+      "outputs": ["{projectRoot}/dist"],
+      "inputs": ["build", "^build"]
     },
     "test": {
-      "inputs": [
-        "{projectRoot}/src/**/*",
-        "{projectRoot}/tsconfig.json",
-        "{projectRoot}/package.json",
-        "{projectRoot}/modern.config.*"
-      ]
+      "inputs": ["test", "^test"]
     }
   },
   "affected": {


### PR DESCRIPTION
## Summary

enable inputs of a dependencies to ensure the correctness of cache key calculations when topological dependencies exist between packages.

配置 dependencies 的 inputs 以确保包之间存在拓扑依赖关系时缓存影响面计算的正确性

## Related Issue

https://nx.dev/recipes/running-tasks/configure-inputs#configure-inputs-for-task-caching

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
