### PR TITLE
fix: sidebar navigate link error

### DIFF
--- a/e2e/tests/auto-nav-sidebar.test.ts
+++ b/e2e/tests/auto-nav-sidebar.test.ts
@@ -142,4 +142,14 @@ test.describe('Auto nav and sidebar test', async () => {
     const aTexts = await Promise.all(a.map(element => element.textContent()));
     expect(aTexts.join(',')).toEqual(['Usage', 'Example'].join(','));
   });
+
+  test('Sidebar not have same name md/mdx will not navigate', async ({
+    page,
+  }) => {
+    await page.goto(`http://localhost:${appPort}/guide/`, {
+      waitUntil: 'networkidle',
+    });
+    await page.click('.rspress-scrollbar nav section div');
+    expect(page.url()).toBe(`http://localhost:${appPort}/guide/`);
+  });
 });

--- a/packages/plugin-auto-nav-sidebar/src/utils.ts
+++ b/packages/plugin-auto-nav-sidebar/src/utils.ts
@@ -18,7 +18,7 @@ export async function detectFilePath(rawPath: string) {
     );
     const findPath = pathWithExtension.find((_, i) => pathExistInfo[i]);
     // file may be public resource, see issue: https://github.com/web-infra-dev/rspress/issues/1052
-    if (findPath) {
+    if (!fileExtname || findPath) {
       realPath = findPath;
     }
   }


### PR DESCRIPTION
## Summary

when a sidebar dir not have the same name file or index file, we should return undefined

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
