### PR TITLE
fix: replace < in render inline markdown

### DIFF
--- a/packages/theme-default/src/logic/utils.ts
+++ b/packages/theme-default/src/logic/utils.ts
@@ -50,7 +50,8 @@ const EMPHASIS_TEXT_PATTERN = /\*(?!\*)(.*?)(?<!\*)\*/g;
  */
 export function renderInlineMarkdown(text: string) {
   const htmlText = text
-    .replace(/</g, '&lt;')
+    // replace `<list>` to prevent disappearing in dom, but not replace \<number\>
+    .replace(/`[^`]+`/g, match => match.replace(/</g, '&lt;'))
     .replace(STRONG_TEXT_PATTERN, '<strong>$1</strong>')
     .replace(EMPHASIS_TEXT_PATTERN, '<em>$1</em>')
     .replace(CODE_TEXT_PATTERN, '<code>$1</code>');


### PR DESCRIPTION
## Summary

closes: #1258 

replace `<list>` to prevent disappearing in dom, but not replace \<number\>

**source code**

![image](https://github.com/user-attachments/assets/b0d28c98-e635-4cf8-bd9f-dce3d751bc73)


**origin**
![image](https://github.com/user-attachments/assets/94bdbaad-d906-43ea-bcd5-fa55f8d52968)

**now**
![image](https://github.com/user-attachments/assets/d0973b50-5650-4921-bba5-37d2350ecf96)


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
