### PR TITLE
refactor(theme-default): add title attribute to `CopyCodeButton` and …

### DIFF
--- a/packages/theme-default/src/layout/DocLayout/docComponents/code/CopyCodeButton.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/code/CopyCodeButton.tsx
@@ -51,6 +51,7 @@ export function CopyCodeButton({
       className={styles.codeCopyButton}
       onClick={() => copyCode(codeBlockRef.current, copyButtonRef.current)}
       ref={copyButtonRef}
+      title="Copy code"
     >
       <SvgWrapper icon={IconCopy} className={styles.iconCopy} />
       <SvgWrapper icon={IconSuccess} className={styles.iconSuccess} />

--- a/packages/theme-default/src/layout/DocLayout/docComponents/code/index.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/code/index.tsx
@@ -64,6 +64,7 @@ export function Code(props: CodeProps) {
           ref={wrapButtonRef}
           className={styles.codeWrapButton}
           onClick={() => toggleCodeWrap(wrapButtonRef.current)}
+          title="Toggle code wrap"
         >
           <SvgWrapper icon={IconWrapped} className={styles.iconWrapped} />
           <SvgWrapper icon={IconWrap} className={styles.iconWrap} />


### PR DESCRIPTION
## Summary

To provide a better user experience, I added the title attribute to the `CopyCodeButton` and `CodeWrapButton` components to hint at its functionality.

![image](https://github.com/web-infra-dev/rspress/assets/48519459/ae5a9660-4784-4157-a008-8f48ae869702)

![image](https://github.com/web-infra-dev/rspress/assets/48519459/285fca87-db17-4b4c-933a-28bb6889637c)


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
