### PR TITLE
feat: improve bg opacity of container blocks

### DIFF
--- a/.changeset/serious-boxes-tickle.md
+++ b/.changeset/serious-boxes-tickle.md
@@ -1,0 +1,5 @@
+---
+"@rspress/plugin-container-syntax": patch
+---
+
+docs: improve bg opacity of container blocks

--- a/.changeset/serious-boxes-tickle.md
+++ b/.changeset/serious-boxes-tickle.md
@@ -2,4 +2,4 @@
 "@rspress/plugin-container-syntax": patch
 ---
 
-docs: improve bg opacity of container blocks
+feat: improve bg opacity of container blocks

--- a/packages/plugin-container-syntax/container.css
+++ b/packages/plugin-container-syntax/container.css
@@ -4,7 +4,7 @@
 :root {
   --rp-container-info-border: rgba(7, 156, 112, 0.3);
   --rp-container-info-text: #399c70;
-  --rp-container-info-bg: rgba(7, 156, 112, 0.1);
+  --rp-container-info-bg: rgba(7, 156, 112, 0.06);
   --rp-container-info-code-bg: rgba(7, 156, 112, 0.1);
 
   --rp-container-warning-border: rgba(255, 197, 23, 0.5);
@@ -12,9 +12,9 @@
   --rp-container-warning-bg: rgba(255, 197, 23, 0.1);
   --rp-container-warning-code-bg: rgba(255, 197, 23, 0.1);
 
-  --rp-container-danger-border: rgba(237, 60, 80, 0.5);
+  --rp-container-danger-border: rgba(237, 60, 80, 0.3);
   --rp-container-danger-text: #ab2131;
-  --rp-container-danger-bg: rgba(237, 60, 80, 0.2);
+  --rp-container-danger-bg: rgba(237, 60, 80, 0.08);
   --rp-container-danger-code-bg: rgba(237, 60, 80, 0.1);
 
   --rp-container-details-border: rgba(128, 128, 128, 0.3);
@@ -25,17 +25,17 @@
 
 .dark {
   --rp-container-info-text: var(--rp-text-1);
-  --rp-container-info-bg: rgba(7, 156, 112, 0.2);
+  --rp-container-info-bg: rgba(7, 156, 112, 0.1);
 
   --rp-container-details-text: var(--rp-text-1);
-  --rp-container-details-bg: rgba(128, 128, 128, 0.2);
+  --rp-container-details-bg: rgba(128, 128, 128, 0.16);
 
   --rp-container-warning-border: rgba(255, 197, 23, 0.25);
-  --rp-container-warning-bg: rgba(255, 197, 23, 0.2);
+  --rp-container-warning-bg: rgba(255, 197, 23, 0.12);
   --rp-container-warning-text: var(--rp-text-1);
 
   --rp-container-danger-border: rgba(237, 60, 80, 0.3);
-  --rp-container-danger-bg: rgba(237, 60, 80, 0.3);
+  --rp-container-danger-bg: rgba(237, 60, 80, 0.12);
   --rp-container-danger-text: var(--rp-text-1);
 }
 


### PR DESCRIPTION
## Summary

Improve bg opacity of container blocks, make the transparency more consistent and moderate.


- light

<img width="1434" alt="Screenshot 2024-03-22 at 11 25 07" src="https://github.com/web-infra-dev/rspress/assets/7237365/be41e25b-0a7b-4269-8fcb-000e475f56f0">


- dark

<img width="1425" alt="Screenshot 2024-03-22 at 11 24 47" src="https://github.com/web-infra-dev/rspress/assets/7237365/d2fdb0d6-5f37-498b-91fc-a565f4f2558a">


## Related Issue

- https://github.com/web-infra-dev/rspress/commit/7b6eea0472f84c8338341d38a6d8a597b3fd3af2
- https://github.com/web-infra-dev/rspress/pull/699

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
