### PR TITLE
fix: checkDeadLinks when mdxRs is set to false

### DIFF
--- a/packages/core/src/node/route/RouteService.ts
+++ b/packages/core/src/node/route/RouteService.ts
@@ -69,6 +69,7 @@ export const normalizeRoutePath = (
   )
     // remove the extension
     .replace(new RegExp(`\\.(${extensions.join('|')})$`), '')
+    .replace(/\.html$/, '')
     .replace(/\/index$/, '/');
 
   // restore the trail slash


### PR DESCRIPTION
## Summary

handle `.html` extension separately, because `extensions` can be overridden via config, but it's always present in the output.

## Related Issue

closes #965 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
