### PR TITLE
fix: should watch whole doc root dir for add/delete file

### DIFF
--- a/.changeset/cyan-yaks-pull.md
+++ b/.changeset/cyan-yaks-pull.md
@@ -1,0 +1,6 @@
+---
+"rspress": patch
+---
+
+fix: should watch whole doc root dir for add/delete file
+fix: 应该监听整个文档根目录的文件，保证添加和删除时重启

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -64,10 +64,7 @@ cli
         });
 
         cliWatcher = chokidar.watch(
-          [
-            `${cwd}/**/{${CONFIG_FILES.join(',')}}`,
-            `${docDirectory}/**/${META_FILE}`,
-          ],
+          [`${cwd}/**/{${CONFIG_FILES.join(',')}}`, docDirectory],
           {
             ignoreInitial: true,
             ignored: ['**/node_modules/**', '**/.git/**', '**/.DS_Store/**'],


### PR DESCRIPTION
## Summary

some patch for #1312 .

we should watch whole doc root. cause user will add or delete `md` file.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
