### PR TITLE
fix(core): set the correct initial theme in client entry

### DIFF
--- a/.changeset/moody-cats-tap.md
+++ b/.changeset/moody-cats-tap.md
@@ -1,0 +1,6 @@
+---
+'@rspress/theme-default': patch
+'@rspress/core': patch
+---
+
+fix: set the correct initial theme in entry

--- a/packages/core/src/runtime/clientEntry.tsx
+++ b/packages/core/src/runtime/clientEntry.tsx
@@ -7,6 +7,7 @@ import {
   normalizeRoutePath,
   BrowserRouter,
 } from '@rspress/runtime';
+import { isDarkMode } from '@theme';
 import { App, initPageData } from './App';
 
 const enableSSG = siteData.ssg;
@@ -22,7 +23,10 @@ export async function renderInBrowser() {
     );
     return function RootApp() {
       const [data, setData] = useState(initialPageData);
-      const [theme, setTheme] = useState<'light' | 'dark'>('light');
+      const [theme, setTheme] = useState<'light' | 'dark'>(
+        // set the initial theme
+        isDarkMode() ? 'dark' : 'light',
+      );
       return (
         <ThemeContext.Provider value={{ theme, setTheme }}>
           <DataContext.Provider value={{ data, setData }}>

--- a/packages/core/src/runtime/ssrEntry.tsx
+++ b/packages/core/src/runtime/ssrEntry.tsx
@@ -11,7 +11,6 @@ export async function render(
   helmetContext: object,
 ): Promise<{ appHtml: string; pageData: PageData }> {
   const initialPageData = await initPageData(pagePath);
-
   const appHtml = renderToString(
     <ThemeContext.Provider value={{ theme: DEFAULT_THEME }}>
       <DataContext.Provider value={{ data: initialPageData }}>

--- a/packages/theme-default/src/components/Nav/NavBarTitle.tsx
+++ b/packages/theme-default/src/components/Nav/NavBarTitle.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useMemo } from 'react';
 import {
   ThemeContext,
   normalizeImagePath,
@@ -6,7 +6,7 @@ import {
   withBase,
 } from '@rspress/runtime';
 import styles from './index.module.scss';
-import { getLogoUrl, useLocaleSiteData } from '../../logic';
+import { useLocaleSiteData } from '../../logic';
 
 export const NavBarTitle = () => {
   const { siteData } = usePageData();
@@ -14,10 +14,16 @@ export const NavBarTitle = () => {
   const { logo: rawLogo } = siteData;
   const title = localeData.title ?? siteData.title;
   const { theme } = useContext(ThemeContext);
-  const [logo, setLogo] = useState(getLogoUrl(rawLogo, theme));
-
-  useEffect(() => {
-    setLogo(getLogoUrl(rawLogo, theme));
+  const logoUrl = useMemo(() => {
+    let logo;
+    // If logo is a string, use it directly
+    if (typeof rawLogo === 'string') {
+      logo = rawLogo;
+    } else {
+      // If logo is an object, use dark/light mode logo
+      logo = theme === 'dark' ? rawLogo.dark : rawLogo.light;
+    }
+    return normalizeImagePath(logo);
   }, [theme]);
 
   return (
@@ -26,9 +32,9 @@ export const NavBarTitle = () => {
         href={withBase(localeData.langRoutePrefix || '/')}
         className="flex items-center w-full h-full text-base font-semibold transition-opacity duration-300 hover:opacity-60"
       >
-        {logo ? (
+        {logoUrl ? (
           <img
-            src={normalizeImagePath(logo)}
+            src={logoUrl}
             alt="logo"
             id="logo"
             className="mr-4 rspress-logo"

--- a/packages/theme-default/src/components/SwitchAppearance/index.tsx
+++ b/packages/theme-default/src/components/SwitchAppearance/index.tsx
@@ -22,6 +22,7 @@ export function SwitchAppearance({ onClick }: { onClick?: () => void }) {
       setTheme('dark');
     }
     if (typeof window !== 'undefined') {
+      // Keep theme same when multiple pages are open and switch appearance in one page.
       window.addEventListener('storage', updateAppearanceAndTheme);
     }
     return () => {

--- a/packages/theme-default/src/logic/index.ts
+++ b/packages/theme-default/src/logic/index.ts
@@ -7,4 +7,5 @@ export { setup, bindingAsideScroll, scrollToTarget } from './sideEffects';
 export { usePathUtils } from './usePathUtils';
 export { useFullTextSearch } from './useFullTextSearch';
 export { useRedirect4FirstVisit } from './useRedirect4FirstVisit';
+export { isDarkMode } from './useAppearance'
 export * from './utils';


### PR DESCRIPTION
## Summary
When refreshing the page in dark mode, the logo and the icon to switch between light and dark themes will first display in light mode, and then display in dark mode after a while.

I found that the initial theme is not correct, so it will be changed. 
By the way, remove the effect to update theme in switchAppearance.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
