### PR TITLE
fix: support source-build in mdx files

### DIFF
--- a/.changeset/four-gifts-fix.md
+++ b/.changeset/four-gifts-fix.md
@@ -1,0 +1,5 @@
+---
+"@rspress/core": patch
+---
+
+fix: support source-build in mdx files

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -160,8 +160,9 @@ async function createInternalBuildConfig(
     },
     tools: {
       bundlerChain(chain, { CHAIN_ID }) {
-        const swcLoaderOptions = chain.module
-          .rule(CHAIN_ID.RULE.JS)
+        const jsModuleRule = chain.module.rule(CHAIN_ID.RULE.JS);
+
+        const swcLoaderOptions = jsModuleRule
           .use(CHAIN_ID.USE.SWC)
           .get('options');
 
@@ -169,6 +170,11 @@ async function createInternalBuildConfig(
           .rule('MDX')
           .type('javascript/auto')
           .test(MDX_REGEXP)
+          .resolve.merge({
+            conditionNames: jsModuleRule.resolve.get('conditionNames'),
+            mainFields: jsModuleRule.resolve.mainFields.values(),
+          })
+          .end()
           .oneOf('MDXCompile')
           .use('builtin:swc-loader')
           .loader('builtin:swc-loader')


### PR DESCRIPTION
## Summary

fix: https://github.com/web-infra-dev/rspress/issues/756

The Rsbuild source-build plugin only applies `resolve.mainFields` and `conditionNames` in JS & TS rules, in Rspress, it also needs support in mdx files.
<img width="964" alt="image" src="https://github.com/web-infra-dev/rspress/assets/22373761/43b4638e-433a-4446-9d25-c219dbb282a2">

https://github.com/web-infra-dev/rsbuild/blob/main/packages/plugin-source-build/src/index.ts#L87

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
