### PR TITLE
feat: respond to the change of system theme appearance

### DIFF
--- a/.changeset/perfect-islands-shave.md
+++ b/.changeset/perfect-islands-shave.md
@@ -1,0 +1,6 @@
+---
+'@rspress/theme-default': minor
+'@rspress/core': minor
+---
+
+feat: respond to the change of system theme appearance

--- a/packages/core/src/runtime/clientEntry.tsx
+++ b/packages/core/src/runtime/clientEntry.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { isProduction } from '@rspress/shared';
 import siteData from 'virtual-site-data';
 import {
@@ -12,7 +12,7 @@ import { App, initPageData } from './App';
 const enableSSG = siteData.ssg;
 
 // eslint-disable-next-line import/no-commonjs
-const { default: Theme } = require('@theme');
+const { default: Theme, useThemeState } = require('@theme');
 
 export async function renderInBrowser() {
   const container = document.getElementById('root')!;
@@ -23,10 +23,14 @@ export async function renderInBrowser() {
     );
     return function RootApp() {
       const [data, setData] = useState(initialPageData);
-      const [theme, setTheme] = useState<'light' | 'dark'>('light');
+      const [theme, setTheme] = useThemeState();
       return (
-        <ThemeContext.Provider value={{ theme, setTheme }}>
-          <DataContext.Provider value={{ data, setData }}>
+        <ThemeContext.Provider
+          value={useMemo(() => ({ theme, setTheme }), [theme, setTheme])}
+        >
+          <DataContext.Provider
+            value={useMemo(() => ({ data, setData }), [data, setData])}
+          >
             <BrowserRouter>
               <App />
             </BrowserRouter>

--- a/packages/theme-default/src/components/SwitchAppearance/index.tsx
+++ b/packages/theme-default/src/components/SwitchAppearance/index.tsx
@@ -1,41 +1,16 @@
-import { useContext, useEffect, useState } from 'react';
+import { useContext } from 'react';
 import { ThemeContext } from '@rspress/runtime';
 import SunSvg from '@theme-assets/sun';
 import MoonSvg from '@theme-assets/moon';
-import {
-  getToggle,
-  isDarkMode,
-  updateUserPreferenceFromStorage,
-} from '../../logic/useAppearance';
 import { SvgWrapper } from '../SvgWrapper';
 
 export function SwitchAppearance({ onClick }: { onClick?: () => void }) {
   const { theme, setTheme } = useContext(ThemeContext);
-  const toggleAppearance = getToggle();
-  const updateAppearanceAndTheme = () => {
-    const isDark = updateUserPreferenceFromStorage();
-    setTheme(isDark ? 'dark' : 'light');
-  };
-
-  useEffect(() => {
-    if (isDarkMode()) {
-      setTheme('dark');
-    }
-    if (typeof window !== 'undefined') {
-      window.addEventListener('storage', updateAppearanceAndTheme);
-    }
-    return () => {
-      if (typeof window !== 'undefined') {
-        window.removeEventListener('storage', updateAppearanceAndTheme);
-      }
-    };
-  }, []);
 
   return (
     <div
       onClick={() => {
         setTheme(theme === 'dark' ? 'light' : 'dark');
-        toggleAppearance();
         onClick?.();
       }}
       className="md:mr-2 rspress-nav-appearance"

--- a/packages/theme-default/src/logic/index.ts
+++ b/packages/theme-default/src/logic/index.ts
@@ -7,4 +7,5 @@ export { setup, bindingAsideScroll, scrollToTarget } from './sideEffects';
 export { usePathUtils } from './usePathUtils';
 export { useFullTextSearch } from './useFullTextSearch';
 export { useRedirect4FirstVisit } from './useRedirect4FirstVisit';
+export { useThemeState } from './useAppearance';
 export * from './utils';

--- a/packages/theme-default/src/logic/useHandler.ts
+++ b/packages/theme-default/src/logic/useHandler.ts
@@ -1,0 +1,10 @@
+import { useRef } from 'react';
+
+/**
+ * Create a memoized handler function with stable reference
+ */
+export const useHandler = <T extends (...args: any[]) => any>(handler: T) => {
+  const handlerRef = useRef<T>(handler);
+  handlerRef.current = handler;
+  return useRef(((...args: any[]) => handlerRef.current(...args)) as T).current;
+};

--- a/packages/theme-default/src/logic/useMediaQuery.ts
+++ b/packages/theme-default/src/logic/useMediaQuery.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Wrapper of CSS Media Query API
+ */
+export const useMediaQuery = (query: string) => {
+  const [matches, setMatches] = useState(() => {
+    return typeof window !== 'undefined'
+      ? window.matchMedia(query).matches
+      : false;
+  });
+
+  useEffect(() => {
+    const mediaQueryList = window.matchMedia(query);
+    const listener = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mediaQueryList.addEventListener('change', listener);
+    return () => mediaQueryList.removeEventListener('change', listener);
+  }, [query]);
+
+  return matches;
+};

--- a/packages/theme-default/src/logic/useStorageValue.ts
+++ b/packages/theme-default/src/logic/useStorageValue.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * Read/update the value in localStorage, and keeping it in sync with other tabs.
+ */
+export const useStorageValue = (key: string, defaultValue = null) => {
+  const [value, setValueInternal] = useState(() => {
+    if (typeof window === 'undefined') {
+      return defaultValue;
+    }
+    return localStorage.getItem(key) ?? defaultValue;
+  });
+
+  const setValue = useCallback(
+    value => {
+      setValueInternal(prev => {
+        const next = typeof value === 'function' ? value(prev) : value;
+        if (next == null) {
+          localStorage.removeItem(key);
+        } else {
+          localStorage.setItem(key, next);
+        }
+        return next;
+      });
+    },
+    [key],
+  );
+
+  useEffect(() => {
+    const listener = (e: StorageEvent) => {
+      if (e.key === key) {
+        setValueInternal(localStorage.getItem(key) ?? defaultValue);
+      }
+    };
+    window.addEventListener('storage', listener);
+    return () => {
+      window.removeEventListener('storage', listener);
+    };
+  }, [key, defaultValue]);
+
+  return [value, setValue] as const;
+};


### PR DESCRIPTION
## Summary

Splits:
- #878 also add `color-scheme` on root element, this is useful for theme styling based on native CSS media queries or `light-dark()` function, third-party libraries and creators may use this feature
- #879 

In this PR,  all the appearance related codes are refactored to a single React Hook, the checklist:

- [x] Should respond to system preference change (light/dark/auto)
- [x] Should respond to local storage change (every tab should be in sync)
- [x] Should be in sync with Media Query (prefers-color-scheme)
- [x] Should not flash in dev/prod mode
- [x] Should not break the usage of `window.RSPRESS_THEME`, however, the use of global variables is flawed, see comments beblow [#issuecomment-2027006896](#issuecomment-2027006896)

After these are done, we can use two patterns to display elements without flash:

```html
<!-- double element trick by class hook of Tailwind -->
<MyComponent className="dark:hidden" />
<MyComponent className="hidden dark:block" />

<!-- native CSS media query (image/video only) -->
<picture>
  <source srcset="dark.svg" media="(prefers-color-scheme: dark)" />
  <source srcset="light.svg" media="(prefers-color-scheme: light)" />
  <img src="light.svg" />
</picture>
```



## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
