### PR TITLE
fix(core): set ssg:false in plugin not work in build mode

### DIFF
--- a/.changeset/swift-needles-tickle.md
+++ b/.changeset/swift-needles-tickle.md
@@ -1,0 +1,5 @@
+---
+"@rspress/core": patch
+---
+
+fix(core): set ssg:false in plugin not work in build mode

--- a/packages/core/src/node/build.ts
+++ b/packages/core/src/node/build.ts
@@ -228,10 +228,10 @@ export async function renderPages(
 export async function build(options: BuildOptions) {
   const { docDirectory, appDirectory, config } = options;
   const pluginDriver = new PluginDriver(config, true);
-  const enableSSG = config.ssg ?? true;
   await pluginDriver.init();
   const modifiedConfig = await pluginDriver.modifyConfig();
   await pluginDriver.beforeBuild();
+  const enableSSG = modifiedConfig.ssg ?? true;
 
   // empty temp dir before build
   await fs.emptyDir(TEMP_DIR);


### PR DESCRIPTION
## Summary


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
