### PR TITLE
feat(create-rspress): enable mdx type hints by default

### DIFF
--- a/packages/create-rspress/template/tsconfig.json
+++ b/packages/create-rspress/template/tsconfig.json
@@ -2,5 +2,8 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "esModuleInterop": true
+  },
+  "mdx": {
+    "checkMdx": true
   }
 }

--- a/packages/document/tsconfig.json
+++ b/packages/document/tsconfig.json
@@ -4,6 +4,7 @@
     "jsx": "preserve",
     "paths": {
       "i18n": ["./i18n.json"],
+      "@theme": ["./theme"],
       "@/assets/*": ["./docs/public/*"],
       "@/components/*": ["./components/*"],
       "@zh/*": ["./docs/zh/*"],
@@ -17,5 +18,8 @@
     "components/**/*",
     "theme/**/*",
     "search.tsx"
-  ]
+  ],
+  "mdx": {
+    "checkMdx": true
+  }
 }


### PR DESCRIPTION
## Summary

Enable MDX type hints to provide better DX:

![image](https://github.com/web-infra-dev/rspress/assets/7237365/84d8ca09-7ff6-4501-a129-8fb15b2521d4)

## Related Issue

https://github.com/mdx-js/mdx-analyzer?tab=readme-ov-file#typescript

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
