### PR TITLE
fix: should not redirect when page is visited by bot

### DIFF
--- a/packages/theme-default/src/logic/useRedirect4FirstVisit.ts
+++ b/packages/theme-default/src/logic/useRedirect4FirstVisit.ts
@@ -10,17 +10,28 @@ export function useRedirect4FirstVisit() {
   const localeLanguages = Object.values(siteData.themeConfig.locales || {});
   const langs = localeLanguages.map(item => item.lang) || [];
   const currentLang = page.lang;
+
   useEffect(() => {
     const localeRedirect = siteData.themeConfig.localeRedirect ?? 'auto';
     if (localeRedirect !== 'auto') {
       return;
     }
+
     if (!defaultLang || process.env.TEST === '1') {
       // Check the window.navigator.language to determine the default language
       // If the default language is not the same as the current language, redirect to the default language
       // The default language will not have a lang prefix in the URL
       return;
     }
+
+    const botRegex = /bot|spider|crawl|lighthouse/i;
+    const userAgent = window.navigator.userAgent.toLowerCase();
+    // If the request is coming from a bot or crawler, do not redirect.
+    // this ensures that Google's search crawler can work as expected.
+    if (botRegex.test(userAgent)) {
+      return;
+    }
+
     // Normalize current url, to ensure that the home url is always with a trailing slash
     const { pathname, search } = window.location;
     const cleanPathname = removeBase(pathname);

--- a/packages/theme-default/src/logic/useRedirect4FirstVisit.ts
+++ b/packages/theme-default/src/logic/useRedirect4FirstVisit.ts
@@ -25,10 +25,9 @@ export function useRedirect4FirstVisit() {
     }
 
     const botRegex = /bot|spider|crawl|lighthouse/i;
-    const userAgent = window.navigator.userAgent;
     // If the request is coming from a bot or crawler, do not redirect.
     // this ensures that Google's search crawler can work as expected.
-    if (botRegex.test(userAgent)) {
+    if (botRegex.test(window.navigator.userAgent)) {
       return;
     }
 

--- a/packages/theme-default/src/logic/useRedirect4FirstVisit.ts
+++ b/packages/theme-default/src/logic/useRedirect4FirstVisit.ts
@@ -25,7 +25,7 @@ export function useRedirect4FirstVisit() {
     }
 
     const botRegex = /bot|spider|crawl|lighthouse/i;
-    const userAgent = window.navigator.userAgent.toLowerCase();
+    const userAgent = window.navigator.userAgent;
     // If the request is coming from a bot or crawler, do not redirect.
     // this ensures that Google's search crawler can work as expected.
     if (botRegex.test(userAgent)) {


### PR DESCRIPTION
## Summary

When the request comes from a bot (such as Google's crawler), Rspress should not redirect the page.

This change should fix the "Page with redirect" warning of Google:

![image](https://github.com/user-attachments/assets/8de90626-1ef7-41bd-8369-d5368755d373)

The RegExp is referenced from https://www.npmjs.com/package/isbot

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
