### PR TITLE
fix: catch can not found tailwindcss error when debug

### DIFF
--- a/packages/theme-default/src/node/source-build-plugin.ts
+++ b/packages/theme-default/src/node/source-build-plugin.ts
@@ -21,16 +21,20 @@ export function SourceBuildPlugin(): RspressPlugin {
       },
       tools: {
         postcss: (_, { addPlugins }) => {
-          addPlugins(
-            require('tailwindcss')({
-              config: {
-                ...tailwindConfig,
-                content: tailwindConfig.content.map(item =>
-                  path.resolve(ROOT_DIR, item),
-                ),
-              },
-            }),
-          );
+          try {
+            addPlugins(
+              require('tailwindcss')({
+                config: {
+                  ...tailwindConfig,
+                  content: tailwindConfig.content.map(item =>
+                    path.resolve(ROOT_DIR, item),
+                  ),
+                },
+              }),
+            );
+          } catch (e) {
+            // if require tailwindcss failed, skip
+          }
         },
       },
     },


### PR DESCRIPTION
## Summary

tailwindcss is a devDependency, and this logic only used to debug.

<img width="801" alt="image" src="https://github.com/user-attachments/assets/42f52e21-48f3-4495-b2fe-012e6b27f77d">


## Related Issue

https://github.com/web-infra-dev/rspress/pull/600/files

https://github.com/web-infra-dev/rspress/pull/471/files

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
