### PR TITLE
docs: Replace the outdated @rspress/plugin-last-updated api lastUpdat…

### DIFF
--- a/packages/document/docs/en/plugin/official-plugins/last-updated.mdx
+++ b/packages/document/docs/en/plugin/official-plugins/last-updated.mdx
@@ -23,11 +23,11 @@ When you have configured `lastUpdated: true` in the default theme, this plugin w
 ### 1. Register the Plugin
 
 ```ts title="rspress.config.ts"
-import { lastUpdated } from '@rspress/plugin-last-updated';
+import { pluginLastUpdated } from '@rspress/plugin-last-updated';
 import { defineConfig } from 'rspress/config';
 
 export default defineConfig({
-  plugins: [lastUpdated()],
+  plugins: [pluginLastUpdated()],
 });
 ```
 

--- a/packages/document/docs/zh/plugin/official-plugins/last-updated.mdx
+++ b/packages/document/docs/zh/plugin/official-plugins/last-updated.mdx
@@ -23,11 +23,11 @@ import { SourceCode, PackageManagerTabs } from 'rspress/theme';
 ### 1. 注册插件
 
 ```ts title="rspress.config.ts"
-import { lastUpdated } from '@rspress/plugin-last-updated';
+import { pluginLastUpdated } from '@rspress/plugin-last-updated';
 import { defineConfig } from 'rspress/config';
 
 export default defineConfig({
-  plugins: [lastUpdated()],
+  plugins: [pluginLastUpdated()],
 });
 ```
 


### PR DESCRIPTION
…ed with pluginLastUpdated

## Summary
 Replace the outdated @rspress/plugin-last-updated api lastUpdated with pluginLastUpdated #941
## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

> * [x] Tests updated (or not required).
> * [x] Documentation updated (or not required).
