### PR TITLE
fix: Tabs component children contains linebreak or with no tab

### DIFF
--- a/e2e/fixtures/tabs-component/doc/index.mdx
+++ b/e2e/fixtures/tabs-component/doc/index.mdx
@@ -13,4 +13,9 @@ import { Tabs, Tab } from 'rspress/theme';
 <Tabs tabContainerClassName="tabs-b">
   <Tab label="label2">content2</Tab>
   <Tab label="label3">content3</Tab>
+  <Tab label="label4">content4</Tab>
 </Tabs>
+
+## Tab C
+
+<Tabs tabContainerClassName="tabs-c"></Tabs>

--- a/e2e/tests/tabs-component.test.ts
+++ b/e2e/tests/tabs-component.test.ts
@@ -38,5 +38,18 @@ test.describe('tabs-component test', async () => {
     const contentBText = await page.evaluate(node => node?.innerHTML, contentB);
     expect(tabBText).toContain('label2');
     expect(contentBText).toContain('content2');
+    const notSelected = await page.$$eval(
+      '.tabs-b div',
+      divs => divs.filter(div => div.className.includes('not-selected')).length,
+    );
+    expect(notSelected).toEqual(2);
+
+    // Tab C
+    const tabC = await page.$('.tabs-c');
+    const contentC = await page.$('.tabs-c + div');
+    const tabCText = await page.evaluate(node => node?.innerHTML, tabC);
+    const contentCText = await page.evaluate(node => node?.innerHTML, contentC);
+    expect(tabCText).toEqual('');
+    expect(contentCText).toEqual('');
   });
 });

--- a/packages/theme-default/src/components/Tabs/index.tsx
+++ b/packages/theme-default/src/components/Tabs/index.tsx
@@ -49,11 +49,15 @@ export const Tabs: ForwardRefExoticComponent<TabsProps> = forwardRef(
       values,
       defaultValue,
       onChange,
-      children,
+      children: rawChildren,
       groupId,
       tabPosition = 'left',
       tabContainerClassName,
     } = props;
+    // remove "\n" character when write JSX element in multiple lines, use Children.toArray for Tabs with no Tab element
+    const children = Children.toArray(rawChildren).filter(
+      child => !(typeof child === 'string' && child.trim() === ''),
+    );
 
     let tabValues = values || [];
 


### PR DESCRIPTION
## Summary

fix tabs component children contains linebreak or with no tab

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
