### PR TITLE
fix: merge duplicated border CSS

### DIFF
--- a/packages/theme-default/src/layout/DocLayout/docComponents/index.module.scss
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/index.module.scss
@@ -42,8 +42,7 @@
   }
 
   &:hover {
-    border-bottom: 1px dashed var(--rp-c-brand);
-    border-style: solid;
+    border-bottom: 1px solid var(--rp-c-brand);
   }
 }
 


### PR DESCRIPTION
## Summary

Merge duplicated border CSS to reduce the CSS size.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
