### PR TITLE
fix: url containing dots were not correctly normalized with .html extension

### DIFF
--- a/.changeset/spotty-pumas-travel.md
+++ b/.changeset/spotty-pumas-travel.md
@@ -1,0 +1,5 @@
+---
+"@rspress/shared": patch
+---
+
+fix: url containing dots were not correctly normalized with .html extension

--- a/packages/shared/src/runtime-utils/index.test.ts
+++ b/packages/shared/src/runtime-utils/index.test.ts
@@ -58,6 +58,16 @@ describe('test shared utils', () => {
     );
     expect(normalizeHref('tel:123456789')).toBe('tel:123456789');
     expect(normalizeHref('/guide/', true)).toBe('/guide/index');
+    expect(normalizeHref('/guide/version-0.1')).toBe('/guide/version-0.1.html');
+    expect(normalizeHref('/guide/version-0.1.html')).toBe(
+      '/guide/version-0.1.html',
+    );
+    expect(normalizeHref('/guide/version-0.1/')).toBe(
+      '/guide/version-0.1/index.html',
+    );
+    expect(normalizeHref('/guide/version-0.1/', true)).toBe(
+      '/guide/version-0.1/index',
+    );
   });
 
   describe('replaceLang', () => {

--- a/packages/shared/src/runtime-utils/index.ts
+++ b/packages/shared/src/runtime-utils/index.ts
@@ -242,9 +242,7 @@ export function normalizeHref(url?: string, cleanUrls = false) {
   // eslint-disable-next-line prefer-const
   let { url: cleanUrl, hash } = parseUrl(decodeURIComponent(url));
 
-  const hasHtmlExt = cleanUrl.endsWith('.html');
-
-  if (!cleanUrls && !cleanUrl.endsWith('.html') && !hasHtmlExt) {
+  if (!cleanUrls && !cleanUrl.endsWith('.html')) {
     if (cleanUrl.endsWith('/')) {
       cleanUrl += 'index.html';
     } else {

--- a/packages/shared/src/runtime-utils/index.ts
+++ b/packages/shared/src/runtime-utils/index.ts
@@ -242,9 +242,9 @@ export function normalizeHref(url?: string, cleanUrls = false) {
   // eslint-disable-next-line prefer-const
   let { url: cleanUrl, hash } = parseUrl(decodeURIComponent(url));
 
-  const hasExt = cleanUrl.split('/').pop()?.includes('.');
+  const hasHtmlExt = cleanUrl.endsWith('.html');
 
-  if (!cleanUrls && !cleanUrl.endsWith('.html') && !hasExt) {
+  if (!cleanUrls && !cleanUrl.endsWith('.html') && !hasHtmlExt) {
     if (cleanUrl.endsWith('/')) {
       cleanUrl += 'index.html';
     } else {


### PR DESCRIPTION
## Summary

This PR fixes an issue where URLs containing dots were not correctly appended with the `.html` extension.

```text
/guide/version-0.1
expect:
/guide/version-0.1.html
actual:
/guide/version-0.1
```

## Related Issue

<!--- Provide link of related issues -->
https://github.com/web-infra-dev/rspress/issues/933

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
