### PR TITLE
fix(plugin-playground): export EditorProps error

### DIFF
--- a/packages/plugin-playground/src/web/editor.tsx
+++ b/packages/plugin-playground/src/web/editor.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import MonacoEditor, {
   loader,
-  EditorProps as MonacoEditorProps,
+  type EditorProps as MonacoEditorProps,
 } from '@monaco-editor/react';
 import { useDark } from '@rspress/core/runtime';
 import { DEFAULT_MONACO_URL } from './constant';

--- a/packages/plugin-playground/src/web/index.ts
+++ b/packages/plugin-playground/src/web/index.ts
@@ -1,7 +1,7 @@
 export {
   default as MonacoEditor,
   loader as MonacoEditorLoader,
-  EditorProps as MonacoEditorProps,
+  type EditorProps as MonacoEditorProps,
 } from '@monaco-editor/react';
 export { Editor } from './editor';
 export { Runner } from './runner';


### PR DESCRIPTION
## Summary

![image](https://github.com/web-infra-dev/rspress/assets/50201324/24a1adbb-b046-45d3-b260-328db9a62ae6)

Above issue arises after updating Rsbuild version.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
