### PR TITLE
fix(watch): improve watch solution, ignore _meta.json out of doc root dir

### DIFF
--- a/.changeset/thick-moons-cry.md
+++ b/.changeset/thick-moons-cry.md
@@ -1,0 +1,6 @@
+---
+"rspress": patch
+---
+
+fix: improve watch solution, ignore _meta.json out of doc root dir
+fix: 优化监听文件变动策略，忽略 doc 根目录之外的 _meta.json


### PR DESCRIPTION
## Summary

before:
1. rspress will watch all file in doc root dir, but only handle some config file.
2. all the `_meta.json` in cwd are watched.

now
1. only watch `_meta.json` files in doc root dir.


<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
