### PR TITLE
chore(theme): remove imports, use relative path instead

### DIFF
--- a/.changeset/clean-apricots-explode.md
+++ b/.changeset/clean-apricots-explode.md
@@ -1,0 +1,5 @@
+---
+'@rspress/theme-default': patch
+---
+
+chore: remove #theme in source code

--- a/packages/theme-default/src/components/Aside/index.tsx
+++ b/packages/theme-default/src/components/Aside/index.tsx
@@ -1,7 +1,12 @@
 import { useEffect } from 'react';
 import { Header } from '@rspress/shared';
-import { bindingAsideScroll, renderInlineMarkdown, scrollToTarget, useHiddenNav } from '../../logic';
-import { DEFAULT_NAV_HEIGHT } from '#theme/logic/sideEffects';
+import {
+  bindingAsideScroll,
+  renderInlineMarkdown,
+  scrollToTarget,
+  useHiddenNav,
+} from '../../logic';
+import { DEFAULT_NAV_HEIGHT } from '../../logic/sideEffects';
 import './index.css';
 
 export function Aside(props: { headers: Header[]; outlineTitle: string }) {
@@ -52,7 +57,9 @@ export function Aside(props: { headers: Header[]; outlineTitle: string }) {
             }
           }}
         >
-          <span className="aside-link-text block">{renderInlineMarkdown(header.text)}</span>
+          <span className="aside-link-text block">
+            {renderInlineMarkdown(header.text)}
+          </span>
         </a>
       </li>
     );

--- a/packages/theme-default/src/components/HomeFeature/index.tsx
+++ b/packages/theme-default/src/components/HomeFeature/index.tsx
@@ -1,6 +1,6 @@
 import { FrontMatterMeta, Feature } from '@rspress/shared';
 import styles from './index.module.scss';
-import { renderHtmlOrText } from '#theme/logic';
+import { renderHtmlOrText } from '../../logic';
 
 const GRID_PREFIX = 'grid-';
 

--- a/packages/theme-default/src/components/Link/index.tsx
+++ b/packages/theme-default/src/components/Link/index.tsx
@@ -12,7 +12,7 @@ import nprogress from 'nprogress';
 import { routes } from 'virtual-routes';
 import { isExternalUrl } from '@rspress/shared';
 import styles from './index.module.scss';
-import { scrollToTarget } from '#theme/logic';
+import { scrollToTarget } from '../../logic';
 
 export interface LinkProps extends ComponentProps<'a'> {
   href?: string;

--- a/packages/theme-default/src/components/LocalSideBar/index.tsx
+++ b/packages/theme-default/src/components/LocalSideBar/index.tsx
@@ -4,7 +4,7 @@ import MenuIcon from '@theme-assets/menu';
 import ArrowRight from '@theme-assets/arrow-right';
 import { SideBar, Toc } from '@theme';
 import './index.scss';
-import { UISwitchResult } from '#theme/logic/useUISwitch';
+import { UISwitchResult } from '../../logic/useUISwitch';
 import { SvgWrapper } from '../SvgWrapper';
 import { CSSTransition } from 'react-transition-group';
 

--- a/packages/theme-default/src/components/Nav/NavBarTitle.tsx
+++ b/packages/theme-default/src/components/Nav/NavBarTitle.tsx
@@ -6,7 +6,7 @@ import {
   withBase,
 } from '@rspress/runtime';
 import styles from './index.module.scss';
-import { getLogoUrl, useLocaleSiteData } from '#theme/logic';
+import { getLogoUrl, useLocaleSiteData } from '../../logic';
 
 export const NavBarTitle = () => {
   const { siteData } = usePageData();

--- a/packages/theme-default/src/components/Nav/index.tsx
+++ b/packages/theme-default/src/components/Nav/index.tsx
@@ -12,7 +12,7 @@ import styles from './index.module.scss';
 import { NavBarTitle } from './NavBarTitle';
 import { NavTranslations } from './NavTranslations';
 import { NavVersions } from './NavVersions';
-import { useNavData } from '#theme/logic/useNav';
+import { useNavData } from '../../logic/useNav';
 
 export interface NavProps {
   beforeNav?: React.ReactNode;

--- a/packages/theme-default/src/components/NavScreen/index.tsx
+++ b/packages/theme-default/src/components/NavScreen/index.tsx
@@ -12,7 +12,7 @@ import {
 } from '../Nav/menuDataHooks';
 import { NavScreenMenuGroup } from './NavScreenMenuGroup';
 import styles from './index.module.scss';
-import { useNavData } from '#theme/logic/useNav';
+import { useNavData } from '../../logic/useNav';
 
 interface Props {
   isScreenOpen: boolean;

--- a/packages/theme-default/src/components/Search/index.tsx
+++ b/packages/theme-default/src/components/Search/index.tsx
@@ -3,7 +3,7 @@ import SearchSvg from '@theme-assets/search';
 import styles from './index.module.scss';
 import { SearchPanel } from './SearchPanel';
 import { SvgWrapper } from '../SvgWrapper';
-import { useLocaleSiteData } from '#theme/logic';
+import { useLocaleSiteData } from '../../logic';
 
 export function Search() {
   const [focused, setFocused] = useState(false);

--- a/packages/theme-default/src/components/Sidebar/SidebarGroup.tsx
+++ b/packages/theme-default/src/components/Sidebar/SidebarGroup.tsx
@@ -12,7 +12,7 @@ import { SidebarItem } from './SidebarItem';
 import { SidebarDivider } from './SidebarDivider';
 import { highlightTitleStyle, matchCache, type SidebarItemProps } from '.';
 import { SvgWrapper } from '../SvgWrapper';
-import { renderInlineMarkdown } from '#theme/logic';
+import { renderInlineMarkdown } from '../../logic';
 
 export function SidebarGroup(props: SidebarItemProps) {
   const { item, depth = 0, activeMatcher, id, setSidebarData } = props;

--- a/packages/theme-default/src/components/Sidebar/SidebarItem.tsx
+++ b/packages/theme-default/src/components/Sidebar/SidebarItem.tsx
@@ -8,8 +8,8 @@ import { Link, Tag } from '@theme';
 import styles from './index.module.scss';
 import { SidebarGroup } from './SidebarGroup';
 import { SidebarItemProps, highlightTitleStyle } from '.';
-import { renderInlineMarkdown } from '#theme/logic';
-import { useRenderer } from '#theme/logic/useRerender';
+import { renderInlineMarkdown } from '../../logic';
+import { useRenderer } from '../../logic/useRerender';
 
 const removeExtension = (path: string) => {
   return path.replace(/\.(mdx?)$/, '');

--- a/packages/theme-default/src/components/Sidebar/SidebarSectionHeader.tsx
+++ b/packages/theme-default/src/components/Sidebar/SidebarSectionHeader.tsx
@@ -1,4 +1,4 @@
-import { renderInlineMarkdown } from '#theme/logic';
+import { renderInlineMarkdown } from '../../logic';
 import { Tag } from '@theme';
 
 export function SidebarSectionHeader({

--- a/packages/theme-default/src/components/Sidebar/index.tsx
+++ b/packages/theme-default/src/components/Sidebar/index.tsx
@@ -13,7 +13,7 @@ import { NavBarTitle } from '../Nav/NavBarTitle';
 import styles from './index.module.scss';
 import { SidebarItem } from './SidebarItem';
 import { SidebarDivider } from './SidebarDivider';
-import { UISwitchResult } from '#theme/logic/useUISwitch';
+import { UISwitchResult } from '../../logic/useUISwitch';
 import { SidebarSectionHeader } from './SidebarSectionHeader';
 
 const isSidebarDivider = (

--- a/packages/theme-default/src/components/Toc/index.tsx
+++ b/packages/theme-default/src/components/Toc/index.tsx
@@ -1,6 +1,6 @@
 import { Header } from '@rspress/shared';
 import { usePageData } from '@rspress/runtime';
-import { renderInlineMarkdown, scrollToTarget } from '#theme/logic';
+import { renderInlineMarkdown, scrollToTarget } from '../../logic';
 import './index.css';
 
 const TocItem = ({

--- a/packages/theme-default/src/layout/DocLayout/docComponents/code/CopyCodeButton.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/code/CopyCodeButton.tsx
@@ -3,7 +3,7 @@ import copy from 'copy-to-clipboard';
 import IconCopy from '@theme-assets/copy';
 import IconSuccess from '@theme-assets/success';
 import styles from './index.module.scss';
-import { SvgWrapper } from '#theme/components/SvgWrapper';
+import { SvgWrapper } from '../../../../components/SvgWrapper';
 
 const timeoutIdMap: Map<HTMLElement, NodeJS.Timeout> = new Map();
 

--- a/packages/theme-default/src/layout/DocLayout/docComponents/code/index.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/code/index.tsx
@@ -5,7 +5,7 @@ import IconWrapped from '@theme-assets/wrapped';
 import styles from './index.module.scss';
 import { PrismSyntaxHighlighter } from './PrismSytaxHighlighter';
 import { CopyCodeButton } from './CopyCodeButton';
-import { SvgWrapper } from '#theme/components/SvgWrapper';
+import { SvgWrapper } from '../../../../components/SvgWrapper';
 
 export interface CodeProps {
   children: string;

--- a/packages/theme-default/src/layout/DocLayout/docComponents/link.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/link.tsx
@@ -1,7 +1,7 @@
 import { ComponentProps } from 'react';
 import styles from './index.module.scss';
-import { Link } from '#theme/components/Link';
-import { usePathUtils } from '#theme/logic';
+import { Link } from '@theme';
+import { usePathUtils } from '../../../logic';
 
 export const A = (props: ComponentProps<'a'>) => {
   const { href = '', className = '' } = props;

--- a/packages/theme-default/src/layout/DocLayout/index.tsx
+++ b/packages/theme-default/src/layout/DocLayout/index.tsx
@@ -8,7 +8,7 @@ import { useLocaleSiteData } from '../../logic';
 import { SideMenu } from '../../components/LocalSideBar';
 import { TabDataContext } from '../../logic/TabDataContext';
 import styles from './index.module.scss';
-import { UISwitchResult } from '#theme/logic/useUISwitch';
+import { UISwitchResult } from '../../logic/useUISwitch';
 
 export interface DocLayoutProps {
   beforeSidebar?: React.ReactNode;

--- a/packages/theme-default/src/layout/Layout/index.tsx
+++ b/packages/theme-default/src/layout/Layout/index.tsx
@@ -7,9 +7,9 @@ import { usePageData, Content } from '@rspress/runtime';
 import { DocLayout, DocLayoutProps } from '../DocLayout';
 import { HomeLayoutProps } from '../HomeLayout';
 import type { NavProps } from '../../components/Nav';
-import { useLocaleSiteData } from '#theme/logic';
-import { useRedirect4FirstVisit } from '#theme/logic/useRedirect4FirstVisit';
-import { useUISwitch } from '#theme/logic/useUISwitch';
+import { useLocaleSiteData } from '../../logic';
+import { useRedirect4FirstVisit } from '../../logic/useRedirect4FirstVisit';
+import { useUISwitch } from '../../logic/useUISwitch';
 
 export type LayoutProps = {
   top?: React.ReactNode;


### PR DESCRIPTION
## Summary
When we use #theme, we will get the same module id in dist/bundle.js.
Use relative path instead, and bundle it by module-tools.

![image](https://github.com/web-infra-dev/rspress/assets/50694858/2684ddeb-37fe-4f28-92ae-171c083f84a2)


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
