### PR TITLE
chore: remove @modern-js/types dependency

### DIFF
--- a/.changeset/nice-planets-invent.md
+++ b/.changeset/nice-planets-invent.md
@@ -1,0 +1,7 @@
+---
+"@rspress/theme-default": patch
+"@rspress/runtime": patch
+"@rspress/core": patch
+---
+
+chore: remove @modern-js/types dependency

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -103,7 +103,6 @@
     "tailwindcss": "^3.2.7",
     "@modern-js/plugin-tailwindcss": "2.48.1",
     "@modern-js/tsconfig": "2.48.1",
-    "@modern-js/types": "2.48.1",
     "@types/body-scroll-lock": "^3.1.0",
     "@types/fs-extra": "^9.0.13",
     "@types/hast": "^2.3.4",

--- a/packages/core/src/node/searchIndex.ts
+++ b/packages/core/src/node/searchIndex.ts
@@ -1,7 +1,7 @@
 import path, { join } from 'path';
 import fs from '@rspress/shared/fs-extra';
 import chalk from '@rspress/shared/chalk';
-import { RequestHandler } from '@modern-js/types';
+import type { IncomingMessage, ServerResponse } from 'http';
 import fetch from 'node-fetch';
 import { UserConfig, isSCM, SEARCH_INDEX_NAME } from '@rspress/shared';
 import { logger } from '@rspress/shared/logger';
@@ -62,6 +62,12 @@ export async function writeSearchIndex(config: UserConfig) {
     }
   }
 }
+
+type RequestHandler = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  next: () => void,
+) => void;
 
 export function serveSearchIndexMiddleware(config: UserConfig): RequestHandler {
   return (req, res, next) => {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -48,7 +48,6 @@
   },
   "devDependencies": {
     "@modern-js/tsconfig": "2.48.1",
-    "@modern-js/types": "2.48.1",
     "@types/jest": "^26.0.9",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/packages/theme-default/package.json
+++ b/packages/theme-default/package.json
@@ -69,7 +69,6 @@
   "devDependencies": {
     "@modern-js/plugin-tailwindcss": "2.48.1",
     "@modern-js/tsconfig": "2.48.1",
-    "@modern-js/types": "2.48.1",
     "@types/body-scroll-lock": "^3.1.0",
     "@types/hast": "^2.3.4",
     "@types/html-to-text": "^8.1.1",
@@ -97,7 +96,10 @@
     "virtual-global-styles",
     "./src/styles/index.ts"
   ],
-  "files": ["dist", "src"],
+  "files": [
+    "dist",
+    "src"
+  ],
   "publishConfig": {
     "access": "public",
     "provenance": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -461,9 +461,6 @@ importers:
       '@modern-js/tsconfig':
         specifier: 2.48.1
         version: 2.48.1
-      '@modern-js/types':
-        specifier: 2.48.1
-        version: 2.48.1
       '@types/body-scroll-lock':
         specifier: ^3.1.0
         version: 3.1.0
@@ -1041,9 +1038,6 @@ importers:
       '@modern-js/tsconfig':
         specifier: 2.48.1
         version: 2.48.1
-      '@modern-js/types':
-        specifier: 2.48.1
-        version: 2.48.1
       '@types/jest':
         specifier: ^26.0.9
         version: 26.0.9
@@ -1188,9 +1182,6 @@ importers:
         specifier: 2.48.1
         version: 2.48.1(tailwindcss@3.2.7)
       '@modern-js/tsconfig':
-        specifier: 2.48.1
-        version: 2.48.1
-      '@modern-js/types':
         specifier: 2.48.1
         version: 2.48.1
       '@types/body-scroll-lock':


### PR DESCRIPTION
## Summary

Remove `@modern-js/types` dependency, this is an internal package of Modern.js and we should avoid depending on it.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.