### PR TITLE
fix(doc): fix logo sidebar cannot be used properly.

### DIFF
--- a/.changeset/metal-papayas-live.md
+++ b/.changeset/metal-papayas-live.md
@@ -1,0 +1,5 @@
+---
+"@rspress/docs": patch
+---
+
+fix(doc): fix logo sidebar cannot be used properly.

--- a/packages/document/docs/en/api/config/config-basic.mdx
+++ b/packages/document/docs/en/api/config/config-basic.mdx
@@ -86,7 +86,7 @@ export default defineConfig({
 
 The framework will find your icon in the `public` directory, of course you can also set it to a CDN address.
 
-## logo
+## logo \{#logo-1}
 
 - Type: `string | { dark: string; light: string }`
 - Default: `""`

--- a/packages/document/docs/zh/api/config/config-basic.mdx
+++ b/packages/document/docs/zh/api/config/config-basic.mdx
@@ -86,7 +86,7 @@ export default defineConfig({
 
 框架会在 `public` 目录中找到你的图标，当然你也可以设置成一个 CDN 地址。
 
-## logo
+## logo \{#logo-1}
 
 - Type: `string | { dark: string; light: string }`
 - Default: `""`


### PR DESCRIPTION
## Summary
The website's logo icon has a logo id, which will cause `const target=document.getElementById(header.id);` get wrong dom. So, I set the custom id (`## logo \{#logo-1}`) for logo sidebar. 

## Related Issue

Close #853

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
