### PR TITLE
fix(theme-default): remove globby in deps

### DIFF
--- a/packages/theme-default/package.json
+++ b/packages/theme-default/package.json
@@ -42,7 +42,6 @@
     "copy-to-clipboard": "^3.3.3",
     "flexsearch": "0.6.32",
     "github-slugger": "^2.0.0",
-    "globby": "11.1.0",
     "hast-util-from-html": "^1.0.0",
     "html-to-text": "^9.0.3",
     "htmr": "^1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1345,9 +1345,6 @@ importers:
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
-      globby:
-        specifier: 11.1.0
-        version: link:../core/compiled/globby
       hast-util-from-html:
         specifier: ^1.0.0
         version: 1.0.0


### PR DESCRIPTION
## Summary

globby is pre-compiled in `@rspress/core` and not used in `@rspress/theme-default`

closes: #1286 

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
