### PR TITLE
Save and sync chosed package manager tab.

### DIFF
--- a/packages/runtime/src/hooks.ts
+++ b/packages/runtime/src/hooks.ts
@@ -1,5 +1,7 @@
 import {
   ReactElement,
+  SetStateAction,
+  Dispatch,
   createContext,
   useCallback,
   useContext,
@@ -18,7 +20,7 @@ declare global {
 }
 interface IDataContext {
   data: PageData;
-  setData?: (data: PageData) => void;
+  setData?: Dispatch<SetStateAction<PageData>>;
 }
 
 interface IThemeContext {

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -168,6 +168,10 @@ export interface UserConfig<ThemeConfig = DefaultThemeConfig> {
      */
     versions: string[];
   };
+  /**
+   * Default package manager
+   */
+  defaultPackageManager?: PackageManager;
 }
 
 export type BaseRuntimePageInfo = Omit<
@@ -199,7 +203,10 @@ export interface SiteData<ThemeConfig = NormalizedDefaultThemeConfig> {
     default: string;
     versions: string[];
   };
+  defaultPackageManager?: PackageManager;
 }
+
+export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun';
 
 export type PageIndexInfo = {
   id: number;

--- a/packages/theme-default/src/components/PackageManagerTabs/index.tsx
+++ b/packages/theme-default/src/components/PackageManagerTabs/index.tsx
@@ -1,3 +1,6 @@
+import { useContext } from 'react';
+import { DataContext } from '@rspress/runtime';
+
 import { Tabs, Tab } from '@theme';
 import { Pre } from '../../layout/DocLayout/docComponents/pre';
 import { Code } from '../../layout/DocLayout/docComponents/code';
@@ -5,17 +8,13 @@ import { Npm } from './icons/Npm';
 import { Yarn } from './icons/Yarn';
 import { Pnpm } from './icons/Pnpm';
 import { Bun } from './icons/Bun';
+import { type PackageManager } from '@rspress/shared';
 import './index.scss';
 
+type PackageManagerDict<T> = Record<PackageManager, T>;
+
 export interface PackageManagerTabProps {
-  command:
-    | string
-    | {
-        npm?: string;
-        yarn?: string;
-        pnpm?: string;
-        bun?: string;
-      };
+  command: string | Partial<PackageManagerDict<string>>;
   additionalTabs?: {
     tool: string;
     icon?: React.ReactNode;
@@ -42,16 +41,12 @@ export function PackageManagerTabs({
   command,
   additionalTabs = [],
 }: PackageManagerTabProps) {
-  let commandInfo: {
-    npm?: string;
-    yarn?: string;
-    pnpm?: string;
-    bun?: string;
-    [key: string]: string;
-  };
+  const { data, setData } = useContext(DataContext);
+
+  let commandInfo: Partial<PackageManagerDict<string>>;
 
   // Init Icons
-  const packageMangerToIcon = {
+  const packageMangerToIcon: PackageManagerDict<React.ReactNode> = {
     npm: <Npm />,
     yarn: <Yarn />,
     pnpm: <Pnpm />,
@@ -83,6 +78,17 @@ export function PackageManagerTabs({
   return (
     <Tabs
       groupId="package.manager"
+      onChange={(index: number) => {
+        setData(prev => ({
+          ...prev,
+          siteData: {
+            ...prev.siteData,
+            defaultPackageManager: Object.keys(commandInfo)[
+              index
+            ] as PackageManager,
+          },
+        }));
+      }}
       values={Object.entries(commandInfo).map(([key]) => (
         <div
           key={key}


### PR DESCRIPTION
## Summary

This PR updates internal `<PackageManagerTabs />` component to cache user-chosed package manager tab, and sync it around all `<PackageManagerTabs />` components inside this site.

This change optimizes the user's reading experience and copying efficiency, as he/she won't need to select target package manager repeatedly.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

(Provide later if this PR is considered to be acceptable)

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
