### PR TITLE
build(@modern-js/plugin-rspress): remove exports field

### DIFF
--- a/packages/modern-plugin-rspress/package.json
+++ b/packages/modern-plugin-rspress/package.json
@@ -19,15 +19,6 @@
   "jsnext:source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",
-  "exports": {
-    ".": {
-      "node": {
-        "jsnext:source": "./src/index.ts",
-        "require": "./dist/index.js"
-      }
-    },
-    "./package.json": "./package.json"
-  },
   "scripts": {
     "new": "modern new",
     "build": "modern build",


### PR DESCRIPTION
## Summary

No `types` declared in current `exports` field, it will break in ESM project. And since we're only publishing single CJS entry. We don't need to use exports field.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
