### PR TITLE
fix: window unexpected href when feature link is not configured

### DIFF
--- a/e2e/fixtures/page-type-home/doc/index.md
+++ b/e2e/fixtures/page-type-home/doc/index.md
@@ -5,14 +5,14 @@ hero:
   text: E2E case subTitle
   tagline: E2E case tagline
   actions:
-  - text: Action 1
-    link: /action-1
-  - text: Action 2
-    link: /action-2
-    theme: brand
-  - text: External
-    link: https://example.com/
-    theme: alt
+    - text: Action 1
+      link: /action-1
+    - text: Action 2
+      link: /action-2
+      theme: brand
+    - text: External
+      link: https://example.com/
+      theme: alt
   image:
     src: /brand.png
     alt: E2E case brand image
@@ -21,5 +21,13 @@ hero:
       - /brand@2x.png 2x
     sizes:
       - '((min-width: 50em) and (max-width: 60em)) 50em'
-      - "(max-width: 30em) 20em"
+      - '(max-width: 30em) 20em'
+features:
+  - title: Blazing fast build speed
+    details: The core compilation module is based on the Rust front-end toolchain, providing a more ultimate development experience.
+    icon: 🏃🏻‍♀️
+  - title: Support for MDX content writing
+    details: MDX is a powerful way to write content, allowing you to use React components in Markdown.
+    icon: 📦
+    link: https://example.com/
 ---

--- a/e2e/tests/page-type-home.test.ts
+++ b/e2e/tests/page-type-home.test.ts
@@ -42,4 +42,17 @@ test.describe('home pageType', async () => {
 
     // todo: add tests for hero actions
   });
+
+  test('Features', async ({ page }) => {
+    await page.goto(`http://localhost:${appPort}`);
+    const features = await page.$$('.rspress-home-feature-card');
+    expect(features).toHaveLength(2);
+
+    const url1 = page.url();
+    await features[0].click();
+    expect(page.url()).toBe(url1);
+
+    await features[1].click();
+    expect(page.url()).toBe('https://example.com/');
+  });
 });

--- a/packages/theme-default/src/components/HomeFeature/index.tsx
+++ b/packages/theme-default/src/components/HomeFeature/index.tsx
@@ -25,9 +25,13 @@ export function HomeFeature({
     <div className="overflow-hidden m-auto flex flex-wrap max-w-6xl">
       {features?.map(feature => {
         const { icon, title, details, link: rawLink } = feature;
-        const link = isExternalUrl(rawLink)
-          ? rawLink
-          : normalizeHrefInRuntime(withBase(rawLink, routePath));
+
+        let link = rawLink;
+        if (rawLink) {
+          link = isExternalUrl(rawLink)
+            ? rawLink
+            : normalizeHrefInRuntime(withBase(rawLink, routePath));
+        }
 
         return (
           <div


### PR DESCRIPTION
## Summary

`normalizeHrefInRuntime(withBase(rawLink, routePath))` will generate a `/index`, which will cause unexpected window href if user click a feature component without link configured.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
