### PR TITLE
fix(plugin-playground): manually load babel.min.js to avoid conflict with monaco

### DIFF
--- a/.changeset/thin-ads-serve.md
+++ b/.changeset/thin-ads-serve.md
@@ -1,0 +1,5 @@
+---
+"@rspress/plugin-playground": patch
+---
+
+fix(plugin-playground): manually load babel.min.js to avoid conflict with monaco

--- a/packages/plugin-playground/src/cli/index.ts
+++ b/packages/plugin-playground/src/cli/index.ts
@@ -44,7 +44,7 @@ export function pluginPlayground(
     include,
     defaultDirection = 'horizontal',
     editorPosition = 'left',
-    babelUrl = '',
+    babelUrl = DEFAULT_BABEL_URL,
     monacoLoader = {},
     monacoOptions = {},
     defaultRenderMode = 'playground',
@@ -208,30 +208,20 @@ export function pluginPlayground(
           __PLAYGROUND_DIRECTION__: JSON.stringify(defaultDirection),
           __PLAYGROUND_MONACO_LOADER__: JSON.stringify(monacoLoader),
           __PLAYGROUND_MONACO_OPTIONS__: JSON.stringify(monacoOptions),
+          __PLAYGROUND_BABEL_URL__: JSON.stringify(babelUrl),
         },
         include: [join(__dirname, '..', '..', '..')],
       },
       html: {
-        tags: [
-          ...preloads.map(url => ({
-            tag: 'link',
-            head: true,
-            attrs: {
-              rel: 'preload',
-              href: url,
-              as: 'script',
-            },
-          })),
-          {
-            tag: 'script',
-            head: true,
-            attrs: {
-              id: 'rspress-playground-babel',
-              async: true,
-              src: babelUrl || DEFAULT_BABEL_URL,
-            },
+        tags: preloads.map(url => ({
+          tag: 'link',
+          head: true,
+          attrs: {
+            rel: 'preload',
+            href: url,
+            as: 'script',
           },
-        ],
+        })),
       },
       tools: {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error

--- a/packages/plugin-playground/src/web/babel.ts
+++ b/packages/plugin-playground/src/web/babel.ts
@@ -6,21 +6,52 @@ declare global {
   interface Window {
     Babel: Babel;
   }
+  const __PLAYGROUND_BABEL_URL__: string;
 }
 
-function getBabel(): Babel | Promise<Babel> {
+// see https://github.com/web-infra-dev/rspress/issues/876
+async function loadUmdBabelModule(): Promise<Babel> {
+  const data = await fetch(__PLAYGROUND_BABEL_URL__);
+
+  const umdSourceCode = await data.text();
+
+  const run = new Function(
+    'exports',
+    'module',
+    'require',
+    'globalThis',
+    `with(exports, module, require, globalThis) {return ${umdSourceCode}}`,
+  );
+
+  const exports: Babel = { version: undefined } as unknown as Babel;
+  const module = { exports };
+  const global: any = {};
+  const require = (key: string) => {};
+
+  run(exports, module, require, global);
+
+  return exports;
+}
+
+let loadBabelPromise: null | Promise<Babel> = null;
+
+async function getBabel(): Promise<Babel> {
   if (window.Babel) {
     return window.Babel;
   }
-  const el = document.getElementById('rspress-playground-babel');
-  if (!el) {
-    throw new Error('Babel not found');
+  if (loadBabelPromise) {
+    return loadBabelPromise;
   }
-  return new Promise(resolve => {
-    el.addEventListener('load', () => {
-      resolve(window.Babel);
-    });
-  });
+
+  loadBabelPromise = loadUmdBabelModule();
+  try {
+    const Babel = await loadBabelPromise;
+    window.Babel = Babel;
+    return Babel;
+  } catch (e) {
+    loadBabelPromise = null;
+    throw e;
+  }
 }
 
 export { getBabel };


### PR DESCRIPTION
## Summary

## Related Issue

closes  #876
<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have added tests to cover my changes.
