### PR TITLE
fix(theme-default): sidebar begining top items was unchanged after page switch

### DIFF
--- a/.changeset/curly-seahorses-try.md
+++ b/.changeset/curly-seahorses-try.md
@@ -1,0 +1,5 @@
+---
+"@rspress/theme-default": patch
+---
+
+fix sidebar begining top items was unchanged after page switch

--- a/packages/theme-default/src/components/Sidebar/index.tsx
+++ b/packages/theme-default/src/components/Sidebar/index.tsx
@@ -16,13 +16,25 @@ import { SidebarDivider } from './SidebarDivider';
 import { UISwitchResult } from '#theme/logic/useUISwitch';
 import { SidebarSectionHeader } from './SidebarSectionHeader';
 
-const isSidebarDivider = (item: NormalizedSidebarGroup | ISidebarItem | ISidebarDivider | ISidebarSectionHeader): item is ISidebarDivider => {
+const isSidebarDivider = (
+  item:
+    | NormalizedSidebarGroup
+    | ISidebarItem
+    | ISidebarDivider
+    | ISidebarSectionHeader,
+): item is ISidebarDivider => {
   return 'dividerType' in item;
-}
+};
 
-const isSidebarSectionHeader = (item: NormalizedSidebarGroup | ISidebarItem | ISidebarDivider | ISidebarSectionHeader): item is ISidebarSectionHeader => {
+const isSidebarSectionHeader = (
+  item:
+    | NormalizedSidebarGroup
+    | ISidebarItem
+    | ISidebarDivider
+    | ISidebarSectionHeader,
+): item is ISidebarSectionHeader => {
   return 'sectionHeaderText' in item;
-}
+};
 
 export interface SidebarItemProps {
   id: string;
@@ -131,7 +143,14 @@ export function SideBar(props: Props) {
       route.preload();
     }
   };
-  const renderItem = (item: NormalizedSidebarGroup | ISidebarItem | ISidebarDivider | ISidebarSectionHeader, index: number) => {
+  const renderItem = (
+    item:
+      | NormalizedSidebarGroup
+      | ISidebarItem
+      | ISidebarDivider
+      | ISidebarSectionHeader,
+    index: number,
+  ) => {
     if (isSidebarDivider(item)) {
       return (
         <SidebarDivider
@@ -151,20 +170,21 @@ export function SideBar(props: Props) {
         />
       );
     }
+    const itemId = getSideBarItemKey(item, [index]);
 
     return (
       <SidebarItem
-        id={String(index)}
+        id={itemId}
         item={item}
         depth={0}
         activeMatcher={activeMatcher}
-        key={index}
+        key={itemId}
         collapsed={(item as NormalizedSidebarGroup).collapsed ?? true}
         setSidebarData={setSidebarData}
         preloadLink={preloadLink}
       />
     );
-  }
+  };
   return (
     <aside
       className={`${styles.sidebar} rspress-sidebar ${
@@ -195,4 +215,15 @@ export function SideBar(props: Props) {
       </div>
     </aside>
   );
+}
+
+function getSideBarItemKey(item: NormalizedSidebarGroup | ISidebarItem, additionalParts?: any[]) {
+  const parts: (PropertyKey | null | undefined)[] = [
+    item._fileKey,
+    item.link,
+    item.text,
+    'items' in item ? item.items.length : -1,
+    ...additionalParts
+  ];
+  return parts.join('|');
 }


### PR DESCRIPTION
## Summary

https://github.com/web-infra-dev/rspress/assets/18117084/eeffe26f-5e8e-4428-9880-9f7db3bfac29



## Related Issue

<!--- Provide link of related issues -->

- relate: https://github.com/web-infra-dev/rsbuild/issues/1798
- fixes: #770

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
