### PR TITLE
test: should print error log when process unexpected exit

### DIFF
--- a/e2e/utils/runCommands.ts
+++ b/e2e/utils/runCommands.ts
@@ -61,11 +61,20 @@ export async function runCommand(
       process.stderr.write(stderrOutput);
     });
 
-    instance.on('close', () => {
+    instance.on('close', (code, signal) => {
       instance.stdout!.removeListener('data', handleStdout);
+
       if (!didResolve) {
+        if (code !== 0) {
+          reject(
+            new Error(
+              `process unexpected exit with code: ${code} signal: ${signal}`,
+            ),
+          );
+        } else {
+          resolve(null);
+        }
         didResolve = true;
-        resolve(null);
       }
     });
   });


### PR DESCRIPTION
## Summary

optimize error log, should print error log when process unexpected exit

<img width="786" alt="image" src="https://github.com/web-infra-dev/rspress/assets/22373761/ff3347d7-ff59-47dd-88b0-bc284d841255">

## Related Issue

https://github.com/web-infra-dev/rspack-ecosystem-ci/actions/runs/9479241139/job/26117554452

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
