### PR TITLE
fix(theme-default): fix the capitalization issue of X in socialLinks presetIcons

### DIFF
--- a/.changeset/hot-falcons-smoke.md
+++ b/.changeset/hot-falcons-smoke.md
@@ -1,0 +1,5 @@
+---
+"@rspress/theme-default": patch
+---
+
+Fix the capitalization issue of X in socialLinks presetIcons

--- a/packages/theme-default/src/components/SocialLinks/presetIcons.tsx
+++ b/packages/theme-default/src/components/SocialLinks/presetIcons.tsx
@@ -233,7 +233,7 @@ export default {
       />
     </svg>
   ),
-  x: (
+  X: (
     <svg
       role="img"
       viewBox="0 0 24 24"


### PR DESCRIPTION
## Summary

Fix the capitalization issue of X in socialLinks presetIcons

## Related Issue

No Issue

## Checklist

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
