### PR TITLE
fix(core): replace flattened mdx content by rules

### DIFF
--- a/.changeset/chilly-pumpkins-remember.md
+++ b/.changeset/chilly-pumpkins-remember.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+fix(core): replace flattened mdx content by rules

--- a/e2e/fixtures/basic/doc/content.mdx
+++ b/e2e/fixtures/basic/doc/content.mdx
@@ -1,0 +1,1 @@
+## content

--- a/e2e/fixtures/basic/doc/index.mdx
+++ b/e2e/fixtures/basic/doc/index.mdx
@@ -5,3 +5,7 @@
 This is a TIP.
 
 :::
+
+import Content from './content.mdx';
+
+<Content />

--- a/e2e/fixtures/basic/rspress.config.ts
+++ b/e2e/fixtures/basic/rspress.config.ts
@@ -3,4 +3,10 @@ import { defineConfig } from 'rspress/config';
 
 export default defineConfig({
   root: path.join(__dirname, 'doc'),
+  replaceRules: [
+    {
+      search: /content/g,
+      replace: 'h2',
+    },
+  ],
 });

--- a/e2e/tests/basic.test.ts
+++ b/e2e/tests/basic.test.ts
@@ -23,7 +23,7 @@ test.describe('basic test', async () => {
     await page.goto(`http://localhost:${appPort}`);
     const h1 = await page.$('h1');
     const text = await page.evaluate(h1 => h1?.textContent, h1);
-    await expect(text).toContain('Hello World');
+    expect(text).toContain('Hello World');
     // expect the .header-anchor to be rendered and take the correct href
     const headerAnchor = await page.$('.header-anchor');
     const href = await page.evaluate(
@@ -31,6 +31,9 @@ test.describe('basic test', async () => {
       headerAnchor,
     );
     expect(href).toBe('#hello-world');
+    const h2 = await page.$('h2');
+    const content = await page.evaluate(h2 => h2?.textContent, h2);
+    expect(content).toContain('h2')
   });
 
   test('Guide page', async ({ page }) => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -93,7 +93,6 @@
     "remark-rehype": "^10.1.0",
     "rspack-plugin-virtual-module": "0.1.12",
     "source-map": "0.7.4",
-    "string-replace-loader": "^3.1.0",
     "unified": "^10.1.2",
     "unist-util-visit": "^4.1.1",
     "unist-util-visit-children": "^2.0.1",

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -189,12 +189,7 @@ async function createInternalBuildConfig(
             routeService,
             pluginDriver,
           })
-          .end()
-          .use('string-replace-loader')
-          .loader(require.resolve('string-replace-loader'))
-          .options({
-            multiple: config?.replaceRules || [],
-          });
+          .end();
 
         if (chain.plugins.has(CHAIN_ID.PLUGIN.REACT_FAST_REFRESH)) {
           chain.plugin(CHAIN_ID.PLUGIN.REACT_FAST_REFRESH).tap(options => {

--- a/packages/core/src/node/mdx/loader.ts
+++ b/packages/core/src/node/mdx/loader.ts
@@ -11,6 +11,7 @@ import {
   normalizePath,
   escapeMarkdownHeadingIds,
   flattenMdxContent,
+  applyReplaceRules,
 } from '../utils';
 import { PluginDriver } from '../PluginDriver';
 import { TEMP_DIR } from '../constants';
@@ -111,8 +112,10 @@ export default async function mdxLoader(
     filepath,
     alias as Record<string, string>,
   );
+  // replace content
+  const replacedContent = applyReplaceRules(flattenContent, config.replaceRules);
   // preprocessor
-  const preprocessedContent = escapeMarkdownHeadingIds(flattenContent);
+  const preprocessedContent = escapeMarkdownHeadingIds(replacedContent);
 
   deps.forEach(dep => context.addDependency(dep));
 

--- a/packages/theme-default/package.json
+++ b/packages/theme-default/package.json
@@ -63,7 +63,6 @@
     "react-helmet-async": "^1.3.0",
     "react-syntax-highlighter": "^15.5.0",
     "rspack-plugin-virtual-module": "0.1.12",
-    "string-replace-loader": "^3.1.0",
     "react-transition-group": "4.4.5"
   },
   "devDependencies": {
@@ -96,10 +95,7 @@
     "virtual-global-styles",
     "./src/styles/index.ts"
   ],
-  "files": [
-    "dist",
-    "src"
-  ],
+  "files": ["dist", "src"],
   "publishConfig": {
     "access": "public",
     "provenance": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -439,9 +439,6 @@ importers:
       source-map:
         specifier: 0.7.4
         version: 0.7.4
-      string-replace-loader:
-        specifier: ^3.1.0
-        version: 3.1.0(webpack@5.88.2)
       unified:
         specifier: ^10.1.2
         version: 10.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1171,9 +1171,6 @@ importers:
       rspack-plugin-virtual-module:
         specifier: 0.1.12
         version: 0.1.12
-      string-replace-loader:
-        specifier: ^3.1.0
-        version: 3.1.0(webpack@5.88.2)
     devDependencies:
       '@modern-js/plugin-tailwindcss':
         specifier: 2.48.3
@@ -5090,10 +5087,6 @@ packages:
       is-windows: 1.0.2
     dev: true
 
-  /big.js@5.2.2:
-    resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
-    dev: false
-
   /binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
@@ -5887,11 +5880,6 @@ packages:
 
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-
-  /emojis-list@3.0.0:
-    resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
-    engines: {node: '>= 4'}
-    dev: false
 
   /end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
@@ -7736,15 +7724,6 @@ packages:
   /loader-runner@4.3.0:
     resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
     engines: {node: '>=6.11.5'}
-
-  /loader-utils@2.0.4:
-    resolution: {integrity: sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==}
-    engines: {node: '>=8.9.0'}
-    dependencies:
-      big.js: 5.2.2
-      emojis-list: 3.0.0
-      json5: 2.2.3
-    dev: false
 
   /loader-utils@3.2.1:
     resolution: {integrity: sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==}
@@ -10790,16 +10769,6 @@ packages:
   /string-hash@1.1.3:
     resolution: {integrity: sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==}
     dev: true
-
-  /string-replace-loader@3.1.0(webpack@5.88.2):
-    resolution: {integrity: sha512-5AOMUZeX5HE/ylKDnEa/KKBqvlnFmRZudSOjVJHxhoJg9QYTwl1rECx7SLR8BBH7tfxb4Rp7EM2XVfQFxIhsbQ==}
-    peerDependencies:
-      webpack: ^5
-    dependencies:
-      loader-utils: 2.0.4
-      schema-utils: 3.3.0
-      webpack: 5.88.2
-    dev: false
 
   /string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}


### PR DESCRIPTION
## Summary
In #640 , we will flatten mdx content in mdx loader, and then replace-string-loader failed.
So removed it and replace in mdx loader.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
