### PR TITLE
fix(plugin-rss): invalid link rel type

### DIFF
--- a/e2e/tests/plugin-rss.test.ts
+++ b/e2e/tests/plugin-rss.test.ts
@@ -31,7 +31,7 @@ test.describe('plugin rss test', async () => {
   test('`link-rss` should add rss <link> to this page', async ({ page }) => {
     await page.goto(`${prefix}`, { waitUntil: 'networkidle' });
 
-    const link = page.locator('link[rel="alternative"]', {});
+    const link = page.locator('link[rel="alternate"]', {});
 
     await expect(link.getAttribute('href')).resolves.toBe(
       `${siteUrl}rss/blog.xml`,
@@ -41,7 +41,7 @@ test.describe('plugin rss test', async () => {
   test('should add rss <link> to pages matched', async ({ page }) => {
     await page.goto(`${prefix}blog/foo`, { waitUntil: 'networkidle' });
 
-    const link = page.locator('link[rel="alternative"]', {});
+    const link = page.locator('link[rel="alternate"]', {});
 
     await expect(link.getAttribute('href')).resolves.toBe(
       `${siteUrl}rss/blog.xml`,

--- a/packages/document/docs/en/plugin/official-plugins/rss.mdx
+++ b/packages/document/docs/en/plugin/official-plugins/rss.mdx
@@ -102,7 +102,7 @@ Please refer to the [FeedOutputOptions](#feedoutputoptions) below.
 
 ### Linking RSS to document pages
 
-By default, this plugin will insert a `<link rel="alternative">` tag in the selected pages that are included in the RSS, linking to the URL of the RSS file. RSS readers can automatically detect the RSS URL.
+By default, this plugin will insert a `<link rel="alternate">` tag in the selected pages that are included in the RSS, linking to the URL of the RSS file. RSS readers can automatically detect the RSS URL.
 
 If you want to insert this tag in pages that are not included in the RSS (such as the homepage), you can add the `link-rss` frontmatter to the document, with the value being the feed id. For example:
 
@@ -111,7 +111,7 @@ If you want to insert this tag in pages that are not included in the RSS (such a
 link-rss: blog
 ---
 
-This frontmatter will insert a `<link rel="alternative">` tag in the page of this document, pointing to the RSS URL of the `blog` feed.
+This frontmatter will insert a `<link rel="alternate">` tag in the page of this document, pointing to the RSS URL of the `blog` feed.
 
 However, this page itself will not be included in that RSS.
 ```

--- a/packages/document/docs/zh/plugin/official-plugins/rss.mdx
+++ b/packages/document/docs/zh/plugin/official-plugins/rss.mdx
@@ -102,7 +102,7 @@ pluginRss({
 
 ### 链接 RSS 到文档页面中
 
-默认情况下，该插件会在被选择纳入 RSS 的页面中插入一个 `<link rel="alternative">` 标签，链接到 RSS 文件的 URL。RSS 阅读器能够自动识别到 RSS URL。
+默认情况下，该插件会在被选择纳入 RSS 的页面中插入一个 `<link rel="alternate">` 标签，链接到 RSS 文件的 URL。RSS 阅读器能够自动识别到 RSS URL。
 
 如果你想在没被纳入 RSS 的页面（比如首页）中也插入这个标签，可以在文档中添加 `link-rss` 这个 frontmatter，取值为 feed id。比如
 
@@ -111,7 +111,7 @@ pluginRss({
 link-rss: blog
 ---
 
-这个 frontmatter 会为这个文档的页面中插入 `<link rel="alternative">` 标签指向 blog 的 RSS URL。
+这个 frontmatter 会为这个文档的页面中插入 `<link rel="alternate">` 标签指向 blog 的 RSS URL。
 
 但这个页面自身不会被纳入该 RSS。
 ```

--- a/packages/plugin-rss/static/global-components/FeedsAnnotations.tsx
+++ b/packages/plugin-rss/static/global-components/FeedsAnnotations.tsx
@@ -10,7 +10,7 @@ export default function FeedsAnnotations() {
     <Helmet>
       {feeds.map(({ language, url, mime }) => {
         const props: LinkHTMLAttributes<HTMLLinkElement> = {
-          rel: 'alternative',
+          rel: 'alternate',
           type: mime,
           href: url,
         };


### PR DESCRIPTION
## Summary

`<link rel="alternative">` is invalid, we should use `<link rel="alternate">` 

https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#alternate

## Related Issue

https://github.com/web-infra-dev/rspress/issues/828

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
