### PR TITLE
fix(theme): remove invalid `className`

### DIFF
--- a/.changeset/real-cobras-double.md
+++ b/.changeset/real-cobras-double.md
@@ -1,0 +1,5 @@
+---
+"@rspress/theme-default": patch
+---
+
+fix: remove invalid `className`

--- a/packages/theme-default/src/components/Nav/index.tsx
+++ b/packages/theme-default/src/components/Nav/index.tsx
@@ -140,9 +140,7 @@ export function Nav(props: NavProps) {
           {beforeNavTitle}
           <NavBarTitle />
           {afterNavTitle}
-          <div
-            className={`${styles.content} flex flex-1 justify-end items-center`}
-          >
+          <div className="flex flex-1 justify-end items-center">
             {leftNav()}
             {rightNav()}
             {afterNavMenu}

--- a/packages/theme-default/src/components/NavScreen/index.tsx
+++ b/packages/theme-default/src/components/NavScreen/index.tsx
@@ -23,9 +23,7 @@ interface Props {
 const NavScreenTranslations = () => {
   const translationMenuData = useTranslationMenuData();
   return (
-    <div
-      className={`${styles.navTranslations} flex text-sm font-bold justify-center`}
-    >
+    <div className="flex text-sm font-bold justify-center">
       <div className="mx-1.5 my-1">
         <NavScreenMenuGroup {...translationMenuData} />
       </div>


### PR DESCRIPTION
## Summary

<img width="364" alt="image" src="https://github.com/web-infra-dev/rspress/assets/24606443/8abfff08-fc87-4100-8b41-b9d3d229e223">

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
