### PR TITLE
fix(theme): adjust the dir sidebar font size

### DIFF
--- a/.changeset/chilly-cycles-agree.md
+++ b/.changeset/chilly-cycles-agree.md
@@ -1,0 +1,6 @@
+---
+"@rspress/theme-default": patch
+---
+
+fix: adjust the dir sidebar font size
+fix: 调整目录侧边栏字体大小

--- a/packages/theme-default/src/components/Sidebar/SidebarGroup.tsx
+++ b/packages/theme-default/src/components/Sidebar/SidebarGroup.tsx
@@ -133,7 +133,14 @@ export function SidebarGroup(props: SidebarItemProps) {
           }}
         >
           <Tag tag={item.tag} />
-          <span className="flex-center">{renderInlineMarkdown(item.text)}</span>
+          <span
+            className="flex-center"
+            style={{
+              fontSize: depth === 0 ? '14px' : '13px',
+            }}
+          >
+            {renderInlineMarkdown(item.text)}
+          </span>
         </h2>
         {collapsible && (
           <div


### PR DESCRIPTION
## Summary

Adjust the font size of the 'dir' sidebar to be the same as the 'title' sidebar

before:
![image](https://github.com/user-attachments/assets/3e9c00db-cc49-494b-9569-9be06ef2d822)

after:
![image](https://github.com/user-attachments/assets/2159f28a-2f29-44a7-a70c-f02b6df4d8c7)



## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
