### PR TITLE
chore: enable dev.lazyCompilation in website

### DIFF
--- a/packages/document/rspress.config.ts
+++ b/packages/document/rspress.config.ts
@@ -19,6 +19,9 @@ export default defineConfig({
   },
   plugins: [pluginFontOpenSans()],
   builderConfig: {
+    dev: {
+      lazyCompilation: true,
+    },
     plugins: [
       pluginGoogleAnalytics({ id: 'G-66B2Z6KG0J' }),
       pluginOpenGraph({


### PR DESCRIPTION
## Summary

enable `dev.lazyCompilation` to improve dev start performance.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
