### PR TITLE
feat: optimize ux of the 2nd sticky nav on mobile

### DIFF
--- a/.changeset/mean-worms-fix.md
+++ b/.changeset/mean-worms-fix.md
@@ -1,0 +1,5 @@
+---
+"@rspress/theme-default": patch
+---
+
+feat: optimize mobile ui

--- a/packages/theme-default/package.json
+++ b/packages/theme-default/package.json
@@ -63,7 +63,8 @@
     "react-helmet-async": "^1.3.0",
     "react-syntax-highlighter": "^15.5.0",
     "rspack-plugin-virtual-module": "0.1.12",
-    "string-replace-loader": "^3.1.0"
+    "string-replace-loader": "^3.1.0",
+    "react-transition-group": "4.4.5"
   },
   "devDependencies": {
     "@modern-js/plugin-tailwindcss": "2.48.1",
@@ -96,10 +97,7 @@
     "virtual-global-styles",
     "./src/styles/index.ts"
   ],
-  "files": [
-    "dist",
-    "src"
-  ],
+  "files": ["dist", "src"],
   "publishConfig": {
     "access": "public",
     "provenance": true,

--- a/packages/theme-default/src/components/LocalSideBar/index.scss
+++ b/packages/theme-default/src/components/LocalSideBar/index.scss
@@ -48,16 +48,23 @@
   background-color: var(--rp-c-bg-soft);
   left: 20px;
   right: 20px;
-  height: calc(100vh - var(--rp-nav-height) - 20px);
+  max-height: calc(100vh - var(--rp-nav-height) - 20px);
   overflow: scroll;
   box-shadow: var(--rp-shadow-1);
   border: 1px solid var(--rp-c-divider-light);
-  transition: transform 0.3s ease-out;
 }
 
 .fly-in-enter {
   opacity: 0;
   transform: translateY(-16px);
+}
+
+.fly-in-enter-active {
+  opacity: 1;
+  transform: translateX(0);
+  transition:
+    opacity 300ms,
+    transform 300ms;
 }
 
 .fly-in-exit,

--- a/packages/theme-default/src/components/LocalSideBar/index.scss
+++ b/packages/theme-default/src/components/LocalSideBar/index.scss
@@ -44,10 +44,24 @@
   position: absolute;
   padding: 6px;
   border-radius: var(--rp-radius-small);
-  top: var(--rp-nav-height);
+  top: calc(var(--rp-nav-height) - 14px);
   background-color: var(--rp-c-bg-soft);
+  left: 20px;
   right: 20px;
-  max-width: 250px;
-  transition: all 0.3s;
-  overflow-y: scroll;
+  height: calc(100vh - var(--rp-nav-height) - 20px);
+  overflow: scroll;
+  box-shadow: var(--rp-shadow-1);
+  border: 1px solid var(--rp-c-divider-light);
+  transition: transform 0.3s ease-out;
+}
+
+.fly-in-enter {
+  opacity: 0;
+  transform: translateY(-16px);
+}
+
+.fly-in-exit,
+.fly-in-exit-active {
+  opacity: 0;
+  transition: none;
 }

--- a/packages/theme-default/src/components/LocalSideBar/index.tsx
+++ b/packages/theme-default/src/components/LocalSideBar/index.tsx
@@ -7,6 +7,7 @@ import './index.scss';
 import { Toc } from '../Toc';
 import { UISwitchResult } from '#theme/logic/useUISwitch';
 import { SvgWrapper } from '../SvgWrapper';
+import { CSSTransition } from 'react-transition-group';
 
 export function SideMenu({
   beforeSidebar,
@@ -20,6 +21,7 @@ export function SideMenu({
   const [isSidebarOpen, setSidebarIsOpen] = useState<boolean>(false);
   const [isTocOpen, setIsTocOpen] = useState<boolean>(false);
   const tocContainerRef = useRef<HTMLDivElement>();
+  const outlineButtonRef = useRef<HTMLButtonElement>();
   const { pathname } = useLocation();
 
   function openSidebar() {
@@ -46,6 +48,10 @@ export function SideMenu({
 
   const handleClickOutsideForToc = e => {
     const { current: tocContainer } = tocContainerRef;
+    if (outlineButtonRef.current.contains(e.target)) {
+      return;
+    }
+
     if (tocContainer && !tocContainer.contains(e.target)) {
       setIsTocOpen(false);
     }
@@ -64,21 +70,36 @@ export function SideMenu({
         <button
           onClick={() => setIsTocOpen(tocOpened => !tocOpened)}
           className="flex-center"
+          ref={outlineButtonRef}
         >
           <span className="text-sm">On this page</span>
-          <div className="text-md mr-2">
+          <div
+            className="text-md mr-2"
+            style={{
+              transform: isTocOpen ? 'rotate(90deg)' : 'rotate(0deg)',
+              transition: 'transform 0.2s ease-out',
+              marginTop: '2px',
+            }}
+          >
             <SvgWrapper icon={ArrowRight} />
           </div>
         </button>
-        <div
-          className="rspress-local-toc-container"
-          style={{
-            display: isTocOpen ? 'block' : 'none',
-          }}
-          ref={tocContainerRef}
+
+        <CSSTransition
+          in={isTocOpen}
+          timeout={200}
+          unmountOnExit
+          classNames="rspress-local-toc-container fly-in"
+          nodeRef={tocContainerRef}
         >
-          <Toc />
-        </div>
+          <div ref={tocContainerRef} className="absolute">
+            <Toc
+              onItemClick={() => {
+                setIsTocOpen(false);
+              }}
+            />
+          </div>
+        </CSSTransition>
       </div>
       {/* Sidebar Component */}
       <SideBar

--- a/packages/theme-default/src/components/LocalSideBar/index.tsx
+++ b/packages/theme-default/src/components/LocalSideBar/index.tsx
@@ -87,12 +87,12 @@ export function SideMenu({
 
         <CSSTransition
           in={isTocOpen}
-          timeout={200}
+          timeout={300}
           unmountOnExit
-          classNames="rspress-local-toc-container fly-in"
+          classNames="fly-in"
           nodeRef={tocContainerRef}
         >
-          <div ref={tocContainerRef} className="absolute">
+          <div className="rspress-local-toc-container" ref={tocContainerRef}>
             <Toc
               onItemClick={() => {
                 setIsTocOpen(false);

--- a/packages/theme-default/src/components/Nav/index.tsx
+++ b/packages/theme-default/src/components/Nav/index.tsx
@@ -126,9 +126,13 @@ export function Nav(props: NavProps) {
     <>
       {beforeNav}
       <div
-        className={`${styles.navContainer} sticky rspress-nav px-6 ${
-          hiddenNav ? styles.hidden : ''
+        className={`${styles.navContainer} rspress-nav px-6 ${
+          // Only hidden when it's not mobile
+          hiddenNav && !isMobile ? styles.hidden : ''
         }`}
+        style={{
+          position: isMobile ? 'relative' : 'sticky',
+        }}
       >
         <div
           className={`${styles.container} flex justify-between items-center h-full`}

--- a/packages/theme-default/src/components/Toc/index.tsx
+++ b/packages/theme-default/src/components/Toc/index.tsx
@@ -3,7 +3,13 @@ import { usePageData } from '@rspress/runtime';
 import { renderInlineMarkdown, scrollToTarget } from '#theme/logic';
 import './index.css';
 
-const TocItem = (header: Header) => {
+const TocItem = ({
+  header,
+  onItemClick,
+}: {
+  header: Header;
+  onItemClick?: (header: Header) => void;
+}) => {
   return (
     <li key={header.id}>
       <a
@@ -19,21 +25,28 @@ const TocItem = (header: Header) => {
           if (target) {
             scrollToTarget(target, false);
           }
+          onItemClick?.(header);
         }}
       >
-        <span className={'rspress-toc-link-text block'}>{renderInlineMarkdown(header.text)}</span>
+        <span className={'rspress-toc-link-text block'}>
+          {renderInlineMarkdown(header.text)}
+        </span>
       </a>
     </li>
   );
 };
 
-export function Toc() {
+export function Toc({
+  onItemClick,
+}: {
+  onItemClick?: (header: Header) => void;
+}) {
   const { page } = usePageData();
 
   return (
     <ul>
       {page.toc.map(item => (
-        <TocItem key={item.id} {...item} />
+        <TocItem key={item.id} header={item} onItemClick={onItemClick} />
       ))}
     </ul>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1174,6 +1174,9 @@ importers:
       react-syntax-highlighter:
         specifier: ^15.5.0
         version: 15.5.0(react@18.2.0)
+      react-transition-group:
+        specifier: 4.4.5
+        version: 4.4.5(react-dom@18.2.0)(react@18.2.0)
       rspack-plugin-virtual-module:
         specifier: 0.1.12
         version: 0.1.12


### PR DESCRIPTION
## Summary

Optimize ui and interaction for nav in mobile device:

1. Make the toc list scrollable.
2. Optimize the interaction between the first nav and the second nav menu when user scrolls the page.
3. Add transition animation for the toc component enters when user click the `On this page`  button.

preview:


https://github.com/web-infra-dev/rspress/assets/39261479/8866bac6-ef0b-4904-b903-b53e46dc3e50


## Related Issue

#799 

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
