### PR TITLE
feat: format JSON in generated virtual modules

### DIFF
--- a/packages/core/src/node/mdx/loader.ts
+++ b/packages/core/src/node/mdx/loader.ts
@@ -50,14 +50,18 @@ export async function updateSiteDataRuntimeModule(
   );
   await fs.writeFile(
     siteDataModulePath,
-    `export default ${JSON.stringify({
-      ...siteData,
-      timestamp: Date.now().toString(),
-      pages: siteData.pages.map(page =>
-        // Update page meta if the page is updated
-        page._filepath === modulePath ? { ...page, ...pageMeta } : page,
-      ),
-    })}`,
+    `export default ${JSON.stringify(
+      {
+        ...siteData,
+        timestamp: Date.now().toString(),
+        pages: siteData.pages.map(page =>
+          // Update page meta if the page is updated
+          page._filepath === modulePath ? { ...page, ...pageMeta } : page,
+        ),
+      },
+      null,
+      2,
+    )}`,
   );
 }
 

--- a/packages/core/src/node/runtimeModule/i18n.ts
+++ b/packages/core/src/node/runtimeModule/i18n.ts
@@ -19,6 +19,6 @@ export function i18nVMPlugin(context: FactoryContext) {
   const { config } = context;
   const i18nData = getI18nData(config);
   return {
-    [RuntimeModuleID.I18nText]: `export default ${JSON.stringify(i18nData)}`,
+    [RuntimeModuleID.I18nText]: `export default ${JSON.stringify(i18nData, null, 2)}`,
   };
 }

--- a/packages/core/src/node/runtimeModule/siteData/index.ts
+++ b/packages/core/src/node/runtimeModule/siteData/index.ts
@@ -149,12 +149,18 @@ export async function siteDataVMPlugin(context: FactoryContext) {
   return {
     [`${RuntimeModuleID.SiteData}.mjs`]: `export default ${JSON.stringify(
       siteData,
+      null,
+      2,
     )}`,
     [RuntimeModuleID.SearchIndexHash]: `export default ${JSON.stringify(
       indexHashByGroup,
+      null,
+      2,
     )}`,
     [RuntimeModuleID.PrismLanguages]: `export const aliases = ${JSON.stringify(
       sortedAliases,
+      null,
+      2,
     )};
     export const languages = {
       ${sortedHighlightLanguages.map(lang => {

--- a/packages/core/tests/__snapshots__/prismLanguages.test.ts.snap
+++ b/packages/core/tests/__snapshots__/prismLanguages.test.ts.snap
@@ -1,7 +1,14 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`automatic import of prism languages > prism languages aliases should be configurable to users 1`] = `
-"export const aliases = {\\"javascript\\":[\\"js\\"],\\"objectivec\\":[\\"oc\\"]};
+"export const aliases = {
+  \\"javascript\\": [
+    \\"js\\"
+  ],
+  \\"objectivec\\": [
+    \\"oc\\"
+  ]
+};
     export const languages = {
       \\"javascript\\": require(
           \\"react-syntax-highlighter/dist/cjs/languages/prism/javascript\\"


### PR DESCRIPTION
## Summary

Format JSON in generated virtual modules.

This can help to display readable code frames when there are some syntax errors in the virtual modules.

For example:

- before

<img width="1241" alt="截屏2024-06-15 20 32 16" src="https://github.com/web-infra-dev/rspress/assets/7237365/1d5ae82a-f4bf-45b9-85d2-2c8be8168ad7">

- after

<img width="1207" alt="截屏2024-06-15 20 45 13" src="https://github.com/web-infra-dev/rspress/assets/7237365/c59e47b5-7a5d-4f08-971c-6fd1bd77d4a8">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
