### PR TITLE
feat: add divider border for h2 title

### DIFF
--- a/packages/theme-default/src/layout/DocLayout/docComponents/title.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/title.tsx
@@ -14,7 +14,7 @@ export const H2 = (props: React.ComponentProps<'h2'>) => {
   return (
     <h2
       {...props}
-      className={`mt-14 mb-6 text-2xl tracking-tight ${styles.title}`}
+      className={`mt-12 mb-6 pt-8 text-2xl tracking-tight border-t-[1px] border-divider-light ${styles.title}`}
     />
   );
 };

--- a/packages/theme-default/src/styles/vars.css
+++ b/packages/theme-default/src/styles/vars.css
@@ -13,7 +13,7 @@
   --rp-c-bg-mute: #f1f1f1;
 
   --rp-c-divider: rgba(60, 60, 60, 0.29);
-  --rp-c-divider-light: rgba(60, 60, 60, 0.12);
+  --rp-c-divider-light: rgba(60, 60, 60, 0.1);
 
   --rp-c-text-1: #213547;
   --rp-c-text-2: rgba(60, 60, 60, 0.66);


### PR DESCRIPTION
## Summary

Add divider border for h2 title.

This is a common design in software documents (such as [next.js doc](https://nextjs.org/docs)), which can make the boundaries of paragraphs clearer and help read long documents.

Preview:

![image](https://github.com/web-infra-dev/rspress/assets/7237365/b0dc086b-1315-4153-bab2-b020134403c4)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
