### PR TITLE
chore(workflow): no need to trigger update for rsbuild

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,12 +130,3 @@ jobs:
           -H 'Authorization: Bearer ${{ secrets.REPO_SCOPED_TOKEN }}' \
           -d '{"ref": "main"}' \
           https://api.github.com/repos/web-infra-dev/modern.js/actions/workflows/update-rspress.yml/dispatches
-
-      - name: Trigger Rsbuild Update Rspress
-        if: ${{github.event.inputs.version == 'latest'}}
-        run: |
-          curl -X POST \
-          -H 'Content-Type: application/json' \
-          -H 'Authorization: Bearer ${{ secrets.REPO_SCOPED_TOKEN }}' \
-          -d '{"ref": "main"}' \
-          https://api.github.com/repos/web-infra-dev/rsbuild/actions/workflows/update-rspress.yml/dispatches


### PR DESCRIPTION
## Summary

No need to trigger update for rsbuild, as rsbuild uses renovate to update dependencies.

## Related Issue

- https://github.com/web-infra-dev/rsbuild/pull/1861
- https://github.com/web-infra-dev/modern.js/pull/5545

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
