### PR TITLE
docs: fix OG tags examples

### DIFF
--- a/packages/document/docs/en/api/config/config-frontmatter.mdx
+++ b/packages/document/docs/en/api/config/config-frontmatter.mdx
@@ -75,13 +75,13 @@ For example, you can use these headers to specify custom meta tags for [Open Gra
 ---
 head:
   - - meta
-    - name: og:title
+    - property: og:title
       content: The Rock
   - - meta
-    - name: og:url
+    - property: og:url
       content: https://www.imdb.com/title/tt0117500/
   - - meta
-    - name: og:image
+    - property: og:image
       content: https://ia.media-imdb.com/images/rock.jpg
 # - - [htmlTag]
 #   - [attributeName]: [attributeValue]

--- a/packages/document/docs/en/fragments/internal-components.mdx
+++ b/packages/document/docs/en/fragments/internal-components.mdx
@@ -40,7 +40,7 @@ import { Helmet } from 'rspress/runtime';
 function App() {
   return (
     <Helmet>
-      <meta property="og:description" value="Out-of-box Rspack build tools" />
+      <meta property="og:description" content="Out-of-box Rspack build tools" />
     </Helmet>
   );
 }

--- a/packages/document/docs/zh/api/config/config-frontmatter.mdx
+++ b/packages/document/docs/zh/api/config/config-frontmatter.mdx
@@ -75,13 +75,13 @@ titleSuffix: '| 基于 Rspack 的静态站点生成器'
 ---
 head:
   - - meta
-    - name: og:title
+    - property: og:title
       content: The Rock
   - - meta
-    - name: og:url
+    - property: og:url
       content: https://www.imdb.com/title/tt0117500/
   - - meta
-    - name: og:image
+    - property: og:image
       content: https://ia.media-imdb.com/images/rock.jpg
 # - - [htmlTag]
 #   - [attributeName]: [attributeValue]

--- a/packages/document/docs/zh/fragments/internal-components.mdx
+++ b/packages/document/docs/zh/fragments/internal-components.mdx
@@ -40,7 +40,7 @@ import { Helmet } from 'rspress/runtime';
 function App() {
   return (
     <Helmet>
-      <meta property="og:description" value="Out-of-box Rspack build tools" />
+      <meta property="og:description" content="Out-of-box Rspack build tools" />
     </Helmet>
   );
 }


### PR DESCRIPTION
## Summary

Fix OG tags examples, should use `property` and `content`.

![image](https://github.com/web-infra-dev/rspress/assets/7237365/f36eb704-c6fe-462d-9f26-5ba6359fd9ad)


## Related Issue

https://ogp.me/

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
