### PR TITLE
fix(theme): homepage mask based on logo vertical centering

### DIFF
--- a/.changeset/moody-frogs-end.md
+++ b/.changeset/moody-frogs-end.md
@@ -1,0 +1,5 @@
+---
+"@rspress/theme-default": major
+---
+
+Homepage mask based on logo vertical centering

--- a/.changeset/nasty-carrots-share.md
+++ b/.changeset/nasty-carrots-share.md
@@ -1,5 +1,5 @@
 ---
-"@rspress/theme-default": major
+"@rspress/theme-default": patch
 ---
 
 Homepage mask based on logo vertical centering

--- a/packages/theme-default/src/components/HomeHero/index.module.scss
+++ b/packages/theme-default/src/components/HomeHero/index.module.scss
@@ -20,7 +20,8 @@
   mixblendmode: normal;
   filter: blur(80px);
   opacity: 0.05;
-  top: -100px;
+  top: 50%;
+  margin-top: -250px;
   transform: translateX(-50%);
   z-index: 0;
 }

--- a/packages/theme-default/src/components/HomeHero/index.tsx
+++ b/packages/theme-default/src/components/HomeHero/index.tsx
@@ -26,7 +26,7 @@ export function HomeHero({ frontmatter }: { frontmatter: FrontMatterMeta }) {
         .filter(text => text !== '')
     : [];
   return (
-    <div className="m-auto pt-0 px-6 pb-12 sm:pt-10 sm:px-16 md:pt-16 md:px-16 md:pb-16">
+    <div className="m-auto pt-0 px-6 pb-12 sm:pt-10 sm:px-16 md:pt-16 md:px-16 md:pb-16 relative">
       <div
         className={styles.mask}
         style={{


### PR DESCRIPTION
## Summary

Make the homepage mask vertically centered based on the logo.
Now the height of the mask is fixed, I'm not sure if this needs to be changed or not.

## Related Issue

<!--- Provide link of related issues -->
[#897](https://github.com/web-infra-dev/rspress/issues/897) [Bug]: The position of the homepage mask is offset from the logo

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
