### PR TITLE
feat: increase title font size to distinguish from main text

### DIFF
--- a/packages/theme-default/src/components/HomeHero/index.tsx
+++ b/packages/theme-default/src/components/HomeHero/index.tsx
@@ -56,7 +56,7 @@ export function HomeHero({ frontmatter }: { frontmatter: FrontMatterMeta }) {
             ))}
 
           <p
-            className={`rspress-home-hero-tagline whitespace-pre-wrap pt-4 m-auto md:m-0 text-sm sm:tex-xl md:text-2xl text-text-2 font-medium z-10 ${textMaxWidth}`}
+            className={`rspress-home-hero-tagline whitespace-pre-wrap pt-4 m-auto md:m-0 text-sm sm:tex-xl md:text-[1.5rem] text-text-2 font-medium z-10 ${textMaxWidth}`}
           >
             {renderHtmlOrText(hero.tagline)}
           </p>

--- a/packages/theme-default/src/layout/DocLayout/docComponents/title.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/title.tsx
@@ -26,9 +26,7 @@ export const H3 = (props: React.ComponentProps<'h3'>) => {
 };
 
 export const H4 = (props: React.ComponentProps<'h4'>) => {
-  return (
-    <h4 {...props} className={`mt-8 leading-6 text-base ${styles.title}`} />
-  );
+  return <h4 {...props} className={`mt-8 leading-6 text-lg ${styles.title}`} />;
 };
 
 export const H5 = (props: React.ComponentProps<'h5'>) => {

--- a/packages/theme-default/tailwind.config.ts
+++ b/packages/theme-default/tailwind.config.ts
@@ -11,6 +11,12 @@ export const tailwindConfig = {
       mute: 'var(--rp-c-bg-mute)',
     }),
     extend: {
+      fontSize: {
+        '3xl': '2rem',
+        '2xl': '1.625rem',
+        xl: '1.375rem',
+        lg: '1.25rem',
+      },
       borderRadius: {
         '4xl': '2rem',
       },


### PR DESCRIPTION
## Summary

Increase the title font size to distinguish from the main text, especially for h3 / h4.

![image](https://github.com/web-infra-dev/rspress/assets/7237365/cbeb9b44-d649-4a7f-873b-b06e630de3e4)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
