### PR TITLE
docs: enable cleanUrls for website

### DIFF
--- a/packages/document/docs/en/guide/start/introduction.mdx
+++ b/packages/document/docs/en/guide/start/introduction.mdx
@@ -97,7 +97,7 @@ We recommend using `declarative config` under normal scenes, which has many bene
 2. The correspondence between the `file directory structure` and the `sidebar directory structure` is more intuitive.
 3. When adding or deleting a sidebar directory, operate directly in the current directory, instead of going to the `rspress.config.ts` config file to locate the corresponding position and then add/delete the config, thereby reducing the cost of switching development context.
 
-The `programming config` is very useful in some scenarios where dynamic config generation is needed. For example, the official Rspress [TypeDoc plugin](https://rspress.dev/plugin/official-plugins/typedoc.html 'TypeDoc plugin') will automatically convert a json data provided by TypeDoc into `nav` and `sidebar` configs.
+The `programming config` is very useful in some scenarios where dynamic config generation is needed. For example, the official Rspress [TypeDoc plugin](/plugin/official-plugins/typedoc) will automatically convert a json data provided by TypeDoc into `nav` and `sidebar` configs.
 
 ### MDX Support
 

--- a/packages/document/docs/zh/guide/start/introduction.mdx
+++ b/packages/document/docs/zh/guide/start/introduction.mdx
@@ -97,7 +97,7 @@ Rspress 内部设计了多种扩展机制，保证足够强的定制能力，包
 1.  `文件目录结构`和`侧边栏目录结构`的对应关系更加直观。
 1.  增加或者删减侧边栏目录时，直接在当前目录中操作，而不用前往 `rspress.config.ts` 配置文件中定位到相应的位置然后添加/删减配置，从而减少了开发上下文切换的成本。
 
-而`编程式配置`则在某些需要动态生成配置的场景中非常有用，比如 Rspress 官方的 [TypeDoc 插件](https://rspress.dev/plugin/official-plugins/typedoc.html 'TypeDoc 插件') 会根据 TypeDoc 提供的一份 json 数据自动转换为 `nav` 和 `sidebar` 的配置。
+而`编程式配置`则在某些需要动态生成配置的场景中非常有用，比如 Rspress 官方的 [TypeDoc 插件](/plugin/official-plugins/typedoc) 会根据 TypeDoc 提供的一份 json 数据自动转换为 `nav` 和 `sidebar` 的配置。
 
 ### MDX 支持
 

--- a/packages/document/rspress.config.ts
+++ b/packages/document/rspress.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
     },
   },
   route: {
+    cleanUrls: true,
     exclude: ['**/fragments/**'],
   },
   themeConfig: {


### PR DESCRIPTION
## Summary

Enable cleanUrls for website to make the URL shorter.

## Related Issue

https://rspress.dev/api/config/config-basic.html#routecleanurls

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
