### PR TITLE
fix: globalStyles being shaked when config some sideEffects

### DIFF
--- a/e2e/fixtures/modern-js/package.json
+++ b/e2e/fixtures/modern-js/package.json
@@ -32,5 +32,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "^5"
-  }
+  },
+  "sideEffects": []
 }

--- a/e2e/tests/modern-js.test.ts
+++ b/e2e/tests/modern-js.test.ts
@@ -35,9 +35,11 @@ test.describe('modernjs module doc test', async () => {
     });
 
     const iframe = await page.$('.fixed-device');
-    const leftCssValue = await iframe?.evaluate(el => {
-      return window.getComputedStyle(el).getPropertyValue('left');
+    const previewPadding = await iframe?.evaluate(el => {
+      return window
+        .getComputedStyle(el)
+        .getPropertyValue('--rp-preview-padding');
     });
-    expect(leftCssValue).not.toEqual('0px');
+    expect(previewPadding).toEqual('32px');
   });
 });

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -226,7 +226,7 @@ async function createInternalBuildConfig(
 
         chain.module
           .rule('css-virtual-module')
-          .test(/\.rspress\/runtime\/virtual-global-styles/)
+          .test(/\.rspress[\\/]runtime[\\/]virtual-global-styles/)
           .merge({ sideEffects: true });
       },
     },

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -223,6 +223,11 @@ async function createInternalBuildConfig(
         }
 
         chain.resolve.extensions.prepend('.md').prepend('.mdx').prepend('.mjs');
+
+        chain.module
+          .rule('css-virtual-module')
+          .test(/\.rspress\/runtime\/virtual-global-styles/)
+          .merge({ sideEffects: true });
       },
     },
   };


### PR DESCRIPTION
## Summary

In a module project, the sideEffects usually be

```
"sideEffects": [
  "**/*.css",
  "**/*.less",
  "**/*.sass",
  "**/*.scss"
],
```
 when we use module doc plugin, it will build a web project, the sideEffects config will influence the tree-shaking behaviour of global styles virtual module, which caused some styles broken in the current version of rspress.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
