### PR TITLE
docs: improve `markdown.highlightLanguages`

### DIFF
--- a/packages/document/docs/en/api/config/config-build.mdx
+++ b/packages/document/docs/en/api/config/config-build.mdx
@@ -207,8 +207,33 @@ Please set `markdown.mdxRs` to `false` when configuring `globalComponents`, othe
 ### markdown.highlightLanguages
 
 - Type: `(string | [string, string])[]`
+- Default:
 
-Register the languages that need to be highlighted. The default supported languages include `js`, `jsx`, `ts`, `tsx`, `json`, `css`, `scss`, `less`, `xml`, `diff`, `yaml`, `md`, `mdx`, `bash`. You can extend based on these languages. For example:
+```js
+const DEFAULT_HIGHLIGHT_LANGUAGES = [
+  ['js', 'javascript'],
+  ['ts', 'typescript'],
+  ['jsx', 'tsx'],
+  'tsx',
+  'json',
+  'css',
+  'scss',
+  'less',
+  ['xml', 'xml-doc'],
+  'diff',
+  'yaml',
+  ['md', 'markdown'],
+  ['mdx', 'tsx'],
+  'bash',
+];
+```
+
+Register the language needed for code highlighting.
+
+- By default, it is implemented based on [Prism.js](https://prismjs.com/). You can also switch to Shiki through [@rspress/plugin-shiki](/plugin/official-plugins/shiki).
+- Default supported languages include `js`, `jsx`, `ts`, `tsx`, `json`, `css`, `scss`, `less`, `html`, `xml`, `diff`, `yaml`, `md`, `mdx`, and `bash`.
+
+Rspress does not register all supported languages by default in order to reduce the bundle size of the build output. You can extend on these default languages, for example:
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';

--- a/packages/document/docs/zh/api/config/config-build.mdx
+++ b/packages/document/docs/zh/api/config/config-build.mdx
@@ -207,8 +207,33 @@ export default defineConfig({
 ### markdown.highlightLanguages
 
 - Type: `(string | [string, string])[]`
+- Default:
 
-注册需要高亮的语言。默认支持的语言包括`js`、`jsx`、`ts`、`tsx`、`json`、`css`、`scss`、`less`、`xml`、`diff`、`yaml`、`md`、`mdx`、`bash`，你可以在这些语言的基础上进行扩展。比如：
+```js
+const DEFAULT_HIGHLIGHT_LANGUAGES = [
+  ['js', 'javascript'],
+  ['ts', 'typescript'],
+  ['jsx', 'tsx'],
+  'tsx',
+  'json',
+  'css',
+  'scss',
+  'less',
+  ['xml', 'xml-doc'],
+  'diff',
+  'yaml',
+  ['md', 'markdown'],
+  ['mdx', 'tsx'],
+  'bash',
+];
+```
+
+注册需要代码高亮的语言。
+
+- 默认基于 [Prism.js](https://prismjs.com/) 实现，你也可以通过 [@rspress/plugin-shiki](/plugin/official-plugins/shiki) 切换到 Shiki。
+- 默认支持的语言包括 `js`、`jsx`、`ts`、`tsx`、`json`、`css`、`scss`、`less`、`html`、`xml`、`diff`、`yaml`、`md`、`mdx`、`bash`。
+
+Rspress 默认没有注册所有可支持的语言，这是为了减少构建产物的包体积。你可以在这些默认语言的基础上进行扩展，比如：
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';


### PR DESCRIPTION
## Summary

Improve `markdown.highlightLanguages` document:

- Add the default value.
- Add `html` because it is supported by default.
- Add plugin Shiki link.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
