### PR TITLE
feat(docs): use frontmatter to customize metadata

### DIFF
--- a/packages/document/docs/en/guide/basic/custom-page.mdx
+++ b/packages/document/docs/en/guide/basic/custom-page.mdx
@@ -167,6 +167,19 @@ import PageType from '@en/fragments/page-type';
 
 <PageType />
 
+### Using frontmatter to generate page metadata for better SEO
+
+Within frontmatter, you can also customize your page's meta tag for SEO optimization.
+
+For example, if you want to add `<meta name="description" content="A modern explaination of &quot;edge&quot;" data-rh="true">` in your `<header>` tag, you can use frontmatter like so:
+
+```md
+---
+title: What does edge mean? ## This will customize your title in frontmatter
+description: A modern explaination of "edge"
+---
+```
+
 ### Using Fine-grained Switches
 
 In addition to the `pageType` page layout level configuration, Rspress also provides more fine-grained switches. You can configure other fields in the frontmatter. These fields and their meanings are as follows:


### PR DESCRIPTION
## Summary

- Added "Customizing header tag" and "Generate metadata for better SEO" in custom-page.mdx for a more user oriented writing + easier to search

## Related Issue

None

## Checklist


- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
