### PR TITLE
chore(workflow): add GitHub release yaml config

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    authors:
+      # Ignore the release PR created by github-actions
+      - github-actions
+  categories:
+    - title: Breaking Changes 🍭
+      labels:
+        - "change: breaking"
+    - title: New Features 🎉
+      labels:
+        - "change: feat"
+    - title: Performance 🚀
+      labels:
+        - "change: perf"
+    - title: Bug Fixes 🐞
+      labels:
+        - "change: fix"
+    - title: Document 📖
+      labels:
+        - "change: docs"
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
## Summary

Add GitHub release yaml config to use GitHub release note generator.

![image](https://github.com/web-infra-dev/rspress/assets/7237365/7d89ea8f-3988-4992-b898-e868a3f5a584)


The same as https://github.com/web-infra-dev/rsbuild/blob/main/.github/release.yml

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
