### PR TITLE
chore(action): add check-dependency-version action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,3 +41,6 @@ jobs:
 
       - name: Lint
         run: pnpm run lint
+
+      - name: Check Dependency Version
+        run: pnpm run check-dependency-version


### PR DESCRIPTION
## Summary

add `.github/workflows/lint.yaml` action

Maybe it will be harsh in some e2e, but we can avoid it by `--ignore-path`

## Related Issue

#999 
