### PR TITLE
✨ feat(route): Update home page title with frontmatter titleSuffix

### DIFF
--- a/packages/document/docs/en/api/config/config-frontmatter.mdx
+++ b/packages/document/docs/en/api/config/config-frontmatter.mdx
@@ -83,7 +83,7 @@ hero:
   name: Rspress
   text: A documentation solution
   tagline: A modern documentation development technology stack
-  titleSuffix: - Rspack-based Static Site Generator
+  titleSuffix: '- Rspack-based Static Site Generator'
   actions:
     - theme: brand
       text: Introduction

--- a/packages/document/docs/en/api/config/config-frontmatter.mdx
+++ b/packages/document/docs/en/api/config/config-frontmatter.mdx
@@ -69,6 +69,7 @@ export interface Hero {
     link: string;
     theme: 'brand' | 'alt';
   }[];
+  titleSuffix?: string;
 }
 ```
 
@@ -82,6 +83,7 @@ hero:
   name: Rspress
   text: A documentation solution
   tagline: A modern documentation development technology stack
+  titleSuffix: - Rspack-based Static Site Generator
   actions:
     - theme: brand
       text: Introduction

--- a/packages/document/docs/en/index.md
+++ b/packages/document/docs/en/index.md
@@ -1,5 +1,6 @@
 ---
 pageType: home
+titleSuffix: - Rspack-based Static Site Generator
 
 hero:
   name: Rspress

--- a/packages/document/docs/en/index.md
+++ b/packages/document/docs/en/index.md
@@ -1,6 +1,6 @@
 ---
 pageType: home
-titleSuffix: - Rspack-based Static Site Generator
+titleSuffix: '- Rspack-based Static Site Generator'
 
 hero:
   name: Rspress

--- a/packages/document/docs/zh/api/config/config-frontmatter.mdx
+++ b/packages/document/docs/zh/api/config/config-frontmatter.mdx
@@ -83,7 +83,7 @@ hero:
   name: Rspress
   text: 文档工程解决方案
   tagline: 现代化文档开发技术栈
-  titleSuffix: - 基于 Rspack 的静态站点生成器
+  titleSuffix: '- 基于 Rspack 的静态站点生成器'
   actions:
     - theme: brand
       text: 介绍

--- a/packages/document/docs/zh/api/config/config-frontmatter.mdx
+++ b/packages/document/docs/zh/api/config/config-frontmatter.mdx
@@ -54,7 +54,7 @@ export interface Hero {
   name: string;
   text: string;
   tagline: string;
-  titleSuffix: - Rspack-based Static Site Generator
+  titleSuffix?: string;
   image?: {
     src: string;
     alt: string;

--- a/packages/document/docs/zh/api/config/config-frontmatter.mdx
+++ b/packages/document/docs/zh/api/config/config-frontmatter.mdx
@@ -54,6 +54,7 @@ export interface Hero {
   name: string;
   text: string;
   tagline: string;
+  titleSuffix: - Rspack-based Static Site Generator
   image?: {
     src: string;
     alt: string;
@@ -82,6 +83,7 @@ hero:
   name: Rspress
   text: 文档工程解决方案
   tagline: 现代化文档开发技术栈
+  titleSuffix: - 基于 Rspack 的静态站点生成器
   actions:
     - theme: brand
       text: 介绍

--- a/packages/document/docs/zh/index.md
+++ b/packages/document/docs/zh/index.md
@@ -1,5 +1,6 @@
 ---
 pageType: home
+titleSuffix: - 基于 Rspack 的静态站点生成器
 
 hero:
   name: Rspress

--- a/packages/document/docs/zh/index.md
+++ b/packages/document/docs/zh/index.md
@@ -1,6 +1,6 @@
 ---
 pageType: home
-titleSuffix: - 基于 Rspack 的静态站点生成器
+titleSuffix: '- 基于 Rspack 的静态站点生成器'
 
 hero:
   name: Rspress

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -273,6 +273,7 @@ export interface FrontMatterMeta {
   outline?: boolean;
   lineNumbers?: boolean;
   overviewHeaders?: number;
+  titleSuffix?: string;
 }
 
 export interface PageData {

--- a/packages/theme-default/src/layout/Layout/index.tsx
+++ b/packages/theme-default/src/layout/Layout/index.tsx
@@ -74,7 +74,7 @@ export const Layout: React.FC<LayoutProps> = props => {
     // append main title as a suffix
     title = `${title} - ${mainTitle}`;
   }  else if (pageType === 'home') {
-    title = frontmatter?.titleSuffix ? `${mainTitle} - ${frontmatter.titleSuffix}` : mainTitle;
+    title = frontmatter?.titleSuffix ? `${mainTitle}${frontmatter.titleSuffix}` : mainTitle;
   } else {
     title = mainTitle;
   }

--- a/packages/theme-default/src/layout/Layout/index.tsx
+++ b/packages/theme-default/src/layout/Layout/index.tsx
@@ -73,6 +73,8 @@ export const Layout: React.FC<LayoutProps> = props => {
   if (title && pageType === 'doc') {
     // append main title as a suffix
     title = `${title} - ${mainTitle}`;
+  }  else if (pageType === 'home') {
+    title = frontmatter?.titleSuffix ? `${mainTitle} - ${frontmatter.titleSuffix}` : mainTitle;
   } else {
     title = mainTitle;
   }


### PR DESCRIPTION
Updated the logic for generating the home page title to include the titleSuffix from frontmatter if available, using the format ${mainTitle} - ${frontmatter.titleSuffix}, or defaulting to mainTitle if titleSuffix is not present.

## Summary

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
