### PR TITLE
feat: improve table border style in dark mode

### DIFF
--- a/packages/theme-default/src/layout/DocLayout/docComponents/table.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/table.tsx
@@ -4,7 +4,7 @@ export const Table = (props: ComponentProps<'table'>) => {
   return (
     <table
       {...props}
-      className="block border-collapse text-base my-5 overflow-x-auto leading-7 border-gray-light-2"
+      className="block border-collapse text-base my-5 overflow-x-auto leading-7 border-gray-light-3 dark:border-divider"
     />
   );
 };
@@ -13,7 +13,7 @@ export const Tr = (props: ComponentProps<'tr'>) => {
   return (
     <tr
       {...props}
-      className="border border-solid transition-colors duration-500 even:bg-soft border-gray-light-2"
+      className="border border-solid transition-colors duration-500 even:bg-soft border-gray-light-3 dark:border-divider"
     />
   );
 };
@@ -22,7 +22,7 @@ export const Td = (props: ComponentProps<'td'>) => {
   return (
     <td
       {...props}
-      className="border border-solid  px-4 py-2 border-gray-light-2"
+      className="border border-solid px-4 py-2 border-gray-light-3 dark:border-divider"
     />
   );
 };
@@ -31,7 +31,7 @@ export const Th = (props: ComponentProps<'th'>) => {
   return (
     <th
       {...props}
-      className="border border-solid px-4 py-2 text-text-1 text-base font-semibold border-gray-light-2"
+      className="border border-solid px-4 py-2 text-text-1 text-base font-semibold border-gray-light-3 dark:border-divider"
     />
   );
 };


### PR DESCRIPTION
## Summary

Improve table border style in dark mode, the current table border color is too "light" and can be more soft.

- Before:

<img width="533" alt="Screenshot 2024-04-19 at 10 43 01" src="https://github.com/web-infra-dev/rspress/assets/7237365/fc866fbc-26af-4a5d-9d3b-8e0ab1274733">

- After:

<img width="543" alt="Screenshot 2024-04-19 at 11 03 08" src="https://github.com/web-infra-dev/rspress/assets/7237365/ec22d257-0362-45b6-941d-926922f23f09">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
