### PR TITLE
fix: only append base to internal non-relative urls

### DIFF
--- a/packages/runtime/src/utils.ts
+++ b/packages/runtime/src/utils.ts
@@ -46,6 +46,10 @@ export function normalizeImagePath(imagePath: string) {
   if (isExternalUrl(imagePath) || isDataUrl(imagePath)) {
     return imagePath;
   }
+  // only append base to internal non-relative urls
+  if (!imagePath.startsWith('/') || imagePath.startsWith('//')) {
+    return imagePath;
+  }
 
   return withBase(imagePath);
 }

--- a/packages/runtime/src/utils.ts
+++ b/packages/runtime/src/utils.ts
@@ -43,7 +43,7 @@ export function normalizeImagePath(imagePath: string) {
   if (!isProd) {
     return imagePath;
   }
-  if (isExternalUrl(imagePath) || isDataUrl(imagePath)) {
+  if (isExternalUrl(imagePath) || isDataUrl(imagePath) || imagePath.startsWith('//')) {
     return imagePath;
   }
   // only append base to internal non-relative urls

--- a/packages/runtime/src/utils.ts
+++ b/packages/runtime/src/utils.ts
@@ -47,7 +47,7 @@ export function normalizeImagePath(imagePath: string) {
     return imagePath;
   }
   // only append base to internal non-relative urls
-  if (!imagePath.startsWith('/') || imagePath.startsWith('//')) {
+  if (!imagePath.startsWith('/')) {
     return imagePath;
   }
 


### PR DESCRIPTION
## Summary

Only append base to internal non-relative urls, to prevent conflict between `base` and `output.assetPrefix` when using relative urls.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
