### PR TITLE
fix: search panel race condition

### DIFF
--- a/packages/theme-default/src/components/Search/SearchPanel.tsx
+++ b/packages/theme-default/src/components/Search/SearchPanel.tsx
@@ -296,8 +296,8 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
       const currQuery = searchInputRef.current?.value;
       if (currQuery === newQuery) {
         setSearchResult(searchResult || DEFAULT_RESULT);
+        setIsSearching(false);
       }
-      setIsSearching(false);
     }
   };
 

--- a/packages/theme-default/src/components/Search/SearchPanel.tsx
+++ b/packages/theme-default/src/components/Search/SearchPanel.tsx
@@ -292,7 +292,7 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
         await userSearchHooks[key](newQuery, searchResult);
       }
 
-      // for latest priority web-infra-dev/rspress#1229
+      // only setSearchResult when query is current query value
       const currQuery = searchInputRef.current?.value;
       if (currQuery === newQuery) {
         setSearchResult(searchResult || DEFAULT_RESULT);

--- a/packages/theme-default/src/components/Search/SearchPanel.tsx
+++ b/packages/theme-default/src/components/Search/SearchPanel.tsx
@@ -39,6 +39,16 @@ export interface SearchPanelProps {
   setFocused: (focused: boolean) => void;
 }
 
+const useDebounce = <T extends (...args: any[]) => void>(cb: T): T => {
+  const cbRef = useRef(cb);
+  cbRef.current = cb;
+  const debounced = useCallback(
+    debounce((...args: any) => cbRef.current(...args), 150),
+    [],
+  );
+  return debounced as unknown as T;
+};
+
 export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
   const [query, setQuery] = useState('');
   const [searchResult, setSearchResult] = useState<MatchResult>([]);
@@ -282,19 +292,13 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
         await userSearchHooks[key](newQuery, searchResult);
       }
 
-      setSearchResult(searchResult || DEFAULT_RESULT);
+      // for latest priority web-infra-dev/rspress#1229
+      const currQuery = searchInputRef.current?.value;
+      if (currQuery === newQuery) {
+        setSearchResult(searchResult || DEFAULT_RESULT);
+      }
       setIsSearching(false);
     }
-  };
-
-  const useDebounce = <T extends (...args: any[]) => void>(cb: T): T => {
-    const cbRef = useRef(cb);
-    cbRef.current = cb;
-    const debounced = useCallback(
-      debounce((...args: any) => cbRef.current(...args), 150),
-      [],
-    );
-    return debounced as unknown as T;
   };
 
   const handleQueryChange = useDebounce(handleQueryChangedImpl);


### PR DESCRIPTION
## Summary

fix async request race condition

搜索框的请求，提交结果时，应遵循 "后发出优先" 
For the request of the search box, when submitting the results, you should follow the "post priority"

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
