### PR TITLE
feat: add new `beforeDocContent`, `afterDocContent` props for layout component

### DIFF
--- a/packages/document/docs/en/guide/advanced/custom-theme.mdx
+++ b/packages/document/docs/en/guide/advanced/custom-theme.mdx
@@ -62,6 +62,10 @@ const Layout = () => (
     beforeDoc={<div>beforeDoc</div>}
     /* Doc page end */
     afterDoc={<div>afterDoc</div>}
+    /* Doc content front */
+    beforeDoc={<div>beforeDoc</div>}
+    /* Doc content end */
+    afterDoc={<div>afterDoc</div>}
     /* Before the nav bar */
     beforeNav={<div>beforeNav</div>}
     /* Before the title of the nav bar in the upper left corner */

--- a/packages/document/docs/zh/guide/advanced/custom-theme.mdx
+++ b/packages/document/docs/zh/guide/advanced/custom-theme.mdx
@@ -62,6 +62,10 @@ const Layout = () => (
     beforeDoc={<div>beforeDoc</div>}
     /* 正文页最后面 */
     afterDoc={<div>afterDoc</div>}
+    /* 文档内容前面 */
+    beforeDoc={<div>beforeDoc</div>}
+    /* 文档内容后面 */
+    afterDoc={<div>afterDoc</div>}
     /* 导航栏之前 */
     beforeNav={<div>beforeNav</div>}
     /* 左上角导航栏标题之前 */

--- a/packages/theme-default/src/layout/DocLayout/index.tsx
+++ b/packages/theme-default/src/layout/DocLayout/index.tsx
@@ -17,6 +17,8 @@ export interface DocLayoutProps {
   afterDocFooter?: React.ReactNode;
   beforeDoc?: React.ReactNode;
   afterDoc?: React.ReactNode;
+  beforeDocContent?: React.ReactNode;
+  afterDocContent?: React.ReactNode;
   beforeOutline?: React.ReactNode;
   afterOutline?: React.ReactNode;
   uiSwitch?: UISwitchResult;
@@ -28,6 +30,8 @@ export function DocLayout(props: DocLayoutProps) {
     afterDocFooter,
     beforeDoc,
     afterDoc,
+    beforeDocContent,
+    afterDocContent,
     beforeOutline,
     afterOutline,
     beforeSidebar,
@@ -73,10 +77,18 @@ export function DocLayout(props: DocLayoutProps) {
       >
         <div className="w-full flex-1">
           {isOverviewPage ? (
-            <Overview content={docContent} />
+            <>
+              {beforeDocContent}
+                <Overview content={docContent} />
+              {afterDocContent}
+            </>
           ) : (
             <div>
-              <div className="rspress-doc">{docContent}</div>
+              <div className="rspress-doc">
+                {beforeDocContent}
+                {docContent}
+                {afterDocContent}
+              </div>
               <div className="rspress-doc-footer">
                 {beforeDocFooter}
                 {uiSwitch.showDocFooter && <DocFooter />}

--- a/packages/theme-default/src/layout/Layout/index.tsx
+++ b/packages/theme-default/src/layout/Layout/index.tsx
@@ -26,6 +26,8 @@ export const Layout: React.FC<LayoutProps> = props => {
     afterDocFooter,
     beforeDoc,
     afterDoc,
+    beforeDocContent,
+    afterDocContent,
     beforeSidebar,
     afterSidebar,
     beforeOutline,
@@ -42,6 +44,8 @@ export const Layout: React.FC<LayoutProps> = props => {
   const docProps: DocLayoutProps = {
     beforeDocFooter,
     afterDocFooter,
+    beforeDocContent,
+    afterDocContent,
     beforeDoc,
     afterDoc,
     beforeSidebar,


### PR DESCRIPTION
## Summary

Add `beforeDocContent`, `afterDocContent` for layout component props

- `beforeDocContent`
![beforeDocContent](https://github.com/web-infra-dev/rspress/assets/4951716/4258c5fe-7c4b-4e09-ba33-75c392d014d0)

- `afterDocContent`
![afterDocContent](https://github.com/web-infra-dev/rspress/assets/4951716/1bc7ad8a-4c41-4c66-9ef4-17695f2e9edf)


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
