### PR TITLE
fix: sidebar not display using cleanUrls: true when visit with .html suffix

### DIFF
--- a/packages/shared/src/runtime-utils/index.test.ts
+++ b/packages/shared/src/runtime-utils/index.test.ts
@@ -46,6 +46,7 @@ describe('test shared utils', () => {
   });
 
   test('normalizeHref', () => {
+    expect(normalizeHref()).toEqual('/');
     expect(normalizeHref('/guide/')).toBe('/guide/index.html');
     expect(normalizeHref('/guide')).toBe('/guide.html');
     expect(normalizeHref('/guide/index.html')).toBe('/guide/index.html');
@@ -57,7 +58,10 @@ describe('test shared utils', () => {
       'mailto:bluth@example.com',
     );
     expect(normalizeHref('tel:123456789')).toBe('tel:123456789');
+    expect(normalizeHref('/guide', true)).toBe('/guide');
     expect(normalizeHref('/guide/', true)).toBe('/guide/index');
+    expect(normalizeHref('/guide.html', true)).toBe('/guide');
+    expect(normalizeHref('/guide/index.html', true)).toBe('/guide/index');
     expect(normalizeHref('/guide/version-0.1')).toBe('/guide/version-0.1.html');
     expect(normalizeHref('/guide/version-0.1.html')).toBe(
       '/guide/version-0.1.html',

--- a/packages/shared/src/runtime-utils/index.ts
+++ b/packages/shared/src/runtime-utils/index.ts
@@ -254,6 +254,10 @@ export function normalizeHref(url?: string, cleanUrls = false) {
     cleanUrl += 'index';
   }
 
+  if (cleanUrls && cleanUrl.endsWith('.html')) {
+    cleanUrl = cleanUrl.replace(/\.html$/, '');
+  }
+
   return addLeadingSlash(hash ? `${cleanUrl}#${hash}` : cleanUrl);
 }
 


### PR DESCRIPTION
## Summary

sidebar not display using cleanUrls: true when visit with .html suffix

## Related Issue

closes: #933 

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
