### PR TITLE
fix: sidebar with link collapse

### DIFF
--- a/packages/theme-default/src/components/Sidebar/SidebarGroup.tsx
+++ b/packages/theme-default/src/components/Sidebar/SidebarGroup.tsx
@@ -115,10 +115,8 @@ export function SidebarGroup(props: SidebarItemProps) {
         onClick={e => {
           if (item.link) {
             navigate(withBase(normalizeHref(item.link)));
-            collapsed && toggleCollapse(e);
-          } else {
-            collapsible && toggleCollapse(e);
           }
+          collapsible && toggleCollapse(e);
         }}
         style={{
           borderRadius:


### PR DESCRIPTION
## Summary

![image](https://github.com/web-infra-dev/rspress/assets/50201324/41315763-1e14-44ae-a5c9-502fcc5a2136)

click here can not toggle collapse of the sidebar which with link for navigate

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
