### PR TITLE
chore(deps): bump TypeScript v5.5

### DIFF
--- a/e2e/fixtures/modern-js/package.json
+++ b/e2e/fixtures/modern-js/package.json
@@ -31,7 +31,7 @@
     "@types/react": "~18.0.26",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "typescript": "^5"
+    "typescript": "^5.5.3"
   },
   "sideEffects": []
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,7 +50,7 @@
     "@types/react": "^18",
     "rimraf": "^3.0.2",
     "ts-node": "^10.9.1",
-    "typescript": "^5"
+    "typescript": "^5.5.3"
   },
   "sideEffects": [],
   "publishConfig": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -106,7 +106,7 @@
     "@types/yaml-front-matter": "^4.1.0",
     "rimraf": "^3.0.2",
     "tailwindcss": "^3.4.3",
-    "typescript": "^5",
+    "typescript": "^5.5.3",
     "vitest": "0.34.1",
     "webpack": "^5.93.0"
   },

--- a/packages/create-rspress/package.json
+++ b/packages/create-rspress/package.json
@@ -32,7 +32,7 @@
     "prompts": "2.4.1",
     "rimraf": "^3.0.2",
     "ts-node": "^10.9.1",
-    "typescript": "^5"
+    "typescript": "^5.5.3"
   },
   "sideEffects": [],
   "publishConfig": {

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -24,7 +24,7 @@
     "rspress": "workspace:*",
     "rspress-plugin-font-open-sans": "^1.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5"
+    "typescript": "^5.5.3"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/modern-plugin-rspress/package.json
+++ b/packages/modern-plugin-rspress/package.json
@@ -44,7 +44,7 @@
     "@types/react": "^18",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "typescript": "^5",
+    "typescript": "^5.5.3",
     "vitest": "0.34.1"
   },
   "sideEffects": [

--- a/packages/plugin-api-docgen/package.json
+++ b/packages/plugin-api-docgen/package.json
@@ -38,7 +38,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.8.1",
-    "typescript": "^5",
+    "typescript": "^5.5.3",
     "unified": "^10.1.2",
     "unist-util-visit": "^4.1.1"
   },
@@ -46,7 +46,7 @@
     "react": ">=17.0.0",
     "react-router-dom": "^6.8.1",
     "@rspress/core": "^1.0.2",
-    "typescript": "^5"
+    "typescript": "^5.5.3"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/plugin-auto-nav-sidebar/package.json
+++ b/packages/plugin-auto-nav-sidebar/package.json
@@ -29,7 +29,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "react": "^18.2.0",
-    "typescript": "^5",
+    "typescript": "^5.5.3",
     "vitest": "0.34.1"
   },
   "sideEffects": [

--- a/packages/plugin-client-redirects/package.json
+++ b/packages/plugin-client-redirects/package.json
@@ -30,7 +30,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "react": "^18.2.0",
-    "typescript": "^5",
+    "typescript": "^5.5.3",
     "vitest": "0.34.1"
   },
   "peerDependencies": {

--- a/packages/plugin-last-updated/package.json
+++ b/packages/plugin-last-updated/package.json
@@ -29,7 +29,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "react": "^18.2.0",
-    "typescript": "^5",
+    "typescript": "^5.5.3",
     "vitest": "0.34.1"
   },
   "dependencies": {

--- a/packages/plugin-medium-zoom/package.json
+++ b/packages/plugin-medium-zoom/package.json
@@ -30,7 +30,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "react": "^18.2.0",
-    "typescript": "^5",
+    "typescript": "^5.5.3",
     "vitest": "0.34.1"
   },
   "peerDependencies": {

--- a/packages/plugin-playground/package.json
+++ b/packages/plugin-playground/package.json
@@ -54,7 +54,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.8.1",
-    "typescript": "^5",
+    "typescript": "^5.5.3",
     "unified": "^10.1.2",
     "unist-util-visit": "^4.1.1"
   },

--- a/packages/plugin-preview/package.json
+++ b/packages/plugin-preview/package.json
@@ -45,7 +45,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.8.1",
-    "typescript": "^5",
+    "typescript": "^5.5.3",
     "unified": "^10.1.2",
     "unist-util-visit": "^4.1.1"
   },

--- a/packages/plugin-rss/package.json
+++ b/packages/plugin-rss/package.json
@@ -39,7 +39,7 @@
     "@types/node": "^18.11.17",
     "@types/react": "^18",
     "react": "^18.2.0",
-    "typescript": "^5"
+    "typescript": "^5.5.3"
   },
   "peerDependencies": {
     "react": ">=17.0.0",

--- a/packages/plugin-shiki/package.json
+++ b/packages/plugin-shiki/package.json
@@ -30,7 +30,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "react": "^18.2.0",
-    "typescript": "^5",
+    "typescript": "^5.5.3",
     "unified": "^10.1.2",
     "vitest": "0.34.1"
   },

--- a/packages/plugin-typedoc/package.json
+++ b/packages/plugin-typedoc/package.json
@@ -28,7 +28,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "react": "^18.2.0",
-    "typescript": "^5",
+    "typescript": "^5.5.3",
     "vitest": "0.34.1"
   },
   "peerDependencies": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -42,7 +42,7 @@
     "@types/jest": "~29.5.12",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "typescript": "^5"
+    "typescript": "^5.5.3"
   },
   "sideEffects": [
     "*.css",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -71,7 +71,7 @@
     "medium-zoom": "1.1.0",
     "rimraf": "^3.0.2",
     "ts-node": "^10.9.1",
-    "typescript": "^5"
+    "typescript": "^5.5.3"
   },
   "sideEffects": [],
   "publishConfig": {

--- a/packages/theme-default/package.json
+++ b/packages/theme-default/package.json
@@ -72,7 +72,7 @@
     "@types/react-syntax-highlighter": "^15.5.13",
     "gray-matter": "4.0.3",
     "tailwindcss": "^3.4.3",
-    "typescript": "^5",
+    "typescript": "^5.5.3",
     "vitest": "0.34.1",
     "webpack": "^5.93.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,8 +254,8 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
       typescript:
-        specifier: ^5
-        version: 5.0.4
+        specifier: ^5.5.3
+        version: 5.5.3
 
   e2e/fixtures/multi-version:
     dependencies:
@@ -448,10 +448,10 @@ importers:
         version: 3.0.2
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@18.11.17)(typescript@5.0.4)
+        version: 10.9.1(@types/node@18.11.17)(typescript@5.5.3)
       typescript:
-        specifier: ^5
-        version: 5.0.4
+        specifier: ^5.5.3
+        version: 5.5.3
 
   packages/core:
     dependencies:
@@ -652,8 +652,8 @@ importers:
         specifier: ^3.4.3
         version: 3.4.3
       typescript:
-        specifier: ^5
-        version: 5.0.4
+        specifier: ^5.5.3
+        version: 5.5.3
       vitest:
         specifier: 0.34.1
         version: 0.34.1(playwright@1.45.0)
@@ -699,16 +699,16 @@ importers:
         version: 3.0.2
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@18.11.17)(typescript@5.0.4)
+        version: 10.9.1(@types/node@18.11.17)(typescript@5.5.3)
       typescript:
-        specifier: ^5
-        version: 5.0.4
+        specifier: ^5.5.3
+        version: 5.5.3
 
   packages/document:
     dependencies:
       rsfamily-nav-icon:
         specifier: ^1.0.1
-        version: 1.0.1
+        version: 1.0.3
     devDependencies:
       '@types/react':
         specifier: ^18
@@ -730,10 +730,10 @@ importers:
         version: 1.0.0
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@18.11.17)(typescript@5.0.4)
+        version: 10.9.1(@types/node@18.11.17)(typescript@5.5.3)
       typescript:
-        specifier: ^5
-        version: 5.0.4
+        specifier: ^5.5.3
+        version: 5.5.3
 
   packages/modern-plugin-rspress:
     dependencies:
@@ -763,8 +763,8 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
       typescript:
-        specifier: ^5
-        version: 5.0.4
+        specifier: ^5.5.3
+        version: 5.5.3
       vitest:
         specifier: 0.34.1
         version: 0.34.1(playwright@1.45.0)
@@ -782,7 +782,7 @@ importers:
         version: 14.0.2
       react-docgen-typescript:
         specifier: 2.2.2
-        version: 2.2.2(typescript@5.0.4)
+        version: 2.2.2(typescript@5.5.3)
       react-markdown:
         specifier: 8.0.7
         version: 8.0.7(@types/react@18.0.26)(react@18.2.0)
@@ -818,8 +818,8 @@ importers:
         specifier: ^6.8.1
         version: 6.11.1(react-dom@18.2.0)(react@18.2.0)
       typescript:
-        specifier: ^5
-        version: 5.0.4
+        specifier: ^5.5.3
+        version: 5.5.3
       unified:
         specifier: ^10.1.2
         version: 10.1.2
@@ -849,8 +849,8 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0
       typescript:
-        specifier: ^5
-        version: 5.0.4
+        specifier: ^5.5.3
+        version: 5.5.3
       vitest:
         specifier: 0.34.1
         version: 0.34.1(playwright@1.45.0)
@@ -880,8 +880,8 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0
       typescript:
-        specifier: ^5
-        version: 5.0.4
+        specifier: ^5.5.3
+        version: 5.5.3
       vitest:
         specifier: 0.34.1
         version: 0.34.1(playwright@1.45.0)
@@ -930,8 +930,8 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0
       typescript:
-        specifier: ^5
-        version: 5.0.4
+        specifier: ^5.5.3
+        version: 5.5.3
       vitest:
         specifier: 0.34.1
         version: 0.34.1(playwright@1.45.0)
@@ -964,8 +964,8 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0
       typescript:
-        specifier: ^5
-        version: 5.0.4
+        specifier: ^5.5.3
+        version: 5.5.3
       vitest:
         specifier: 0.34.1
         version: 0.34.1(playwright@1.45.0)
@@ -1031,8 +1031,8 @@ importers:
         specifier: ^6.8.1
         version: 6.11.1(react-dom@18.2.0)(react@18.2.0)
       typescript:
-        specifier: ^5
-        version: 5.0.4
+        specifier: ^5.5.3
+        version: 5.5.3
       unified:
         specifier: ^10.1.2
         version: 10.1.2
@@ -1110,8 +1110,8 @@ importers:
         specifier: ^6.8.1
         version: 6.11.1(react-dom@18.2.0)(react@18.2.0)
       typescript:
-        specifier: ^5
-        version: 5.0.4
+        specifier: ^5.5.3
+        version: 5.5.3
       unified:
         specifier: ^10.1.2
         version: 10.1.2
@@ -1144,8 +1144,8 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0
       typescript:
-        specifier: ^5
-        version: 5.0.4
+        specifier: ^5.5.3
+        version: 5.5.3
 
   packages/plugin-shiki:
     dependencies:
@@ -1181,8 +1181,8 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0
       typescript:
-        specifier: ^5
-        version: 5.0.4
+        specifier: ^5.5.3
+        version: 5.5.3
       unified:
         specifier: ^10.1.2
         version: 10.1.2
@@ -1200,7 +1200,7 @@ importers:
         version: link:../cli
       typedoc:
         specifier: 0.24.8
-        version: 0.24.8(typescript@5.0.4)
+        version: 0.24.8(typescript@5.5.3)
       typedoc-plugin-markdown:
         specifier: 3.17.1
         version: 3.17.1(typedoc@0.24.8)
@@ -1221,8 +1221,8 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0
       typescript:
-        specifier: ^5
-        version: 5.0.4
+        specifier: ^5.5.3
+        version: 5.5.3
       vitest:
         specifier: 0.34.1
         version: 0.34.1(playwright@1.45.0)
@@ -1258,8 +1258,8 @@ importers:
         specifier: ^18
         version: 18.0.0
       typescript:
-        specifier: ^5
-        version: 5.0.4
+        specifier: ^5.5.3
+        version: 5.5.3
 
   packages/shared:
     dependencies:
@@ -1317,10 +1317,10 @@ importers:
         version: 3.0.2
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@18.11.17)(typescript@5.0.4)
+        version: 10.9.1(@types/node@18.11.17)(typescript@5.5.3)
       typescript:
-        specifier: ^5
-        version: 5.0.4
+        specifier: ^5.5.3
+        version: 5.5.3
 
   packages/theme-default:
     dependencies:
@@ -1431,8 +1431,8 @@ importers:
         specifier: ^3.4.3
         version: 3.4.3
       typescript:
-        specifier: ^5
-        version: 5.0.4
+        specifier: ^5.5.3
+        version: 5.5.3
       vitest:
         specifier: 0.34.1
         version: 0.34.1(playwright@1.45.0)
@@ -8862,12 +8862,12 @@ packages:
       react: 18.2.0
     dev: false
 
-  /react-docgen-typescript@2.2.2(typescript@5.0.4):
+  /react-docgen-typescript@2.2.2(typescript@5.5.3):
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
       typescript: '>= 4.3.x'
     dependencies:
-      typescript: 5.0.4
+      typescript: 5.5.3
     dev: false
 
   /react-dom@18.2.0(react@18.2.0):
@@ -9311,8 +9311,8 @@ packages:
         optional: true
     dev: true
 
-  /rsfamily-nav-icon@1.0.1:
-    resolution: {integrity: sha512-TJdyzLpFfmEGfJiPAwZqn1TdXwoR7j/Y0j9ejovNk3zABzJ1FRQ6WZl7DVQQTHoJnABlRgXphMuxnAZ2UMePdQ==}
+  /rsfamily-nav-icon@1.0.3:
+    resolution: {integrity: sha512-ZbSASDPb30II7x0NWlA9BNP6EA3+lvAVui9ahAT3vomqlP5Pt3cu1eSVaXApIv2gu0EFTC1TOQL4kKdK+8pXbA==}
     dev: false
 
   /rslog@1.1.0:
@@ -10250,7 +10250,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-node@10.9.1(@types/node@18.11.17)(typescript@5.0.4):
+  /ts-node@10.9.1(@types/node@18.11.17)(typescript@5.5.3):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -10276,7 +10276,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.0.4
+      typescript: 5.5.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
@@ -10395,10 +10395,10 @@ packages:
       typedoc: '>=0.24.0'
     dependencies:
       handlebars: 4.7.8
-      typedoc: 0.24.8(typescript@5.0.4)
+      typedoc: 0.24.8(typescript@5.5.3)
     dev: false
 
-  /typedoc@0.24.8(typescript@5.0.4):
+  /typedoc@0.24.8(typescript@5.5.3):
     resolution: {integrity: sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==}
     engines: {node: '>= 14.14'}
     hasBin: true
@@ -10409,12 +10409,12 @@ packages:
       marked: 4.3.0
       minimatch: 9.0.3
       shiki: 0.14.5
-      typescript: 5.0.4
+      typescript: 5.5.3
     dev: false
 
-  /typescript@5.0.4:
-    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
-    engines: {node: '>=12.20'}
+  /typescript@5.5.3:
+    resolution: {integrity: sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   /ufo@1.2.0:


### PR DESCRIPTION
## Summary

bump TypeScript v5.5 to support more tsconfig.json options like `moduleResolution: 'bundler'`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
