### PR TITLE
docs: add hero text line breaks guide

### DIFF
--- a/packages/document/docs/en/api/config/config-frontmatter.mdx
+++ b/packages/document/docs/en/api/config/config-frontmatter.mdx
@@ -50,7 +50,7 @@ import PageType from '@en/fragments/page-type';
 The hero config for the home page. It has the following types:
 
 ```ts
-export interface Hero {
+interface Hero {
   name: string;
   text: string;
   tagline: string;
@@ -81,7 +81,7 @@ pageType: home
 
 hero:
   name: Rspress
-  text: A documentation solution
+  text: A Documentation Solution
   tagline: A modern documentation development technology stack
   titleSuffix: '- Rspack-based Static Site Generator'
   actions:
@@ -94,6 +94,19 @@ hero:
 ---
 ```
 
+When setting `hero.text`, you can use the `|` symbol in YAML to manually control line breaks:
+
+```yaml
+---
+pageType: home
+
+hero:
+  name: Rspress
+  text: |
+    A Documentation
+    Solution
+```
+
 Or you can use `HTML` to specify the hero config for the page:
 
 ```yaml
@@ -102,7 +115,7 @@ pageType: home
 
 hero:
   name: <span class="hero-name">Rspress</span>
-  text: <span class="hero-text">A documentation solution</span>
+  text: <span class="hero-text">A Documentation Solution</span>
   tagline: <span class="hero-tagline">A modern documentation development technology stack</span>
   actions:
     - theme: brand
@@ -122,7 +135,7 @@ hero:
 features config of the `home` page. It has the following types:
 
 ```ts
-export interface Feature {
+interface Feature {
   title: string;
   details: string;
   icon: string;

--- a/packages/document/docs/en/fragments/internal-components.mdx
+++ b/packages/document/docs/en/fragments/internal-components.mdx
@@ -31,7 +31,7 @@ interface BadgeProps {
 
 ## Helmet
 
-It is generally used to set custom head content in documents (using `react-helmet-async` at the underlying level). The usage is as follows:
+It is generally used to set custom head content in documents (based on [react-helmet-async](https://www.npmjs.com/package/react-helmet-async)). The usage is as follows:
 
 ```tsx title="index.tsx"
 // Below is a custom component, you can import it into your document
@@ -40,7 +40,7 @@ import { Helmet } from 'rspress/runtime';
 function App() {
   return (
     <Helmet>
-      <meta property="og:description"  value="Out-of-box Rspack build tools">
+      <meta property="og:description" value="Out-of-box Rspack build tools" />
     </Helmet>
   );
 }
@@ -53,7 +53,7 @@ Feature component in Hero page, look [the effect in this website](/).
 ```tsx
 import { HomeFeature } from 'rspress/theme';
 
-export interface Feature {
+interface Feature {
   title: string;
   details: string;
   icon: string;
@@ -72,7 +72,7 @@ Hero component in Hero page.
 ```tsx
 import { HomeHero } from 'rspress/theme';
 
-export interface Hero {
+interface Hero {
   name: string;
   text: string;
   tagline: string;
@@ -140,7 +140,7 @@ interface Group {
   items: GroupItem[];
 }
 
-export interface OverviewProps {
+interface OverviewProps {
   // content before data rendering
   content?: React.ReactNode;
   // data

--- a/packages/document/docs/zh/api/config/config-frontmatter.mdx
+++ b/packages/document/docs/zh/api/config/config-frontmatter.mdx
@@ -50,7 +50,7 @@ import PageType from '@zh/fragments/page-type';
 `home` 页面的 hero 配置。它有以下类型：
 
 ```ts
-export interface Hero {
+interface Hero {
   name: string;
   text: string;
   tagline: string;
@@ -94,6 +94,19 @@ hero:
 ---
 ```
 
+在设置 `hero.text` 时，你可以使用 YAML 的 `|` 符号来手动控制换行：
+
+```yaml
+---
+pageType: home
+
+hero:
+  name: Rspress
+  text: |
+    文档工程
+    解决方案
+```
+
 或者你也可以用 `HTML` 来指定页面的 hero config：
 
 ```yaml
@@ -122,7 +135,7 @@ hero:
 `home` 页面的功能配置。它有以下类型：
 
 ```ts
-export interface Feature {
+interface Feature {
   title: string;
   details: string;
   icon: string;

--- a/packages/document/docs/zh/fragments/internal-components.mdx
+++ b/packages/document/docs/zh/fragments/internal-components.mdx
@@ -31,7 +31,7 @@ interface BadgeProps {
 
 ## Helmet
 
-一般用于在文档中设置自定义 head 内容(底层使用 `react-helmet-async`)。使用方法如下：
+一般用于在文档中设置自定义 head 内容（基于 [react-helmet-async](https://www.npmjs.com/package/react-helmet-async)）。使用方法如下：
 
 ```tsx title="index.tsx"
 // 以下为一个自定义组件，你可以将其引入到文档中
@@ -40,7 +40,7 @@ import { Helmet } from 'rspress/runtime';
 function App() {
   return (
     <Helmet>
-      <meta property="og:description"  value="Out-of-box Rspack build tools">
+      <meta property="og:description" value="Out-of-box Rspack build tools" />
     </Helmet>
   );
 }
@@ -53,7 +53,7 @@ Home 页面 Feature 组件，查看[本站的效果](/zh/)
 ```tsx
 import { HomeFeature } from 'rspress/theme';
 
-export interface Feature {
+interface Feature {
   title: string;
   details: string;
   icon: string;
@@ -73,7 +73,7 @@ Home 页面 Hero 组件
 ```tsx
 import { HomeHero } from 'rspress/theme';
 
-export interface Hero {
+interface Hero {
   name: string;
   text: string;
   tagline: string;
@@ -141,7 +141,7 @@ interface Group {
   items: GroupItem[];
 }
 
-export interface OverviewProps {
+interface OverviewProps {
   // 预览部分上方的内容
   content?: React.ReactNode;
   // 预览数据


### PR DESCRIPTION
## Summary

Add hero text line breaks guide to document.

## Related Issue

See: https://github.com/web-infra-dev/rspress/issues/184

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
