### PR TITLE
style: modify font-synthesis from none to style

### DIFF
--- a/packages/theme-default/src/styles/base.css
+++ b/packages/theme-default/src/styles/base.css
@@ -29,7 +29,7 @@ body {
   color: var(--rp-c-text-1);
   background-color: var(--rp-c-bg);
   direction: ltr;
-  font-synthesis: none;
+  font-synthesis: style;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
## Summary

change the global styles of `font-synthesis` from `none` to `style`

Consistent with Vitepress: https://github.com/vuejs/vitepress/blob/7ed5148260052840c44bae64a670d8d610999dbe/src/client/theme-default/styles/base.css#L42

## Related Issue

closes: #984 

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
