### PR TITLE
feat(api-docgen): support more config to init parser instance

### DIFF
--- a/packages/document/docs/en/plugin/official-plugins/api-docgen.mdx
+++ b/packages/document/docs/en/plugin/official-plugins/api-docgen.mdx
@@ -169,9 +169,14 @@ Returns **[string][1]** The greeting message.
 
 ```ts
 type ParseToolOptions = {
-  'react-docgen-typescript'?: ParserOptions;
+  'react-docgen-typescript'?: ParserOptions & {
+    tsconfigPath?: string;
+    compilerOptions?: ts.CompilerOptions;
+  };
   documentation?: DocumentationArgs;
 };
 ```
 
 Please refer to [ParserOptions](https://github.com/styleguidist/react-docgen-typescript/blob/b7ea0a235efb7c78a1158ca12d864de2bc2ee30e/src/parser.ts#L84-L95) and [DocumentationArgs](https://github.com/documentationjs/documentation/blob/master/docs/NODE_API.md#parameters-1) to learn about available options.
+
+If the parser is `react-docgen-typescript`, the `withDefaultConfig` method is used by default to create a parser instance. If `tsconfigPath` or `compilerOptions` is configured, the `withCompilerOptions` and `withCustomConfig` methods are used to create the parser instance respectively. See [Custom Parsers](https://github.com/styleguidist/react-docgen-typescript/blob/b7ea0a235efb7c78a1158ca12d864de2bc2ee30e/README.md#usage) for details.

--- a/packages/document/docs/zh/plugin/official-plugins/api-docgen.mdx
+++ b/packages/document/docs/zh/plugin/official-plugins/api-docgen.mdx
@@ -169,9 +169,14 @@ Returns **[string][1]** The greeting message.
 
 ```ts
 type ParseToolOptions = {
-  'react-docgen-typescript'?: ParserOptions;
+  'react-docgen-typescript'?: ParserOptions & {
+    tsconfigPath?: string;
+    compilerOptions?: ts.CompilerOptions;
+  };
   documentation?: DocumentationArgs;
 };
 ```
 
 请参考 [ParserOptions](https://github.com/styleguidist/react-docgen-typescript/blob/b7ea0a235efb7c78a1158ca12d864de2bc2ee30e/src/parser.ts#L84-L95) 和 [DocumentationArgs](https://github.com/documentationjs/documentation/blob/master/docs/NODE_API.md#parameters-1) 了解可用选项。
+
+如果解析器是 `react-docgen-typescript`，默认使用 `withDefaultConfig` 方法创建解析器实例，如果配置了 `tsconfigPath` 或 `compilerOptions` 则会分别使用 `withCompilerOptions` 和 `withCustomConfig` 方法创建解析器实例，详情查看 [Custom Parsers](https://github.com/styleguidist/react-docgen-typescript/blob/b7ea0a235efb7c78a1158ca12d864de2bc2ee30e/README.md#usage)。

--- a/packages/plugin-api-docgen/package.json
+++ b/packages/plugin-api-docgen/package.json
@@ -45,7 +45,8 @@
   "peerDependencies": {
     "react": ">=17",
     "react-router-dom": "^6.8.1",
-    "@rspress/core": "^1.0.2"
+    "@rspress/core": "^1.0.2",
+    "typescript": "^5"
   },
   "files": [
     "dist",

--- a/packages/plugin-api-docgen/package.json
+++ b/packages/plugin-api-docgen/package.json
@@ -48,6 +48,11 @@
     "@rspress/core": "^1.0.2",
     "typescript": "^5"
   },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
   "files": [
     "dist",
     "static",

--- a/packages/plugin-api-docgen/src/types.ts
+++ b/packages/plugin-api-docgen/src/types.ts
@@ -1,6 +1,6 @@
 import type { PageIndexInfo } from '@rspress/shared';
 import type { ParserOptions } from 'react-docgen-typescript';
-import * as ts from 'typescript';
+import type { CompilerOptions } from 'typescript';
 
 export type Entries = Record<string, string>;
 
@@ -29,7 +29,7 @@ export type DocumentationArgs = {
 export type ParseToolOptions = {
   'react-docgen-typescript'?: ParserOptions & {
     tsconfigPath?: string;
-    compilerOptions?: ts.CompilerOptions;
+    compilerOptions?: CompilerOptions;
   };
   documentation?: DocumentationArgs;
 };

--- a/packages/plugin-api-docgen/src/types.ts
+++ b/packages/plugin-api-docgen/src/types.ts
@@ -1,5 +1,6 @@
 import type { PageIndexInfo } from '@rspress/shared';
 import type { ParserOptions } from 'react-docgen-typescript';
+import * as ts from 'typescript';
 
 export type Entries = Record<string, string>;
 
@@ -26,7 +27,10 @@ export type DocumentationArgs = {
 };
 
 export type ParseToolOptions = {
-  'react-docgen-typescript'?: ParserOptions;
+  'react-docgen-typescript'?: ParserOptions & {
+    tsconfigPath?: string;
+    compilerOptions?: ts.CompilerOptions;
+  };
   documentation?: DocumentationArgs;
 };
 


### PR DESCRIPTION
## Summary

If the parser is `react-docgen-typescript`, the `withDefaultConfig` method is used by default to create a parser instance. If `tsconfigPath` or `compilerOptions` is configured, the `withCompilerOptions` and `withCustomConfig` methods are used to create the parser instance respectively. See [Custom Parsers](https://github.com/styleguidist/react-docgen-typescript/blob/b7ea0a235efb7c78a1158ca12d864de2bc2ee30e/README.md#usage) for details.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
