### PR TITLE
fix(theme): add scroll padding top

### DIFF
--- a/.changeset/fuzzy-pugs-occur.md
+++ b/.changeset/fuzzy-pugs-occur.md
@@ -1,0 +1,5 @@
+---
+'@rspress/theme-default': patch
+---
+
+fix: add scroll padding top

--- a/packages/theme-default/src/styles/base.css
+++ b/packages/theme-default/src/styles/base.css
@@ -12,6 +12,7 @@ html {
   line-height: 1.7;
   font-size: 16px;
   -webkit-text-size-adjust: 100%;
+  scroll-padding-top: var(--rp-nav-height);
 }
 
 html.dark {


### PR DESCRIPTION
## Summary
Prevent in-page jump elements from being blocked by nav.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
