### PR TITLE
refactor: when ssg build, init only one rsbuild instance

### DIFF
--- a/packages/core/src/node/build.ts
+++ b/packages/core/src/node/build.ts
@@ -40,31 +40,15 @@ export async function bundle(
   enableSSG: boolean,
 ) {
   try {
-    if (enableSSG) {
-      const [clientBuilder, ssrBuilder] = await Promise.all([
-        initRsbuild(docDirectory, config, pluginDriver, false),
-        initRsbuild(docDirectory, config, pluginDriver, true, {
-          output: {
-            minify: false,
-          },
-          tools: {
-            rspack(options) {
-              options.output.filename = 'main.cjs';
-            },
-          },
-        }),
-      ]);
-      await Promise.all([clientBuilder.build(), ssrBuilder.build()]);
-    } else {
-      // Only build client bundle
-      const clientBuilder = await initRsbuild(
-        docDirectory,
-        config,
-        pluginDriver,
-        false,
-      );
-      await clientBuilder.build();
-    }
+    // if enableSSG, build both client and server bundle
+    // else only build client bundle
+    const rsbuild = await initRsbuild(
+      docDirectory,
+      config,
+      pluginDriver,
+      enableSSG,
+    );
+    await rsbuild.build();
   } finally {
     await writeSearchIndex(config);
   }

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -61,10 +61,8 @@ async function createInternalBuildConfig(
   const CUSTOM_THEME_DIR =
     config?.themeDir ?? path.join(process.cwd(), 'theme');
   const baseOutDir = config?.outDir ?? OUTPUT_DIR;
-  const getRelativePath = (outDir: string) =>
-    path.isAbsolute(outDir) ? path.relative(cwd, outDir) : outDir;
-  const csrOutDir = getRelativePath(baseOutDir);
-  const ssrOutDir = getRelativePath(path.join(baseOutDir, 'ssr'));
+  const csrOutDir = baseOutDir;
+  const ssrOutDir = path.join(baseOutDir, 'ssr');
 
   const DEFAULT_THEME = require.resolve('@rspress/theme-default');
   const base = config?.base ?? '';
@@ -245,7 +243,6 @@ async function createInternalBuildConfig(
 
         if (isServer) {
           chain.output.filename('main.cjs');
-          chain.optimization.minimize(false);
         }
       },
     },
@@ -266,7 +263,6 @@ async function createInternalBuildConfig(
           target: 'web',
           overrideBrowserslist: webBrowserslist,
           distPath: {
-            // `root` must be a relative path in Rsbuild
             root: csrOutDir,
           },
         },
@@ -292,9 +288,9 @@ async function createInternalBuildConfig(
                 target: 'node',
                 overrideBrowserslist: ssrBrowserslist,
                 distPath: {
-                  // `root` must be a relative path in Rsbuild
                   root: ssrOutDir,
                 },
+                minify: false,
               },
             },
           }

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -61,10 +61,10 @@ async function createInternalBuildConfig(
   const CUSTOM_THEME_DIR =
     config?.themeDir ?? path.join(process.cwd(), 'theme');
   const baseOutDir = config?.outDir ?? OUTPUT_DIR;
-  const csrOutDir = baseOutDir;
-  const ssrOutDir = path.join(baseOutDir, 'ssr');
   const getRelativePath = (outDir: string) =>
     path.isAbsolute(outDir) ? path.relative(cwd, outDir) : outDir;
+  const csrOutDir = getRelativePath(baseOutDir);
+  const ssrOutDir = getRelativePath(path.join(baseOutDir, 'ssr'));
 
   const DEFAULT_THEME = require.resolve('@rspress/theme-default');
   const base = config?.base ?? '';
@@ -150,8 +150,8 @@ async function createInternalBuildConfig(
     output: {
       assetPrefix,
       distPath: {
-        // TODO: just for rsbuild preview
-        root: getRelativePath(csrOutDir),
+        // just for rsbuild preview
+        root: csrOutDir,
       },
     },
     source: {
@@ -266,7 +266,7 @@ async function createInternalBuildConfig(
           overrideBrowserslist: webBrowserslist,
           distPath: {
             // `root` must be a relative path in Rsbuild
-            root: getRelativePath(csrOutDir),
+            root: csrOutDir,
           },
         },
       },
@@ -292,7 +292,7 @@ async function createInternalBuildConfig(
                 overrideBrowserslist: ssrBrowserslist,
                 distPath: {
                   // `root` must be a relative path in Rsbuild
-                  root: getRelativePath(ssrOutDir),
+                  root: ssrOutDir,
                 },
               },
             },

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -192,7 +192,8 @@ async function createInternalBuildConfig(
       },
     },
     tools: {
-      bundlerChain(chain, { CHAIN_ID, isServer }) {
+      bundlerChain(chain, { CHAIN_ID, target }) {
+        const isServer = target === 'node';
         const jsModuleRule = chain.module.rule(CHAIN_ID.RULE.JS);
 
         const swcLoaderOptions = jsModuleRule

--- a/packages/core/src/node/runtimeModule/index.ts
+++ b/packages/core/src/node/runtimeModule/index.ts
@@ -60,7 +60,8 @@ export function rsbuildPluginDocVM(
   return {
     name: 'rsbuild-plugin-doc-vm',
     setup(api) {
-      api.modifyBundlerChain(async (bundlerChain, { isServer }) => {
+      api.modifyBundlerChain(async (bundlerChain, { target }) => {
+        const isServer = target === 'node';
         // The order should be sync
         const alias = bundlerChain.resolve.alias.entries();
         const runtimeModule: Record<string, string> = {};

--- a/packages/shared/src/runtime-utils/index.ts
+++ b/packages/shared/src/runtime-utils/index.ts
@@ -17,11 +17,15 @@ export const DEFAULT_HIGHLIGHT_LANGUAGES = [
   ['mdx', 'tsx'],
 ];
 
+// TODO: these utils should be divided into node and runtime
 export const isSCM = () => Boolean(process.env.BUILD_VERSION);
 
 export const isProduction = () => process.env.NODE_ENV === 'production';
 
-export const isDebugMode = () => Boolean(process.env.DOC_DEBUG);
+export const isDebugMode = () => {
+  const values = process.env.DEBUG?.toLocaleLowerCase().split(',') ?? [];
+  return ['rsbuild', 'builder', '*'].some(key => values.includes(key));
+};
 
 export const cleanUrl = (url: string): string =>
   url.replace(HASH_REGEXP, '').replace(QUERY_REGEXP, '');

--- a/packages/shared/src/runtime-utils/index.ts
+++ b/packages/shared/src/runtime-utils/index.ts
@@ -23,6 +23,9 @@ export const isSCM = () => Boolean(process.env.BUILD_VERSION);
 export const isProduction = () => process.env.NODE_ENV === 'production';
 
 export const isDebugMode = () => {
+  if (!process.env.DEBUG) {
+    return false;
+  }
   const values = process.env.DEBUG?.toLocaleLowerCase().split(',') ?? [];
   return ['rsbuild', 'builder', '*'].some(key => values.includes(key));
 };


### PR DESCRIPTION
## Summary

make clientBuilder and serverBuilder merged into one rsbuild builder

some benefits
1. make DEBUG mode align with Rsbuild, and debug the ssg build easily
2. performance better (to be measured)
3. more maintainable

## Related Issue

close #1167 

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
