### PR TITLE
feat: support separate search indexes by version

### DIFF
--- a/packages/core/src/node/runtimeModule/siteData/index.ts
+++ b/packages/core/src/node/runtimeModule/siteData/index.ts
@@ -63,7 +63,7 @@ export async function siteDataVMPlugin(context: FactoryContext) {
 
   const groupedPages = groupBy(pages, page => {
     if (page.frontmatter?.pageType === 'home') {
-      return 'omit';
+      return 'noindex';
     }
 
     const version = versioned ? page.version : '';
@@ -71,8 +71,8 @@ export async function siteDataVMPlugin(context: FactoryContext) {
 
     return `${version}###${lang}`;
   });
-  // remove the pages marked as omit
-  delete groupedPages.omit;
+  // remove the pages marked as noindex
+  delete groupedPages.noindex;
 
   const indexHashByGroup = {} as Record<string, string>;
 

--- a/packages/core/src/node/runtimeModule/siteData/index.ts
+++ b/packages/core/src/node/runtimeModule/siteData/index.ts
@@ -84,6 +84,7 @@ export async function siteDataVMPlugin(context: FactoryContext) {
         groupedPages[group].map(deletePriviteKey),
       );
       const indexHash = createHash(stringifiedIndex);
+      indexHashByGroup[group] = indexHash;
 
       const [version, lang] = group.split('###');
       const indexVersion = version ? `.${version.replace('.', '_')}` : '';

--- a/packages/core/src/node/runtimeModule/siteData/index.ts
+++ b/packages/core/src/node/runtimeModule/siteData/index.ts
@@ -80,10 +80,10 @@ export async function siteDataVMPlugin(context: FactoryContext) {
   await Promise.all(
     Object.keys(groupedPages).map(async group => {
       // Avoid writing filepath in compile-time
-      const stringfiedIndex = JSON.stringify(
+      const stringifiedIndex = JSON.stringify(
         groupedPages[group].map(deletePriviteKey),
       );
-      const indexHash = createHash(stringfiedIndex);
+      const indexHash = createHash(stringifiedIndex);
 
       const [version, lang] = group.split('###');
       const indexVersion = version ? `.${version.replace('.', '_')}` : '';
@@ -95,7 +95,7 @@ export async function siteDataVMPlugin(context: FactoryContext) {
           TEMP_DIR,
           `${SEARCH_INDEX_NAME}${indexVersion}${indexLang}.${indexHash}.json`,
         ),
-        stringfiedIndex,
+        stringifiedIndex,
       );
     }),
   );

--- a/packages/core/src/node/runtimeModule/siteData/index.ts
+++ b/packages/core/src/node/runtimeModule/siteData/index.ts
@@ -1,5 +1,6 @@
 import path from 'path';
-import { PageIndexInfo, SEARCH_INDEX_NAME } from '@rspress/shared';
+import { groupBy } from 'lodash-es';
+import { SEARCH_INDEX_NAME } from '@rspress/shared';
 import fs from '@rspress/shared/fs-extra';
 import { FactoryContext, RuntimeModuleID } from '..';
 import { normalizeThemeConfig } from './normalizeThemeConfig';
@@ -55,37 +56,44 @@ export async function siteDataVMPlugin(context: FactoryContext) {
   // modify page index by plugins
   await pluginDriver.modifySearchIndexData(pages);
 
-  // Categorize pages, sorted by language, and write search index to file
-  const pagesByLang = pages.reduce(
-    (acc, page) => {
-      if (!acc[page.lang]) {
-        acc[page.lang] = [];
-      }
-      if (page.frontmatter?.pageType === 'home') {
-        return acc;
-      }
-      acc[page.lang].push(page);
-      return acc;
-    },
-    {} as Record<string, PageIndexInfo[]>,
-  );
+  const versioned =
+    userConfig.search &&
+    userConfig.search.mode === 'local' &&
+    userConfig.search.versioned;
 
-  const indexHashByLang = {} as Record<string, string>;
+  const groupedPages = groupBy(pages, page => {
+    if (page.frontmatter?.pageType === 'home') {
+      return 'omit';
+    }
 
-  // Generate search index by different languages, file name is {SEARCH_INDEX_NAME}.{lang}.{hash}.json
+    const version = versioned ? page.version : '';
+    const lang = page.lang || '';
+
+    return `${version}###${lang}`;
+  });
+  // remove the pages marked as omit
+  delete groupedPages.omit;
+
+  const indexHashByGroup = {} as Record<string, string>;
+
+  // Generate search index by different versions & languages, file name is {SEARCH_INDEX_NAME}.{version}.{lang}.{hash}.json
   await Promise.all(
-    Object.keys(pagesByLang).map(async lang => {
+    Object.keys(groupedPages).map(async group => {
       // Avoid writing filepath in compile-time
       const stringfiedIndex = JSON.stringify(
-        pagesByLang[lang].map(deletePriviteKey),
+        groupedPages[group].map(deletePriviteKey),
       );
       const indexHash = createHash(stringfiedIndex);
-      indexHashByLang[lang] = indexHash;
+
+      const [version, lang] = group.split('###');
+      const indexVersion = version ? `.${version.replace('.', '_')}` : '';
+      const indexLang = lang ? `.${lang}` : '';
+
       await fs.ensureDir(TEMP_DIR);
       await fs.writeFile(
         path.join(
           TEMP_DIR,
-          `${SEARCH_INDEX_NAME}${lang ? `.${lang}` : ''}.${indexHash}.json`,
+          `${SEARCH_INDEX_NAME}${indexVersion}${indexLang}.${indexHash}.json`,
         ),
         stringfiedIndex,
       );
@@ -131,7 +139,7 @@ export async function siteDataVMPlugin(context: FactoryContext) {
       siteData,
     )}`,
     [RuntimeModuleID.SearchIndexHash]: `export default ${JSON.stringify(
-      indexHashByLang,
+      indexHashByGroup,
     )}`,
   };
 }

--- a/packages/core/src/node/runtimeModule/siteData/index.ts
+++ b/packages/core/src/node/runtimeModule/siteData/index.ts
@@ -58,7 +58,7 @@ export async function siteDataVMPlugin(context: FactoryContext) {
 
   const versioned =
     userConfig.search &&
-    userConfig.search.mode === 'local' &&
+    userConfig.search.mode !== 'remote' &&
     userConfig.search.versioned;
 
   const groupedPages = groupBy(pages, page => {

--- a/packages/core/src/node/searchIndex.ts
+++ b/packages/core/src/node/searchIndex.ts
@@ -12,7 +12,7 @@ export async function writeSearchIndex(config: UserConfig) {
     return;
   }
   const cwd = process.cwd();
-  // get all search index files, format is `${SEARCH_INDEX_NAME}.foo.${hash}.json`
+  // get all search index files, format is `${SEARCH_INDEX_NAME}.foo.bar.${hash}.json`
   const searchIndexFiles = await fs.readdir(TEMP_DIR);
   const outDir = config?.outDir ?? join(cwd, OUTPUT_DIR);
 

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -316,6 +316,10 @@ export interface SearchHooks {
 
 export type LocalSearchOptions = SearchHooks & {
   mode?: 'local';
+  /**
+   * Whether to generate separate search index for each version
+   */
+  versioned?: boolean;
 };
 
 export type RemoteSearchIndexInfo =

--- a/packages/theme-default/src/components/Search/SearchPanel.tsx
+++ b/packages/theme-default/src/components/Search/SearchPanel.tsx
@@ -212,7 +212,7 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
   }, [focused]);
 
   useEffect(() => {
-    const { currentLang, currentVersion } = pageSearcherConfigRef.current;
+    const { currentLang, currentVersion } = pageSearcherConfigRef.current ?? {};
     const isLangChanged = lang !== currentLang;
     const isVersionChanged = versionedSearch && version !== currentVersion;
 

--- a/packages/theme-default/src/components/Search/SearchPanel.tsx
+++ b/packages/theme-default/src/components/Search/SearchPanel.tsx
@@ -79,7 +79,7 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
   };
   const {
     siteData,
-    page: { lang },
+    page: { lang, version },
   } = usePageData();
   const { sidebar } = useLocaleSiteData();
   const { search, title: siteTitle } = siteData;
@@ -105,6 +105,7 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
       indexName: siteTitle,
       ...search,
       currentLang: lang,
+      currentVersion: version,
       extractGroupName,
     });
     pageSearcherRef.current = pageSearcher;

--- a/packages/theme-default/src/components/Search/logic/providers/LocalProvider.ts
+++ b/packages/theme-default/src/components/Search/logic/providers/LocalProvider.ts
@@ -57,16 +57,12 @@ export class LocalProvider implements Provider {
 
     const pagesForSearch: PageIndexForFlexSearch[] = (
       await this.#getPages(currentLang, versioned ? currentVersion : '')
-    )
-      .filter(page => page.lang === currentLang)
-      .map(page => ({
-        ...page,
-        normalizedContent: normalizeTextCase(page.content),
-        headers: page.toc
-          .map(header => normalizeTextCase(header.text))
-          .join(' '),
-        normalizedTitle: normalizeTextCase(page.title),
-      }));
+    ).map(page => ({
+      ...page,
+      normalizedContent: normalizeTextCase(page.content),
+      headers: page.toc.map(header => normalizeTextCase(header.text)).join(' '),
+      normalizedTitle: normalizeTextCase(page.title),
+    }));
     const createOptions: CreateOptions = {
       tokenize: 'full',
       async: true,

--- a/packages/theme-default/src/components/Search/logic/providers/LocalProvider.ts
+++ b/packages/theme-default/src/components/Search/logic/providers/LocalProvider.ts
@@ -53,7 +53,7 @@ export class LocalProvider implements Provider {
 
   async init(options: SearchOptions) {
     const { currentLang, currentVersion } = options;
-    const versioned = options.mode === 'local' && options.versioned;
+    const versioned = options.mode !== 'remote' && options.versioned;
 
     const pagesForSearch: PageIndexForFlexSearch[] = (
       await this.#getPages(currentLang, versioned ? currentVersion : '')

--- a/packages/theme-default/src/components/Search/logic/providers/LocalProvider.ts
+++ b/packages/theme-default/src/components/Search/logic/providers/LocalProvider.ts
@@ -40,19 +40,23 @@ export class LocalProvider implements Provider {
 
   #cyrilicIndex?: SearchIndex<PageIndexInfo[]>;
 
-  async #getPages(lang: string): Promise<PageIndexInfo[]> {
+  async #getPages(lang: string, version: string): Promise<PageIndexInfo[]> {
+    const searchIndexGroupID = `${version}###${lang}`;
+    const searchIndexVersion = version ? `.${version.replace('.', '_')}` : '';
+    const searchIndexLang = lang ? `.${lang}` : '';
+
     const result = await fetch(
-      `${process.env.__ASSET_PREFIX__}/static/${SEARCH_INDEX_NAME}${
-        lang ? `.${lang}` : ''
-      }.${searchIndexHash[lang]}.json`,
+      `${process.env.__ASSET_PREFIX__}/static/${SEARCH_INDEX_NAME}${searchIndexVersion}${searchIndexLang}.${searchIndexHash[searchIndexGroupID]}.json`,
     );
     return result.json();
   }
 
   async init(options: SearchOptions) {
-    const { currentLang } = options;
+    const { currentLang, currentVersion } = options;
+    const versioned = options.mode === 'local' && options.versioned;
+
     const pagesForSearch: PageIndexForFlexSearch[] = (
-      await this.#getPages(currentLang)
+      await this.#getPages(currentLang, versioned ? currentVersion : '')
     )
       .filter(page => page.lang === currentLang)
       .map(page => ({

--- a/packages/theme-default/src/components/Search/logic/types.ts
+++ b/packages/theme-default/src/components/Search/logic/types.ts
@@ -53,6 +53,7 @@ export type MatchResult = (DefaultMatchResult | CustomMatchResult)[];
 
 export type SearchOptions = (LocalSearchOptions | RemoteSearchOptions) & {
   currentLang: string;
+  currentVersion: string;
   extractGroupName: (path: string) => string;
 };
 

--- a/packages/theme-default/src/components/Search/logic/types.ts
+++ b/packages/theme-default/src/components/Search/logic/types.ts
@@ -51,11 +51,14 @@ export type CustomMatchResult = UserMatchResultItem & {
 
 export type MatchResult = (DefaultMatchResult | CustomMatchResult)[];
 
-export type SearchOptions = (LocalSearchOptions | RemoteSearchOptions) & {
+export type PageSearcherConfig = {
   currentLang: string;
   currentVersion: string;
   extractGroupName: (path: string) => string;
 };
+
+export type SearchOptions = (LocalSearchOptions | RemoteSearchOptions) &
+  PageSearcherConfig;
 
 export type BeforeSearch = (query: string) => string | Promise<string> | void;
 

--- a/packages/theme-default/src/logic/useFullTextSearch.ts
+++ b/packages/theme-default/src/logic/useFullTextSearch.ts
@@ -1,4 +1,4 @@
-import { useLang } from '@rspress/runtime';
+import { usePageData } from '@rspress/runtime';
 import { useEffect, useRef, useState } from 'react';
 import { MatchResult } from '..';
 import { PageSearcher } from '../components/Search/logic/search';
@@ -9,7 +9,7 @@ export function useFullTextSearch(): {
   initialized: boolean;
   search: (keyword: string, limit?: number) => Promise<MatchResult>;
 } {
-  const lang = useLang();
+  const { siteData, page } = usePageData();
   const [initialized, setInitialized] = useState(false);
   const { sidebar } = useLocaleSiteData();
   const extractGroupName = (link: string) =>
@@ -20,8 +20,10 @@ export function useFullTextSearch(): {
     async function init() {
       if (!initialized) {
         const searcher = new PageSearcher({
+          ...siteData.search,
           mode: 'local',
-          currentLang: lang,
+          currentLang: page.lang,
+          currentVersion: page.version,
           extractGroupName,
         });
         searchRef.current = searcher;


### PR DESCRIPTION
## Summary

- added new `search.versioned` option to config
- removed redundant `.filter` by lang in `LocalProvider`
- fetch new index on version change (if enabled) in `SearchPanel`

## Related Issue

#947

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
