### PR TITLE
feat(theme): support link keep current params and navigate

### DIFF
--- a/.changeset/soft-horses-greet.md
+++ b/.changeset/soft-horses-greet.md
@@ -1,0 +1,5 @@
+---
+'@rspress/theme-default': minor
+---
+
+feat(theme): support link keep current params and navigate

--- a/packages/theme-default/src/components/Link/index.tsx
+++ b/packages/theme-default/src/components/Link/index.tsx
@@ -19,18 +19,28 @@ export interface LinkProps extends ComponentProps<'a'> {
   children?: React.ReactNode;
   className?: string;
   onNavigate?: () => void;
+  // keep current url parameters when href is internal
+  keepCurrentParams?: boolean;
 }
 
 nprogress.configure({ showSpinner: false });
 
 export function Link(props: LinkProps) {
-  const { href = '/', children, className = '', onNavigate, ...rest } = props;
+  const {
+    href = '/',
+    children,
+    className = '',
+    onNavigate,
+    keepCurrentParams = false,
+    ...rest
+  } = props;
   const isExternal = isExternalUrl(href);
   const target = isExternal ? '_blank' : '';
   const rel = isExternal ? 'noopener noreferrer' : undefined;
   const withBaseUrl = isExternal ? href : withBase(normalizeHref(href));
   const navigate = useNavigate();
-  const { pathname } = useLocation();
+  const { pathname, search } = useLocation();
+  const withQueryUrl = keepCurrentParams ? withBaseUrl + search : withBaseUrl;
   const inCurrentPage = isEqualPath(pathname, withBaseUrl);
   const handleNavigate = async (
     e: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
@@ -74,7 +84,7 @@ export function Link(props: LinkProps) {
         nprogress.done();
       }
       onNavigate?.();
-      navigate(withBaseUrl, { replace: false });
+      navigate(withQueryUrl, { replace: false });
     }
   };
 


### PR DESCRIPTION
## Summary
Support internal link can keep url params.

`keepCurrentParams` is false by default, later we maybe change it to `true`

We can customize it in theme/index.tsx like this:

```jsx
import { Link } from 'rspress/theme';

const myLink = (props) => {
  return <Link keepCurrentParams={true} {...props} />;
};

export { myLink as Link };
```

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
