### PR TITLE
dosc: fix link in zh/guide/basic/custom-page.mdx

### DIFF
--- a/packages/document/docs/zh/guide/basic/custom-page.mdx
+++ b/packages/document/docs/zh/guide/basic/custom-page.mdx
@@ -95,7 +95,7 @@ export default defineConfig({
 }
 ```
 
-> 如果想了解更多内部的全局样式，可以查看 [vars.css](https://github.com/web-infra-dev/rspress/blob/main/packages/core/src/theme-default/styles/vars.css)
+> 如果想了解更多内部的全局样式，可以查看 [vars.css](https://github.com/web-infra-dev/rspress/blob/main/packages/theme-default/src/styles/vars.css)
 
 ## 自定义布局结构
 


### PR DESCRIPTION
https://github.com/web-infra-dev/rspress/blob/main/packages/core/src/theme-default/styles/vars.css is 404 ---->>
https://github.com/web-infra-dev/rspress/blob/main/packages/theme-default/src/styles/vars.css

## Summary


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
