### PR TITLE
fix(theme-default): uiSwitch prop of Layout component not work

### DIFF
--- a/e2e/fixtures/custom-layout-ui-switch/doc/index.mdx
+++ b/e2e/fixtures/custom-layout-ui-switch/doc/index.mdx
@@ -1,0 +1,1 @@
+# Hello World

--- a/e2e/fixtures/custom-layout-ui-switch/package.json
+++ b/e2e/fixtures/custom-layout-ui-switch/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@rspress-fixture/custom-layout-ui-switch",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "rspress dev",
+    "build": "rspress build",
+    "preview": "rspress preview"
+  },
+  "dependencies": {
+    "rspress": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^18.11.17"
+  }
+}

--- a/e2e/fixtures/custom-layout-ui-switch/rspress.config.ts
+++ b/e2e/fixtures/custom-layout-ui-switch/rspress.config.ts
@@ -1,0 +1,6 @@
+import * as path from 'node:path';
+import { defineConfig } from 'rspress/config';
+
+export default defineConfig({
+  root: path.join(__dirname, 'doc'),
+});

--- a/e2e/fixtures/custom-layout-ui-switch/theme/index.tsx
+++ b/e2e/fixtures/custom-layout-ui-switch/theme/index.tsx
@@ -1,0 +1,19 @@
+import Theme from 'rspress/theme';
+import { Layout as BaseLayout } from 'rspress/theme';
+
+const Layout = () => {
+  return (
+    <BaseLayout
+      uiSwitch={{
+        showNavbar: false,
+      }}
+    />
+  );
+};
+
+export default {
+  ...Theme,
+  Layout,
+};
+
+export * from 'rspress/theme';

--- a/e2e/fixtures/custom-layout-ui-switch/tsconfig.json
+++ b/e2e/fixtures/custom-layout-ui-switch/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
+  },
+  "include": [
+    "docs/**/*",
+    "theme/**/*"
+  ],
+  "mdx": {
+    "checkMdx": true
+  }
+}

--- a/e2e/tests/custom-layout-ui-switch.test.ts
+++ b/e2e/tests/custom-layout-ui-switch.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test';
+import path from 'node:path';
+import { getPort, killProcess, runDevCommand } from '../utils/runCommands';
+
+const fixtureDir = path.resolve(__dirname, '../fixtures');
+
+test.describe('custom layout ui switch', async () => {
+  let appPort;
+  let app;
+  test.beforeAll(async () => {
+    const appDir = path.join(fixtureDir, 'custom-layout-ui-switch');
+    appPort = await getPort();
+    app = await runDevCommand(appDir, appPort);
+  });
+
+  test.afterAll(async () => {
+    if (app) {
+      await killProcess(app);
+    }
+  });
+
+  test('Index page', async ({ page }) => {
+    await page.goto(`http://localhost:${appPort}`, {
+      waitUntil: 'networkidle',
+    });
+    const elementExists = (await page.$('.rspress-nav')) !== null;
+    expect(elementExists).toEqual(false);
+  });
+});

--- a/packages/theme-default/src/layout/Layout/index.tsx
+++ b/packages/theme-default/src/layout/Layout/index.tsx
@@ -9,12 +9,16 @@ import type { HomeLayoutProps } from '../HomeLayout';
 import type { NavProps } from '../../components/Nav';
 import { useLocaleSiteData } from '../../logic';
 import { useRedirect4FirstVisit } from '../../logic/useRedirect4FirstVisit';
-import { useUISwitch } from '../../logic/useUISwitch';
+import { type UISwitchResult, useUISwitch } from '../../logic/useUISwitch';
 
 export type LayoutProps = {
   top?: React.ReactNode;
   bottom?: React.ReactNode;
-} & DocLayoutProps &
+  /**
+   * Control whether or not to display the navbar, sidebar, outline and footer
+   */
+  uiSwitch?: Partial<UISwitchResult>;
+} & Omit<DocLayoutProps, 'uiSwitch'> &
   HomeLayoutProps &
   NavProps;
 
@@ -108,8 +112,14 @@ export const Layout: React.FC<LayoutProps> = props => {
     (frontmatter?.description as string) ||
     siteData.description ||
     localesData.description;
-  // Control whether to show navbar/sidebar/outline/footer
-  const uiSwitch = useUISwitch();
+
+  // Control whether or not to display the navbar, sidebar, outline and footer
+  // `props.uiSwitch` has higher priority and allows user to override the default value
+  const uiSwitch = {
+    ...useUISwitch(),
+    ...props.uiSwitch,
+  };
+
   // Use doc layout by default
   const getContentLayout = () => {
     switch (pageType) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,16 @@ importers:
         specifier: ^18.11.17
         version: 18.11.17
 
+  e2e/fixtures/custom-layout-ui-switch:
+    dependencies:
+      rspress:
+        specifier: workspace:*
+        version: link:../../../packages/cli
+    devDependencies:
+      '@types/node':
+        specifier: ^18.11.17
+        version: 18.11.17
+
   e2e/fixtures/custom-plugin:
     dependencies:
       '@rspress/plugin-playground':


### PR DESCRIPTION
## Summary

Fix the `uiSwitch` prop of Layout component not work.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
