### PR TITLE
perf: remove node-bundle-require dependency

### DIFF
--- a/.changeset/angry-coins-drum.md
+++ b/.changeset/angry-coins-drum.md
@@ -1,0 +1,5 @@
+---
+"rspress": patch
+---
+
+perf: remove node-bundle-require dependency

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,7 +37,7 @@
     "upgrade": "modern upgrade"
   },
   "dependencies": {
-    "@modern-js/node-bundle-require": "2.48.1",
+    "@rsbuild/core": "0.5.1",
     "@rspress/core": "workspace:*",
     "@rspress/shared": "workspace:*",
     "cac": "^6.7.14",

--- a/packages/cli/src/config/loadConfigFile.ts
+++ b/packages/cli/src/config/loadConfigFile.ts
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import path from 'path';
-import { createRequire } from 'module';
 import type { UserConfig } from '@rspress/core';
 import { DEFAULT_CONFIG_NAME, DEFAULT_EXTENSIONS } from '@/constants';
 
@@ -27,15 +26,11 @@ export async function loadConfigFile(
     return {};
   }
 
-  const require = createRequire(import.meta.url);
-  const nodeBundleRequire = require('@modern-js/node-bundle-require');
+  const { loadConfig } = await import('@rsbuild/core');
+  const { content } = await loadConfig({
+    cwd: path.dirname(configFilePath),
+    path: configFilePath,
+  });
 
-  let result = (await nodeBundleRequire.bundleRequire(configFilePath, {
-    require,
-  })) as UserConfig | { default: UserConfig };
-
-  if (result && typeof result === 'object' && 'default' in result) {
-    result = result.default || {};
-  }
-  return result;
+  return content as UserConfig;
 }

--- a/packages/cli/src/config/loadConfigFile.ts
+++ b/packages/cli/src/config/loadConfigFile.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import type { UserConfig } from '@rspress/core';
+import { logger } from '@rspress/shared/logger';
 import { DEFAULT_CONFIG_NAME, DEFAULT_EXTENSIONS } from '@/constants';
 
 const findConfig = (basePath: string): string | undefined => {
@@ -22,7 +23,7 @@ export async function loadConfigFile(
     configFilePath = findConfig(path.join(baseDir, DEFAULT_CONFIG_NAME))!;
   }
   if (!configFilePath) {
-    console.log('no config file found');
+    logger.info(`No config file found in ${baseDir}`);
     return {};
   }
 

--- a/packages/cli/src/config/loadConfigFile.ts
+++ b/packages/cli/src/config/loadConfigFile.ts
@@ -33,5 +33,8 @@ export async function loadConfigFile(
     path: configFilePath,
   });
 
+  // delete the meta info of Rsbuild
+  delete content._privateMeta;
+
   return content as UserConfig;
 }

--- a/packages/cli/src/config/loadConfigFile.ts
+++ b/packages/cli/src/config/loadConfigFile.ts
@@ -33,8 +33,5 @@ export async function loadConfigFile(
     path: configFilePath,
   });
 
-  // delete the meta info of Rsbuild
-  delete content._privateMeta;
-
   return content as UserConfig;
 }

--- a/packages/cli/tests/config/config-basic.test.ts
+++ b/packages/cli/tests/config/config-basic.test.ts
@@ -10,7 +10,8 @@ describe('Should load config file', () => {
     const config = await loadConfigFile(
       path.join(fixtureDir, 'rspress.config.cjs'),
     );
-    expect(config).toContain({
+
+    expect(config).toEqual({
       root: fixtureDir,
       title: TEST_TITLE,
     });
@@ -21,7 +22,7 @@ describe('Should load config file', () => {
     const config = await loadConfigFile(
       path.join(fixtureDir, 'rspress.config.mjs'),
     );
-    expect(config).toContain({
+    expect(config).toEqual({
       root: fixtureDir,
       title: TEST_TITLE,
     });
@@ -32,13 +33,13 @@ describe('Should load config file', () => {
     let config = await loadConfigFile(
       path.join(fixtureDir, 'rspress.config.js'),
     );
-    expect(config).toContain({
+    expect(config).toEqual({
       root: fixtureDir,
       title: TEST_TITLE,
     });
 
     config = await loadConfigFile(path.join(fixtureDir, 'rspress.config.ts'));
-    expect(config).toContain({
+    expect(config).toEqual({
       root: fixtureDir,
       title: TEST_TITLE,
     });
@@ -49,13 +50,13 @@ describe('Should load config file', () => {
     let config = await loadConfigFile(
       path.join(fixtureDir, 'rspress.config.js'),
     );
-    expect(config).toContain({
+    expect(config).toEqual({
       root: fixtureDir,
       title: TEST_TITLE,
     });
 
     config = await loadConfigFile(path.join(fixtureDir, 'rspress.config.ts'));
-    expect(config).toContain({
+    expect(config).toEqual({
       root: fixtureDir,
       title: TEST_TITLE,
     });

--- a/packages/cli/tests/config/config-basic.test.ts
+++ b/packages/cli/tests/config/config-basic.test.ts
@@ -6,7 +6,7 @@ const TEST_TITLE = 'my-title';
 
 describe('Should load config file', () => {
   test('Load config.cjs', async () => {
-    const fixtureDir = path.join(__dirname, './cjs');
+    const fixtureDir = path.join(__dirname, 'cjs');
     const config = await loadConfigFile(
       path.join(fixtureDir, 'rspress.config.cjs'),
     );
@@ -17,7 +17,7 @@ describe('Should load config file', () => {
   });
 
   test('Load config.mjs', async () => {
-    const fixtureDir = path.join(__dirname, './esm');
+    const fixtureDir = path.join(__dirname, 'esm');
     const config = await loadConfigFile(
       path.join(fixtureDir, 'rspress.config.mjs'),
     );
@@ -28,7 +28,7 @@ describe('Should load config file', () => {
   });
 
   test('Load config.js/config.ts in cjs project', async () => {
-    const fixtureDir = path.join(__dirname, './cjs');
+    const fixtureDir = path.join(__dirname, 'cjs');
     let config = await loadConfigFile(
       path.join(fixtureDir, 'rspress.config.js'),
     );
@@ -45,7 +45,7 @@ describe('Should load config file', () => {
   });
 
   test('Load config.js/config.ts in esm project', async () => {
-    const fixtureDir = path.join(__dirname, './esm');
+    const fixtureDir = path.join(__dirname, 'esm');
     let config = await loadConfigFile(
       path.join(fixtureDir, 'rspress.config.js'),
     );

--- a/packages/cli/tests/config/config-basic.test.ts
+++ b/packages/cli/tests/config/config-basic.test.ts
@@ -37,14 +37,16 @@ describe('Should load config file', () => {
       path.join(fixtureDir, 'rspress.config.js'),
     );
 
-    const expectConfig = {
-      root: normalizePath(fixtureDir),
+    expect(config).toContain({
+      root: fixtureDir,
       title: TEST_TITLE,
-    };
-    expect(config).toContain(expectConfig);
+    });
 
     config = await loadConfigFile(path.join(fixtureDir, 'rspress.config.ts'));
-    expect(config).toContain(expectConfig);
+    expect(config).toContain({
+      root: normalizePath(fixtureDir),
+      title: TEST_TITLE,
+    });
   });
 
   test('Load config.js/config.ts in esm project', async () => {

--- a/packages/cli/tests/config/config-basic.test.ts
+++ b/packages/cli/tests/config/config-basic.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from 'vitest';
 import { loadConfigFile } from '../../src/config/loadConfigFile';
 import path from 'path';
+import { normalizePath } from '../../../core/src/node/utils/normalizePath';
 
 const TEST_TITLE = 'my-title';
 
@@ -24,9 +25,8 @@ describe('Should load config file', () => {
     );
 
     expect(config).toContain({
-      // use path.posix here,
-      // as jiti will inject `__dirname` with posix separator in esm files
-      root: path.posix.join(__dirname, 'esm'),
+      // we need to normalize path as jiti will inject `__dirname` with posix separator in esm files
+      root: normalizePath(fixtureDir),
       title: TEST_TITLE,
     });
   });
@@ -38,7 +38,7 @@ describe('Should load config file', () => {
     );
 
     const expectConfig = {
-      root: path.posix.join(__dirname, 'cjs'),
+      root: normalizePath(fixtureDir),
       title: TEST_TITLE,
     };
     expect(config).toContain(expectConfig);
@@ -54,7 +54,7 @@ describe('Should load config file', () => {
     );
 
     const expectConfig = {
-      root: path.posix.join(__dirname, 'esm'),
+      root: normalizePath(fixtureDir),
       title: TEST_TITLE,
     };
     expect(config).toContain(expectConfig);

--- a/packages/cli/tests/config/config-basic.test.ts
+++ b/packages/cli/tests/config/config-basic.test.ts
@@ -11,7 +11,7 @@ describe('Should load config file', () => {
       path.join(fixtureDir, 'rspress.config.cjs'),
     );
 
-    expect(config).toEqual({
+    expect(config).toContain({
       root: fixtureDir,
       title: TEST_TITLE,
     });
@@ -22,8 +22,11 @@ describe('Should load config file', () => {
     const config = await loadConfigFile(
       path.join(fixtureDir, 'rspress.config.mjs'),
     );
-    expect(config).toEqual({
-      root: fixtureDir,
+
+    expect(config).toContain({
+      // use path.posix here,
+      // as jiti will inject `__dirname` with posix separator in esm files
+      root: path.posix.join(__dirname, 'esm'),
       title: TEST_TITLE,
     });
   });
@@ -33,16 +36,15 @@ describe('Should load config file', () => {
     let config = await loadConfigFile(
       path.join(fixtureDir, 'rspress.config.js'),
     );
-    expect(config).toEqual({
-      root: fixtureDir,
+
+    const expectConfig = {
+      root: path.posix.join(__dirname, 'cjs'),
       title: TEST_TITLE,
-    });
+    };
+    expect(config).toContain(expectConfig);
 
     config = await loadConfigFile(path.join(fixtureDir, 'rspress.config.ts'));
-    expect(config).toEqual({
-      root: fixtureDir,
-      title: TEST_TITLE,
-    });
+    expect(config).toContain(expectConfig);
   });
 
   test('Load config.js/config.ts in esm project', async () => {
@@ -50,15 +52,14 @@ describe('Should load config file', () => {
     let config = await loadConfigFile(
       path.join(fixtureDir, 'rspress.config.js'),
     );
-    expect(config).toEqual({
-      root: fixtureDir,
+
+    const expectConfig = {
+      root: path.posix.join(__dirname, 'esm'),
       title: TEST_TITLE,
-    });
+    };
+    expect(config).toContain(expectConfig);
 
     config = await loadConfigFile(path.join(fixtureDir, 'rspress.config.ts'));
-    expect(config).toEqual({
-      root: fixtureDir,
-      title: TEST_TITLE,
-    });
+    expect(config).toContain(expectConfig);
   });
 });

--- a/packages/cli/tests/config/config-basic.test.ts
+++ b/packages/cli/tests/config/config-basic.test.ts
@@ -10,7 +10,7 @@ describe('Should load config file', () => {
     const config = await loadConfigFile(
       path.join(fixtureDir, 'rspress.config.cjs'),
     );
-    expect(config).toEqual({
+    expect(config).toContain({
       root: fixtureDir,
       title: TEST_TITLE,
     });
@@ -21,7 +21,7 @@ describe('Should load config file', () => {
     const config = await loadConfigFile(
       path.join(fixtureDir, 'rspress.config.mjs'),
     );
-    expect(config).toEqual({
+    expect(config).toContain({
       root: fixtureDir,
       title: TEST_TITLE,
     });
@@ -32,13 +32,13 @@ describe('Should load config file', () => {
     let config = await loadConfigFile(
       path.join(fixtureDir, 'rspress.config.js'),
     );
-    expect(config).toEqual({
+    expect(config).toContain({
       root: fixtureDir,
       title: TEST_TITLE,
     });
 
     config = await loadConfigFile(path.join(fixtureDir, 'rspress.config.ts'));
-    expect(config).toEqual({
+    expect(config).toContain({
       root: fixtureDir,
       title: TEST_TITLE,
     });
@@ -49,13 +49,13 @@ describe('Should load config file', () => {
     let config = await loadConfigFile(
       path.join(fixtureDir, 'rspress.config.js'),
     );
-    expect(config).toEqual({
+    expect(config).toContain({
       root: fixtureDir,
       title: TEST_TITLE,
     });
 
     config = await loadConfigFile(path.join(fixtureDir, 'rspress.config.ts'));
-    expect(config).toEqual({
+    expect(config).toContain({
       root: fixtureDir,
       title: TEST_TITLE,
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,9 +264,9 @@ importers:
 
   packages/cli:
     dependencies:
-      '@modern-js/node-bundle-require':
-        specifier: 2.48.1
-        version: 2.48.1
+      '@rsbuild/core':
+        specifier: 0.5.1
+        version: 0.5.1
       '@rspress/core':
         specifier: workspace:*
         version: link:../core
@@ -2108,6 +2108,7 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-arm64@0.18.20:
@@ -2134,6 +2135,7 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-arm@0.18.20:
@@ -2160,6 +2162,7 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-x64@0.18.20:
@@ -2186,6 +2189,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/darwin-arm64@0.18.20:
@@ -2212,6 +2216,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/darwin-x64@0.18.20:
@@ -2238,6 +2243,7 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/freebsd-arm64@0.18.20:
@@ -2264,6 +2270,7 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/freebsd-x64@0.18.20:
@@ -2290,6 +2297,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-arm64@0.18.20:
@@ -2316,6 +2324,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-arm@0.18.20:
@@ -2342,6 +2351,7 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-ia32@0.18.20:
@@ -2368,6 +2378,7 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.18.20:
@@ -2394,6 +2405,7 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-mips64el@0.18.20:
@@ -2420,6 +2432,7 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-ppc64@0.18.20:
@@ -2446,6 +2459,7 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-riscv64@0.18.20:
@@ -2472,6 +2486,7 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-s390x@0.18.20:
@@ -2498,6 +2513,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-x64@0.18.20:
@@ -2524,6 +2540,7 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/netbsd-x64@0.18.20:
@@ -2550,6 +2567,7 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/openbsd-x64@0.18.20:
@@ -2576,6 +2594,7 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/sunos-x64@0.18.20:
@@ -2602,6 +2621,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-arm64@0.18.20:
@@ -2628,6 +2648,7 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-ia32@0.18.20:
@@ -2654,6 +2675,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-x64@0.18.20:
@@ -3082,6 +3104,7 @@ packages:
       '@modern-js/utils': 2.48.1
       '@swc/helpers': 0.5.3
       esbuild: 0.17.19
+    dev: true
 
   /@modern-js/plugin-changeset@2.48.1:
     resolution: {integrity: sha512-F3WlZ9SK7tSkd1NZd7fa4y7RoCeN4lst+WI2GBeWGhF9Ftvh5GM6PQOrdQWQ1Z7w9BtDNPzYZI9hPBt89rh7Eg==}
@@ -5838,6 +5861,7 @@ packages:
       '@esbuild/win32-arm64': 0.17.19
       '@esbuild/win32-ia32': 0.17.19
       '@esbuild/win32-x64': 0.17.19
+    dev: true
 
   /esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}


### PR DESCRIPTION
## Summary

This PR uses the public `loadConfig` API of Rsbuild to load the config file, instead of `@modern-js/node-bundle-require`.

The `loadConfig` is based on jiti and offers better performance and less dependencies. The motivation is basically the same as https://github.com/web-infra-dev/rspress/pull/144.

After this change, Rspress will no longer depend on `@modern-js/node-bundle-require` and `esbuild`, so the install size can be reduced by 9+ mB.

## Related Issue

- https://rsbuild.dev/api/javascript-api/core#loadconfig

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
