### PR TITLE
fix: search result duplicate when keyword contains multiple langs

### DIFF
--- a/packages/theme-default/src/components/Search/logic/providers/LocalProvider.ts
+++ b/packages/theme-default/src/components/Search/logic/providers/LocalProvider.ts
@@ -104,12 +104,20 @@ export class LocalProvider implements Provider {
       this.#cjkIndex?.search(searchParams),
       this.#cyrilicIndex.search(searchParams),
     ]);
+
     const flattenSearchResult = searchResult.flat(2).filter(Boolean);
+
+    // There may be duplicate search results when there are multiple languages ​​in the search keyword
+    const uniqueSearchResult = Array.from(
+      new Set(flattenSearchResult.map(item => item.id)),
+    ).map(id => {
+      return flattenSearchResult.find(item => item.id === id);
+    });
 
     return [
       {
         index: LOCAL_INDEX,
-        hits: flattenSearchResult,
+        hits: uniqueSearchResult,
       },
     ];
   }


### PR DESCRIPTION
## Summary

There may be duplicate search results when there are multiple languages ​​in the search keyword

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
