### PR TITLE
docs: parseToolOptions in @rspress/plugin-api-docgen

### DIFF
--- a/packages/document/docs/en/plugin/official-plugins/api-docgen.mdx
+++ b/packages/document/docs/en/plugin/official-plugins/api-docgen.mdx
@@ -49,6 +49,7 @@ interface Options {
   entries?: Record<string, string>;
   apiParseTool?: 'react-docgen-typescript' | 'documentation';
   appDir?: string;
+  parseToolOptions?: ParseToolOptions;
 }
 ```
 
@@ -161,3 +162,16 @@ Returns **[string][1]** The greeting message.
 
 [1]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 ```
+
+### parseToolOptions
+
+`parseToolOptions` is used to pass options to the corresponding parse tool, whose types are as follows:
+
+```ts
+type ParseToolOptions = {
+  'react-docgen-typescript'?: ParserOptions;
+  documentation?: DocumentationArgs;
+};
+```
+
+Please refer to [ParserOptions](https://github.com/styleguidist/react-docgen-typescript/blob/b7ea0a235efb7c78a1158ca12d864de2bc2ee30e/src/parser.ts#L84-L95) and [DocumentationArgs](https://github.com/documentationjs/documentation/blob/master/docs/NODE_API.md#parameters-1) to learn about available options.

--- a/packages/document/docs/zh/plugin/official-plugins/api-docgen.mdx
+++ b/packages/document/docs/zh/plugin/official-plugins/api-docgen.mdx
@@ -49,6 +49,7 @@ interface Options {
   entries?: Record<string, string>;
   apiParseTool?: 'react-docgen-typescript' | 'documentation';
   appDir?: string;
+  parseToolOptions?: ParseToolOptions;
 }
 ```
 
@@ -161,3 +162,16 @@ Returns **[string][1]** The greeting message.
 
 [1]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 ```
+
+### parseToolOptions
+
+`parseToolOptions` 用来传入对应解析器的参数，其类型如下：
+
+```ts
+type ParseToolOptions = {
+  'react-docgen-typescript'?: ParserOptions;
+  documentation?: DocumentationArgs;
+};
+```
+
+请参考 [ParserOptions](https://github.com/styleguidist/react-docgen-typescript/blob/b7ea0a235efb7c78a1158ca12d864de2bc2ee30e/src/parser.ts#L84-L95) 和 [DocumentationArgs](https://github.com/documentationjs/documentation/blob/master/docs/NODE_API.md#parameters-1) 了解可用选项。


### PR DESCRIPTION
## Summary

add missing parseToolOptions options in `@rspress/plugin-api-docgen` doc

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
