### PR TITLE
fix: should not render empty footer

### DIFF
--- a/packages/theme-default/src/components/HomeFooter/index.tsx
+++ b/packages/theme-default/src/components/HomeFooter/index.tsx
@@ -3,17 +3,20 @@ import { usePageData } from '@rspress/runtime';
 export function HomeFooter() {
   const { siteData } = usePageData();
   const { message } = siteData.themeConfig.footer || {};
+
+  if (!message) {
+    return null;
+  }
+
   return (
     <footer className="absolute bottom-0 mt-12 py-8 px-6 sm:p-8 w-full border-t border-solid border-divider-light">
       <div className="m-auto w-full text-center">
-        {message && (
-          <div
-            className="font-meduim text-sm text-text-2"
-            dangerouslySetInnerHTML={{
-              __html: message,
-            }}
-          />
-        )}
+        <div
+          className="font-meduim text-sm text-text-2"
+          dangerouslySetInnerHTML={{
+            __html: message,
+          }}
+        />
       </div>
     </footer>
   );


### PR DESCRIPTION
## Summary

Should not render an empty footer if `footer.message` is not set:

![image](https://github.com/user-attachments/assets/24eb994f-994a-477e-8d99-dc32ae9ce827)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
