### PR TITLE
feat: hero page image src supports light and dark

### DIFF
--- a/e2e/tests/page-type-home.test.ts
+++ b/e2e/tests/page-type-home.test.ts
@@ -30,7 +30,7 @@ test.describe('home pageType', async () => {
       page.locator('.rspress-home-hero-tagline').textContent(),
     ).resolves.toBe('E2E case tagline');
 
-    const img = page.locator('.rspress-home-hero-image img');
+    const img = page.locator('.rspress-home-hero-image img').first();
     await expect(img.getAttribute('src')).resolves.toBe('/brand.png');
     await expect(img.getAttribute('alt')).resolves.toBe('E2E case brand image');
     await expect(img.getAttribute('srcset')).resolves.toBe(

--- a/packages/document/docs/en/api/config/config-frontmatter.mdx
+++ b/packages/document/docs/en/api/config/config-frontmatter.mdx
@@ -75,7 +75,7 @@ interface Hero {
   text: string;
   tagline: string;
   image?: {
-    src: string;
+    src: string | { dark: string; light: string };
     alt: string;
     /**
      * `srcset` and `sizes` are attributes of `<img>` tag. Please refer to https://mdn.io/srcset for the usage.

--- a/packages/document/docs/en/fragments/internal-components.mdx
+++ b/packages/document/docs/en/fragments/internal-components.mdx
@@ -77,7 +77,7 @@ interface Hero {
   text: string;
   tagline: string;
   image?: {
-    src: string;
+    src: string | { dark: string; light: string };
     alt: string;
   };
   actions: {

--- a/packages/document/docs/zh/api/config/config-frontmatter.mdx
+++ b/packages/document/docs/zh/api/config/config-frontmatter.mdx
@@ -75,7 +75,7 @@ interface Hero {
   text: string;
   tagline: string;
   image?: {
-    src: string;
+    src: string | { dark: string; light: string };
     alt: string;
     /**
      * `srcset` 和 `sizes` 同 `<img>` 的同名属性，取值请参考 https://mdn.io/srcset。

--- a/packages/document/docs/zh/fragments/internal-components.mdx
+++ b/packages/document/docs/zh/fragments/internal-components.mdx
@@ -78,7 +78,7 @@ interface Hero {
   text: string;
   tagline: string;
   image?: {
-    src: string;
+    src: string | { dark: string; light: string };
     alt: string;
   };
   actions: {

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -229,7 +229,7 @@ export interface Hero {
   text: string;
   tagline: string;
   image?: {
-    src: string;
+    src: string | { dark: string; light: string };
     alt: string;
     /**
      * `srcset` and `sizes` are attributes of `<img>` tag. Please refer to https://mdn.io/srcset for the usage.

--- a/packages/theme-default/src/components/HomeHero/index.tsx
+++ b/packages/theme-default/src/components/HomeHero/index.tsx
@@ -25,6 +25,10 @@ export function HomeHero({ frontmatter }: { frontmatter: FrontMatterMeta }) {
         .split(/\n/g)
         .filter(text => text !== '')
     : [];
+  const imageSrc =
+    typeof hero.image?.src === 'string'
+      ? { light: hero.image.src, dark: hero.image.src }
+      : hero.image?.src || { light: '', dark: '' };
   return (
     <div className="m-auto pt-0 px-6 pb-12 sm:pt-10 sm:px-16 md:pt-16 md:px-16 md:pb-16 relative">
       <div
@@ -76,12 +80,22 @@ export function HomeHero({ frontmatter }: { frontmatter: FrontMatterMeta }) {
         {hasImage ? (
           <div className="rspress-home-hero-image md:flex-center m-auto order-1 md:order-2 sm:flex md:none lg:flex">
             <img
-              src={normalizeImagePath(hero.image?.src)}
+              src={normalizeImagePath(imageSrc.light)}
               alt={hero.image?.alt}
               srcSet={normalizeSrcsetAndSizes(hero.image?.srcset)}
               sizes={normalizeSrcsetAndSizes(hero.image?.sizes)}
               width={375}
               height={375}
+              className="dark:hidden"
+            />
+            <img
+              src={normalizeImagePath(imageSrc.dark)}
+              alt={hero.image?.alt}
+              srcSet={normalizeSrcsetAndSizes(hero.image?.srcset)}
+              sizes={normalizeSrcsetAndSizes(hero.image?.sizes)}
+              width={375}
+              height={375}
+              className="hidden dark:block"
             />
           </div>
         ) : null}


### PR DESCRIPTION
## Summary

hero page image src supports light and dark

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
