### PR TITLE
fix: invalid exports.types field

### DIFF
--- a/packages/plugin-rss/package.json
+++ b/packages/plugin-rss/package.json
@@ -15,8 +15,8 @@
   "module": "./dist/index.mjs",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
       "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
       "default": "./dist/index.cjs"
     },
     "./FeedsAnnotations": "./static/global-components/FeedsAnnotations"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,34 +11,34 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./execa": {
+      "types": "./dist/execa.d.ts",
       "import": "./dist/execa.mjs",
-      "require": "./dist/execa.js",
-      "types": "./dist/execa.d.ts"
+      "require": "./dist/execa.js"
     },
     "./chalk": {
+      "types": "./dist/chalk.d.ts",
       "import": "./dist/chalk.mjs",
-      "require": "./dist/chalk.js",
-      "types": "./dist/chalk.d.ts"
+      "require": "./dist/chalk.js"
     },
     "./fs-extra": {
+      "types": "./dist/fs-extra.d.ts",
       "import": "./dist/fs-extra.mjs",
-      "require": "./dist/fs-extra.js",
-      "types": "./dist/fs-extra.d.ts"
+      "require": "./dist/fs-extra.js"
     },
     "./logger": {
+      "types": "./dist/logger.d.ts",
       "import": "./dist/logger.mjs",
-      "require": "./dist/logger.js",
-      "types": "./dist/logger.d.ts"
+      "require": "./dist/logger.js"
     },
     "./node-utils": {
+      "types": "./dist/node-utils.d.ts",
       "import": "./dist/node-utils.mjs",
-      "require": "./dist/node-utils.js",
-      "types": "./dist/node-utils.d.ts"
+      "require": "./dist/node-utils.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary

Fix invalid exports.types field in package.json, the `types` should be the first.

<img width="958" alt="截屏2024-04-05 19 53 22" src="https://github.com/web-infra-dev/rspress/assets/7237365/8b8a73e6-c88d-4d14-8a3e-a8e4c2a32e13">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
