### PR TITLE
chore(workflow): let renovate bump package.json

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,6 +35,8 @@
     // manually updating
     "typescript",
     // align Node.js version minimum requirements
-    "@types/node"
+    "@types/node",
+    "node",
+    "pnpm"
   ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,11 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", "schedule:weekly"],
   "packageRules": [
     // Use chore as semantic commit type for commit messages
     {
       "matchPackagePatterns": ["*"],
-      "semanticCommitType": "chore"
+      "semanticCommitType": "chore",
+      // always bump package.json
+      "rangeStrategy": "bump"
     },
     {
       "groupName": "rsbuild",


### PR DESCRIPTION
## Summary

Let renovate bump package.json instead of update lockfile, and trigger updates weekly.

## Related Links

https://docs.renovatebot.com/configuration-options/#rangestrategy