### PR TITLE
fix: not generate ssr route runtime module when client build

### DIFF
--- a/packages/core/src/node/runtimeModule/routeData.ts
+++ b/packages/core/src/node/runtimeModule/routeData.ts
@@ -1,8 +1,15 @@
 import { FactoryContext, RuntimeModuleID } from '.';
 
 export async function routeVMPlugin(context: FactoryContext) {
-  const { routeService } = context;
+  const { routeService, isSSR } = context;
+
   // client: The components of route is lazy loaded
+  if (!isSSR) {
+    return {
+      [RuntimeModuleID.RouteForClient]: routeService.generateRoutesCode(false),
+    };
+  }
+
   return {
     [RuntimeModuleID.RouteForClient]: routeService.generateRoutesCode(false),
     [RuntimeModuleID.RouteForSSR]: routeService.generateRoutesCode(true),


### PR DESCRIPTION
## Summary

Generate route virtual modules based on `isSSR` in different build modes. 

Not generate ssr route runtime module when client build.

This avoids the SSR routing virtual module generated by client build from affecting the module number calculation of lazy compilation.

When ssr build, the client route runtime module still generated since some route match logic function need this structure.

## Related Issue

https://github.com/web-infra-dev/rspack/pull/5915

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
