### PR TITLE
Fix/848 Exclude config.route.exclude files from auto-generated sidebar

### DIFF
--- a/.changeset/little-pumpkins-fly.md
+++ b/.changeset/little-pumpkins-fly.md
@@ -1,0 +1,5 @@
+---
+"@rspress/plugin-auto-nav-sidebar": minor
+---
+
+Exclude config.route.exclude files from auto-generated sidebar

--- a/.changeset/serious-clouds-tap.md
+++ b/.changeset/serious-clouds-tap.md
@@ -1,5 +1,6 @@
 ---
-"@rspress/plugin-auto-nav-sidebar": minor
+"@rspress/plugin-auto-nav-sidebar": patch
+"@rspress/docs": patch
 ---
 
 Exclude config.route.exclude files from auto-generated sidebar

--- a/packages/document/docs/en/guide/basic/auto-nav-sidebar.mdx
+++ b/packages/document/docs/en/guide/basic/auto-nav-sidebar.mdx
@@ -266,7 +266,9 @@ Here is a complete example using the three types above:
 
 ### No Config Usage
 
-In some directories, you don't need to configure `_meta.json` and let the framework automatically generate the sidebar. This requires ensuring that the directory contains only documents, not subdirectories, and you have no requirements for the order of documents. For example, there is now the following document structure:
+In some directories, you don't need to configure `_meta.json` and let the framework automatically generate the sidebar.
+
+For example, there is a document structure:
 
 ```bash
 docs
@@ -293,7 +295,9 @@ In the guides directory you can configure `_meta.json` as follows:
 ]
 ```
 
-In `basic` directory, you may not configure `_meta.json`, and then the framework will automatically generate a sidebar for you, the default is sorted alphabetically according to the file name. If you want to customize the order, you can prefix the file name with a number, such as:
+In `basic` directory, you may not configure `_meta.json`, and then the framework will automatically generate a sidebar for you.
+
+By default files are sorted alphabetically. If you want to customize their orders, you can prefix the file names with a number, such as:
 
 ```bash
 basic
@@ -301,6 +305,8 @@ basic
   ├── 2-install.mdx
   └── 3-plugin-development.md
 ```
+
+> Note : The files defined in [route.exclude](/api/config/config-basic.html#routeexclude) won't appear in the auto-generated sidebar.
 
 ### Add SVG Icons Before Titles
 

--- a/packages/plugin-auto-nav-sidebar/package.json
+++ b/packages/plugin-auto-nav-sidebar/package.json
@@ -57,6 +57,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@rspress/shared": "workspace:*"
+    "@rspress/shared": "workspace:*",
+    "globby": "11.1.0"
   }
 }

--- a/packages/plugin-auto-nav-sidebar/src/index.ts
+++ b/packages/plugin-auto-nav-sidebar/src/index.ts
@@ -157,6 +157,7 @@ function processLocales(
   root: string,
   defaultLang: string,
   defaultVersion: string,
+  excludedFiles?: string[],
 ) {
   return Promise.all(
     langs.map(async lang => {
@@ -168,7 +169,12 @@ function processLocales(
                   lang === defaultLang ? '' : `/${lang}`
                 }`,
               );
-              return walk(path.join(root, version, lang), routePrefix, root);
+              return walk(
+                path.join(root, version, lang),
+                routePrefix,
+                root,
+                excludedFiles,
+              );
             }),
           )
         : [
@@ -176,6 +182,7 @@ function processLocales(
               path.join(root, lang),
               addTrailingSlash(lang === defaultLang ? '' : `/${lang}`),
               root,
+              excludedFiles,
             ),
           ];
       return combineWalkResult(walks, versions);
@@ -203,6 +210,7 @@ export function pluginAutoNavSidebar(): RspressPlugin {
           config.root!,
           defaultLang,
           defaultVersion,
+          config.route?.exclude,
         );
         config.themeConfig.locales = config.themeConfig.locales.map(
           (item, index) => ({
@@ -230,10 +238,18 @@ export function pluginAutoNavSidebar(): RspressPlugin {
                   path.join(config.root!, version),
                   routePrefix,
                   config.root!,
+                  config.route?.exclude,
                 );
               }),
             )
-          : [await walk(config.root!, '/', config.root!)];
+          : [
+              await walk(
+                config.root!,
+                '/',
+                config.root!,
+                config.route?.exclude,
+              ),
+            ];
 
         const combined = combineWalkResult(walks, versions);
 

--- a/packages/plugin-auto-nav-sidebar/src/walk.ts
+++ b/packages/plugin-auto-nav-sidebar/src/walk.ts
@@ -13,7 +13,7 @@ import {
 } from '@rspress/shared';
 import { NavMeta, SideMeta } from './type';
 import { detectFilePath, extractH1Title } from './utils';
-import globby from '../../core/compiled/globby';
+import globby from 'globby';
 
 export async function scanSideMeta(
   workDir: string,
@@ -37,7 +37,6 @@ export async function scanSideMeta(
 
     const includedFiles = globby.sync('**', {
       cwd: workDir,
-      onlyFiles: false,
       ignore: [...excludedFiles],
     });
     const subItems = [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -727,6 +727,9 @@ importers:
       '@rspress/shared':
         specifier: workspace:*
         version: link:../shared
+      globby:
+        specifier: 11.1.0
+        version: link:../core/compiled/globby
     devDependencies:
       '@modern-js/tsconfig':
         specifier: 2.48.4


### PR DESCRIPTION
## Summary

When no `_meta.json` is found, instead of going through all children, use `globby` to exclude files defined in `config.route.exclude`.

## Related Issue

#848 [Bug]: Excluded routes still appear in the no-config sidebars

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I have added changeset via `pnpm run change`.
- [X] I have updated the documentation.
- [ ] I have added tests to cover my changes.
