### PR TITLE
chore(workflow): disable changeset changelog

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.0.0/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": false,
   "commit": false,
   "linked": [],
   "access": "restricted",


### PR DESCRIPTION
## Summary

Disable changeset changelog, we now use GitHub releases to generate changelog.

## Related Issue

https://github.com/web-infra-dev/rspress/pull/918

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
