### PR TITLE
feat: support showing line numbers in shiki plugin

### DIFF
--- a/.changeset/calm-bananas-fail.md
+++ b/.changeset/calm-bananas-fail.md
@@ -1,0 +1,6 @@
+---
+"@rspress/plugin-shiki": patch
+"@rspress/docs": patch
+---
+
+feat: support showing line numbers in shiki plugin

--- a/packages/plugin-shiki/src/shiki/pluginShiki.ts
+++ b/packages/plugin-shiki/src/shiki/pluginShiki.ts
@@ -5,6 +5,10 @@ import type { Lang } from 'shiki';
 import { getHighlighter } from './highlighter';
 import { rehypePluginShiki } from './rehypePlugin';
 import type { ITransformer } from './types';
+import {
+  SHIKI_TRANSFORMER_LINE_NUMBER,
+  createTransformerLineNumber,
+} from './transformers/line-number';
 
 export interface PluginShikiOptions {
   /**
@@ -25,7 +29,12 @@ export interface PluginShikiOptions {
  * The plugin is used to add the last updated time to the page.
  */
 export function pluginShiki(options?: PluginShikiOptions): RspressPlugin {
-  const { theme = 'css-variables', langs = [] } = options || {};
+  const {
+    theme = 'css-variables',
+    langs = [],
+    transformers = [],
+  } = options || {};
+
   return {
     name: '@rspress/plugin-shiki',
 
@@ -35,6 +44,15 @@ export function pluginShiki(options?: PluginShikiOptions): RspressPlugin {
       config.markdown.mdxRs = false;
       config.markdown.codeHighlighter = 'shiki';
       config.markdown.rehypePlugins = config.markdown.rehypePlugins || [];
+      if (
+        config.markdown.showLineNumbers &&
+        !transformers.includes(
+          (transformerItem: ITransformer) =>
+            transformerItem.name === SHIKI_TRANSFORMER_LINE_NUMBER,
+        )
+      ) {
+        transformers.push(createTransformerLineNumber());
+      }
       const highlighter = await getHighlighter({
         theme,
         langs: [
@@ -43,7 +61,7 @@ export function pluginShiki(options?: PluginShikiOptions): RspressPlugin {
           ),
           ...langs,
         ] as Lang[],
-        transformers: options?.transformers,
+        transformers,
       });
 
       config.markdown.rehypePlugins.push([rehypePluginShiki, { highlighter }]);

--- a/packages/plugin-shiki/src/shiki/transformers/line-number.ts
+++ b/packages/plugin-shiki/src/shiki/transformers/line-number.ts
@@ -6,6 +6,8 @@ export interface ITransformerLineNumberOptions {
   classActiveLine?: string;
 }
 
+export const SHIKI_TRANSFORMER_LINE_NUMBER = 'shiki-transformer:line-number';
+
 export function createTransformerLineNumber(
   options: ITransformerLineNumberOptions = {},
 ): ITransformer {
@@ -15,7 +17,7 @@ export function createTransformerLineNumber(
   } = options;
 
   return {
-    name: 'shiki-transformer:line-number',
+    name: SHIKI_TRANSFORMER_LINE_NUMBER,
     preTransformer: ({ code }) => {
       const lineOptions = [] as TLineOptions;
 


### PR DESCRIPTION
## Summary

Support line number in shiki highlight mode:

![image](https://github.com/web-infra-dev/rspress/assets/39261479/93df8ede-18e8-4be1-aac1-96b05a914325)


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
