### PR TITLE
fix: cmd+k search issue

### DIFF
--- a/packages/theme-default/src/components/Search/SearchPanel.tsx
+++ b/packages/theme-default/src/components/Search/SearchPanel.tsx
@@ -200,6 +200,7 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
   }, [
     setCurrentSuggestionIndex,
     setFocused,
+    focused,
     currentSuggestions,
     currentSuggestionIndex,
   ]);


### PR DESCRIPTION
## Summary

fix the search panel cannot be open and close normally when use cmd+k

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
