### PR TITLE
feat: add `localeRedirect` option to theme config

### DIFF
--- a/.changeset/real-beans-cheer.md
+++ b/.changeset/real-beans-cheer.md
@@ -1,0 +1,7 @@
+---
+'@rspress/theme-default': minor
+'@rspress/docs': minor
+'@rspress/shared': minor
+---
+
+feat: add `localeRedirect` option to theme config

--- a/packages/document/docs/en/api/config/config-theme.mdx
+++ b/packages/document/docs/en/api/config/config-theme.mdx
@@ -574,3 +574,20 @@ export default defineConfig({
   },
 });
 ```
+
+## localeRedirect
+
+- Type: `'auto' | 'never'`
+- Default: `'auto'`
+
+Whether to redirect to the closest locale when the user visits the site, the default is `auto`, which means that the user will be redirected on the first visit. If you set it to `never`, the user will not be redirected. For example:
+
+```ts title="rspress.config.ts"
+import { defineConfig } from 'rspress/config';
+
+export default defineConfig({
+  themeConfig: {
+    localeRedirect: 'never',
+  },
+});
+```

--- a/packages/document/docs/en/api/config/config-theme.mdx
+++ b/packages/document/docs/en/api/config/config-theme.mdx
@@ -580,7 +580,7 @@ export default defineConfig({
 - Type: `'auto' | 'never'`
 - Default: `'auto'`
 
-Whether to redirect to the closest locale when the user visits the site, the default is `auto`, which means that the user will be redirected on the first visit. If you set it to `never`, the user will not be redirected. For example:
+Whether to redirect to the locale closest to `window.navigator.language` when the user visits the site, the default is `auto`, which means that the user will be redirected on the first visit. If you set it to `never`, the user will not be redirected. For example:
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';

--- a/packages/document/docs/zh/api/config/config-theme.mdx
+++ b/packages/document/docs/zh/api/config/config-theme.mdx
@@ -564,7 +564,7 @@ export default defineConfig({
 - Type: `'auto' | 'never'`
 - Default: `'auto'`
 
-是否在访问网站时重定向到最接近 `window.navigator.language` 的语言，默认为 `auto` 表示首次访问时区将重定向，`never` 表示不重定向。比如:
+是否在访问网站时重定向到最接近 `window.navigator.language` 的语言，默认为 `auto` 表示首次访问时将重定向，`never` 表示不重定向。比如:
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';

--- a/packages/document/docs/zh/api/config/config-theme.mdx
+++ b/packages/document/docs/zh/api/config/config-theme.mdx
@@ -564,7 +564,7 @@ export default defineConfig({
 - Type: `'auto' | 'never'`
 - Default: `'auto'`
 
-是否在访问网站时重定向到最接近的语言，默认为 `auto` 表示首次访问时区将重定向，`never` 表示不重定向。比如:
+是否在访问网站时重定向到最接近 `window.navigator.language` 的语言，默认为 `auto` 表示首次访问时区将重定向，`never` 表示不重定向。比如:
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';

--- a/packages/document/docs/zh/api/config/config-theme.mdx
+++ b/packages/document/docs/zh/api/config/config-theme.mdx
@@ -559,3 +559,19 @@ export default defineConfig({
 });
 ```
 
+## localeRedirect
+
+- Type: `'auto' | 'never'`
+- Default: `'auto'`
+
+是否在访问网站时重定向到最接近的语言，默认为 `auto` 表示首次访问时区将重定向，`never` 表示不重定向。比如:
+
+```ts title="rspress.config.ts"
+import { defineConfig } from 'rspress/config';
+
+export default defineConfig({
+  themeConfig: {
+    localeRedirect: 'never',
+  },
+});
+```

--- a/packages/shared/src/types/defaultTheme.ts
+++ b/packages/shared/src/types/defaultTheme.ts
@@ -94,6 +94,11 @@ export interface Config {
    * @default false
    */
   enableScrollToTop?: boolean;
+  /**
+   * Whether to redirect to the closest locale when the user visits the site
+   * @default 'auto'
+   */
+  localeRedirect?: 'auto' | 'never';
 }
 
 /**
@@ -160,7 +165,12 @@ export type Image = string | { src: string; alt?: string };
 
 // sidebar -------------------------------------------------------------------
 export interface Sidebar {
-  [path: string]: (SidebarGroup | SidebarItem | SidebarDivider | SidebarSectionHeader)[];
+  [path: string]: (
+    | SidebarGroup
+    | SidebarItem
+    | SidebarDivider
+    | SidebarSectionHeader
+  )[];
 }
 
 export interface SidebarGroup {

--- a/packages/theme-default/src/logic/useRedirect4FirstVisit.ts
+++ b/packages/theme-default/src/logic/useRedirect4FirstVisit.ts
@@ -11,6 +11,10 @@ export function useRedirect4FirstVisit() {
   const langs = localeLanguages.map(item => item.lang) || [];
   const currentLang = page.lang;
   useEffect(() => {
+    const localeRedirect = siteData.themeConfig.localeRedirect ?? 'auto';
+    if (localeRedirect !== 'auto') {
+      return;
+    }
     if (!defaultLang || process.env.TEST === '1') {
       // Check the window.navigator.language to determine the default language
       // If the default language is not the same as the current language, redirect to the default language


### PR DESCRIPTION
## Summary

1. Redirecting is unexpected when sharing the specific locale.
2. It's hard to write a match function for every case, even if there is a guideline (such as https://datatracker.ietf.org/doc/html/rfc4647#section-3.4), locale codes may be too complex.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
