### PR TITLE
fix(theme-default): heading anchor doesn't display when no sidebar or minimum content area

### DIFF
--- a/packages/theme-default/src/layout/DocLayout/docComponents/index.module.scss
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/index.module.scss
@@ -4,8 +4,7 @@
   outline: none;
   :global(.header-anchor) {
     float: left;
-    margin-left: -0.87em;
-    padding-right: 0.23em;
+    margin-left: -0.8em;
     font-weight: 500;
     opacity: 0;
     font-size: inherit;

--- a/packages/theme-default/src/layout/DocLayout/index.module.scss
+++ b/packages/theme-default/src/layout/DocLayout/index.module.scss
@@ -81,7 +81,7 @@
 
   .content {
     width: calc(100% - var(--rp-sidebar-width));
-    padding: 48px 48px 72px max(12px, calc(48px - var(--rp-sidebar-width)));
+    padding: 48px 48px 72px max(24px, calc(48px - var(--rp-sidebar-width)));
 
     :global(.rspress-doc),
     :global(.rspress-doc-footer) {


### PR DESCRIPTION
Fixed #1092 

## Summary
This issue also exists without sidebar.

This is because the area size of the content `padding-left` is `24px`, and due to the `font-size` of h1 being `1.875em`, which is `30px`, the size of the anchor's `margin-left` is `26.1px`, so exceeding it will be hidden. In contrast, the `font-size` of h1 in `vitepress` is fixed at `28px`, so this issue will not occur.

The solution is as follows:
1. Change the baseline `font-size` of the title
2. Expand the content area `padding-left` to `26px`

## Related Issue
#1092 
<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
