### PR TITLE
fix: sort for prism runtime module export to pass test

### DIFF
--- a/packages/core/src/node/runtimeModule/siteData/index.ts
+++ b/packages/core/src/node/runtimeModule/siteData/index.ts
@@ -143,6 +143,8 @@ export async function siteDataVMPlugin(context: FactoryContext) {
     highlightLanguages,
     defaultLanguages,
   );
+  const sortedAliases = Object.fromEntries(Object.entries(aliases).sort());
+  const sortedHighlightLanguages = Array.from(highlightLanguages).sort();
 
   return {
     [`${RuntimeModuleID.SiteData}.mjs`]: `export default ${JSON.stringify(
@@ -152,10 +154,10 @@ export async function siteDataVMPlugin(context: FactoryContext) {
       indexHashByGroup,
     )}`,
     [RuntimeModuleID.PrismLanguages]: `export const aliases = ${JSON.stringify(
-      aliases,
+      sortedAliases,
     )};
     export const languages = {
-      ${Array.from(highlightLanguages).map(lang => {
+      ${sortedHighlightLanguages.map(lang => {
         return `"${lang}": require(
           "react-syntax-highlighter/dist/cjs/languages/prism/${lang}"
         ).default`;

--- a/packages/core/tests/__snapshots__/prismLanguages.test.ts.snap
+++ b/packages/core/tests/__snapshots__/prismLanguages.test.ts.snap
@@ -1,10 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`automatic import of prism languages > prism languages aliases should be configurable to users 1`] = `
-"export const aliases = {\\"javascript\\":[\\"js\\"]};
+"export const aliases = {\\"javascript\\":[\\"js\\"],\\"objectivec\\":[\\"oc\\"]};
     export const languages = {
       \\"javascript\\": require(
           \\"react-syntax-highlighter/dist/cjs/languages/prism/javascript\\"
+        ).default,\\"objectivec\\": require(
+          \\"react-syntax-highlighter/dist/cjs/languages/prism/objectivec\\"
         ).default,\\"rust\\": require(
           \\"react-syntax-highlighter/dist/cjs/languages/prism/rust\\"
         ).default,\\"typescript\\": require(

--- a/packages/core/tests/prismLanguages.test.ts
+++ b/packages/core/tests/prismLanguages.test.ts
@@ -10,7 +10,10 @@ describe('automatic import of prism languages', () => {
     alias: {},
     config: {
       markdown: {
-        highlightLanguages: [['js', 'javascript']],
+        highlightLanguages: [
+          ['js', 'javascript'],
+          ['oc', 'objectivec'],
+        ],
       },
     },
     userDocRoot,

--- a/packages/core/tests/prismLanguages/index.mdx
+++ b/packages/core/tests/prismLanguages/index.mdx
@@ -14,6 +14,15 @@ console.log('Hello, world!');
 console.log('Hello, world!');
 ```
 
+```oc
+int main(int argc, const char * argv[]) {
+    @autoreleasepool {
+        NSLog(@"Hello, Objective-C!");
+    }
+    return 0;
+}
+```
+
 # 内置组件
 
 import InternalComponents from './extend'


### PR DESCRIPTION
## Summary

![image](https://github.com/web-infra-dev/rspress/assets/50201324/109c62b9-8f8c-4536-89e6-5023e6aa9e5c)

the origin test is not stable

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
