### PR TITLE
fix(api-docgen): allow multiple lines description

### DIFF
--- a/.changeset/pink-knives-compare.md
+++ b/.changeset/pink-knives-compare.md
@@ -1,0 +1,5 @@
+---
+"@rspress/plugin-api-docgen": patch
+---
+
+fix(api-docgen): allow multiple lines description

--- a/e2e/fixtures/api-docgen/src/Button.ts
+++ b/e2e/fixtures/api-docgen/src/Button.ts
@@ -1,6 +1,8 @@
 export type ButtonProps = {
   /**
    * Whether to disable the button
+   * - This is extra line a
+   * - This is extra line b
    */
   disabled?: boolean;
   /**

--- a/e2e/tests/api-docgen.test.ts
+++ b/e2e/tests/api-docgen.test.ts
@@ -33,6 +33,8 @@ test.describe('api-docgen test', async () => {
     // Description
     expect(tableContent).toContain('Description');
     expect(tableContent).toContain('Whether to disable the button');
+    expect(tableContent).toContain('- This is extra line a');
+    expect(tableContent).toContain('- This is extra line b');
     expect(tableContent).toContain('Type of Button');
 
     // Type

--- a/packages/plugin-api-docgen/src/docgen.ts
+++ b/packages/plugin-api-docgen/src/docgen.ts
@@ -196,7 +196,12 @@ function generateTable(componentDoc: ComponentDoc[], language: 'zh' | 'en') {
                 return description;
             }
           };
-          return `|${[name, getDescription(), getType(), getDefaultValue()]
+
+          const formattedDescription = getDescription()
+            // allow newline
+            .replace(/\n/g, '&#10;');
+
+          return `|${[name, formattedDescription, getType(), getDefaultValue()]
             .map(str => str.replace(/(?<!\\)\|/g, '&#124;'))
             .join('|')}|`;
         });

--- a/packages/plugin-api-docgen/static/global-components/API.scss
+++ b/packages/plugin-api-docgen/static/global-components/API.scss
@@ -1,4 +1,9 @@
 table {
   table-layout: fixed;
   width: 100%;
+
+  td {
+    // allow use &#10; to break line
+    white-space: pre-wrap;
+  }
 }


### PR DESCRIPTION
## Summary

Allow multiple lines description in the api-docgen plugin.

- input:

![image](https://github.com/web-infra-dev/rspress/assets/7237365/089343e2-505d-4a62-b887-b32587d5397a)

- before:

<img width="685" alt="Screenshot 2024-03-25 at 20 03 46" src="https://github.com/web-infra-dev/rspress/assets/7237365/7b57d2af-f65e-4b34-86c1-333c8a126d5d">

- after:

<img width="669" alt="Screenshot 2024-03-25 at 20 03 22" src="https://github.com/web-infra-dev/rspress/assets/7237365/265e867e-7c82-4a41-9235-910c4218e5f2">


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
