### PR TITLE
chore: remove flex-center in sidebar item

### DIFF
--- a/packages/theme-default/src/components/Sidebar/SidebarItem.tsx
+++ b/packages/theme-default/src/components/Sidebar/SidebarItem.tsx
@@ -83,9 +83,7 @@ export function SidebarItem(props: SidebarItemProps) {
         }}
       >
         <Tag tag={item.tag} />
-        <span className="flex-center">
-          {renderInlineMarkdown(textRef.current)}
-        </span>
+        <span>{renderInlineMarkdown(textRef.current)}</span>
       </div>
     </Link>
   );


### PR DESCRIPTION
## Summary

remove flex-center in sidebar item to avoid unexpected display of white-space

before:

![image](https://github.com/web-infra-dev/rspress/assets/50201324/68daeb19-433c-49e3-ba0e-b3a5d9a45595)


after:

![image](https://github.com/web-infra-dev/rspress/assets/50201324/2d151f9d-4437-4f24-a07a-9b1025be4ffa)


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
