### PR TITLE
feat(theme-default): preserve query string on locale change

### DIFF
--- a/.changeset/little-dots-compete.md
+++ b/.changeset/little-dots-compete.md
@@ -1,0 +1,5 @@
+---
+"@rspress/theme-default": minor
+---
+
+feat(theme-default): preserve query string on locale change

--- a/packages/theme-default/src/components/Nav/menuDataHooks.tsx
+++ b/packages/theme-default/src/components/Nav/menuDataHooks.tsx
@@ -6,7 +6,7 @@ import { SvgWrapper } from '../SvgWrapper';
 export function useTranslationMenuData() {
   const { siteData, page } = usePageData();
   const currentVersion = useVersion();
-  const { pathname } = useLocation();
+  const { pathname, search } = useLocation();
   const defaultLang = siteData.lang || '';
   const defaultVersion = siteData.multiVersion.default || '';
   const localeLanguages = Object.values(
@@ -31,7 +31,7 @@ export function useTranslationMenuData() {
         items: localeLanguages.map(item => ({
           text: item?.label,
           link: replaceLang(
-            pathname,
+            pathname + search,
             {
               current: currentLang,
               target: item.lang,


### PR DESCRIPTION
## Summary

It's useful when you use custom filter/tabs in your site and you want to keep the state on locale change.

The hash could be preserved as well, but it's not common as the query string. (eg. when using Docusaurus, the query string and hash are both preserved: https://docusaurus.io/docs/markdown-features/tabs?current-os=android#query-string)

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
