### PR TITLE
dosc: fix link in en/guide/basic/custom-page.mdx

### DIFF
--- a/packages/document/docs/en/guide/basic/custom-page.mdx
+++ b/packages/document/docs/en/guide/basic/custom-page.mdx
@@ -95,7 +95,7 @@ Here are some commonly used global styles:
 }
 ```
 
-> If you want to know more about the internal global styles, you can check [vars.css](https://github.com/web-infra-dev/rspress/blob/main/packages/core/src/theme-default/styles/vars.css)
+> If you want to know more about the internal global styles, you can check [vars.css](https://github.com/web-infra-dev/rspress/blob/main/packages/theme-default/src/styles/vars.css)
 
 ## Custom Layout Structure
 


### PR DESCRIPTION
https://github.com/web-infra-dev/rspress/blob/main/packages/core/src/theme-default/styles/vars.css is 404 --->>>
https://github.com/web-infra-dev/rspress/blob/main/packages/theme-default/src/styles/vars.css

## Summary


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
