### PR TITLE
docs: link and example on using components

### DIFF
--- a/packages/document/docs/en/guide/advanced/custom-theme.mdx
+++ b/packages/document/docs/en/guide/advanced/custom-theme.mdx
@@ -38,9 +38,9 @@ On the one hand, you need to export a theme configuration object through `export
 
 ### 2. Use slot
 
-It is worth noting that the Layout component has designed a series of props to support slot elements. You can use these props to extend the layout of the default theme. For example, change the above Layout component to the following form:
+It is worth noting that the `Layout` component has designed a series of props to support slot elements. You can use these props to extend the layout of the default theme. For example, change the above `Layout` component to the following form:
 
-```tsx
+```tsx title="theme/index.tsx"
 import Theme from 'rspress/theme';
 
 // Show all props below

--- a/packages/document/docs/en/guide/basic/use-mdx.mdx
+++ b/packages/document/docs/en/guide/basic/use-mdx.mdx
@@ -12,10 +12,9 @@ MDX is a superset of Markdown, which means you can write Markdown files as usual
 
 ## Use Component
 
-When you want to use React components in Markdown files, you should name your files with `.mdx` extension. And remember to mark them [excluded from routes in `rspress.config.ts`](/api/config/config-basic#routeexclude).
+When you want to use React components in Markdown files, you should name your files with `.mdx` extension. For example:
 
-```mdx
-// docs/index.mdx
+```mdx title="index.mdx"
 import { CustomComponent } from './custom';
 
 # Hello World
@@ -23,34 +22,35 @@ import { CustomComponent } from './custom';
 <CustomComponent />
 ```
 
-Put all components under a different directory that is besides the `docs` directory if you don't want to configure `route.exclude`. For example:
+All mdx files are also components and they can import each other:
 
 ```mdx
-// <root>/docs/index.mdx
+import Foo from './shared/foo.mdx';
+
+# Hello world
+
+<Foo />
+```
+
+::: tip
+
+Relevant components need to be excluded from routing meta info through [route.exclude](/api/config/config-basic#routeexclude) configuration.
+
+You can also place components in an adjacent directory outside [root](/api/config/config-basic#root). For example:
+
+```mdx
+// <cwd>/docs/index.mdx
 import { Button } from '../components/button';
 
 # Button
 
 <Button />
 
-// <root>/components/button.mdx
+// <cwd>/components/button.mdx
 export Button = () => <button />;
 ```
 
-One step further, all MDX files are components, they can also import each other:
-
-```mdx
-import License from './license';
-import Contributing from './contributing'; // exclude these imported files from routes
-
-# Hello world
-
-<License />
-
----
-
-<Contributing />
-```
+:::
 
 ## Front Matter
 

--- a/packages/document/docs/en/guide/basic/use-mdx.mdx
+++ b/packages/document/docs/en/guide/basic/use-mdx.mdx
@@ -12,7 +12,7 @@ MDX is a superset of Markdown, which means you can write Markdown files as usual
 
 ## Use Component
 
-When you want to use React components in Markdown files, you should name your files with `.mdx` extension. For example:
+When you want to use React components in Markdown files, you should name your files with `.mdx` extension. And remember to mark them [excluded from routes in `rspress.config.ts`](/api/config/config-basic#routeexclude).
 
 ```mdx
 // docs/index.mdx
@@ -21,6 +21,35 @@ import { CustomComponent } from './custom';
 # Hello World
 
 <CustomComponent />
+```
+
+Put all components under a different directory that is besides the `docs` directory if you don't want to configure `route.exclude`. For example:
+
+```mdx
+// <root>/docs/index.mdx
+import { Button } from '../components/button';
+
+# Button
+
+<Button />
+
+// <root>/components/button.mdx
+export Button = () => <button />;
+```
+
+One step further, all MDX files are components, they can also import each other:
+
+```mdx
+import License from './license';
+import Contributing from './contributing'; // exclude these imported files from routes
+
+# Hello world
+
+<License />
+
+---
+
+<Contributing />
 ```
 
 ## Front Matter

--- a/packages/document/docs/zh/guide/advanced/custom-theme.mdx
+++ b/packages/document/docs/zh/guide/advanced/custom-theme.mdx
@@ -38,7 +38,7 @@ export * from 'rspress/theme';
 
 ### 2. 使用插槽
 
-值得注意的是，Layout 组件设计了一系列的 props 支持插槽元素，你可以通过这些 props 来扩展默认主题的布局，比如将上面的 Layout 组件改成如下的形式:
+值得注意的是，`Layout` 组件设计了一系列的 props 支持插槽元素，你可以通过这些 props 来扩展默认主题的布局，比如将上面的 `Layout` 组件改成如下的形式:
 
 ```tsx title="theme/index.tsx"
 import Theme from 'rspress/theme';

--- a/packages/document/docs/zh/guide/advanced/custom-theme.mdx
+++ b/packages/document/docs/zh/guide/advanced/custom-theme.mdx
@@ -40,7 +40,7 @@ export * from 'rspress/theme';
 
 值得注意的是，Layout 组件设计了一系列的 props 支持插槽元素，你可以通过这些 props 来扩展默认主题的布局，比如将上面的 Layout 组件改成如下的形式:
 
-```tsx
+```tsx title="theme/index.tsx"
 import Theme from 'rspress/theme';
 
 // 以下展示所有的 Props

--- a/packages/document/docs/zh/guide/basic/use-mdx.mdx
+++ b/packages/document/docs/zh/guide/basic/use-mdx.mdx
@@ -12,7 +12,7 @@ MDX 是 Markdown 的超集，这意味着你可以像往常一样编写 Markdown
 
 ## 使用组件
 
-当你想在 Markdown 文件中使用 React 组件时，你应该使用 `.mdx` 扩展名来命名你的文件。例如：
+当你想在 Markdown 文件中使用 React 组件时，你应该使用 `.mdx` 扩展名来命名你的文件。记得在 `rspress.config.ts` 的[路由配置中排除它们](/api/config/config-basic#routeexclude)。例如：
 
 ```mdx
 // docs/index.mdx
@@ -21,6 +21,36 @@ import { CustomComponent } from './custom';
 # Hello World
 
 <CustomComponent />
+```
+
+如果不想配置 `route.exclude`，可以将组件放到 `docs` 以外的相邻目录，例如：
+
+```mdx
+// <root>/docs/index.mdx
+import { Button } from '../components/button';
+
+# Button
+
+<Button />
+
+// <root>/components/button.mdx
+export Button = () => <button />;
+```
+
+更进一步地，所有的 mdx 文件都是组件，它们可以直接被引用：
+
+
+```mdx
+import License from './license';
+import Contributing from './contributing'; // 在路由配置中排除这两个被引用的文件
+
+# Hello world
+
+<License />
+
+---
+
+<Contributing />
 ```
 
 ## Front Matter

--- a/packages/document/docs/zh/guide/basic/use-mdx.mdx
+++ b/packages/document/docs/zh/guide/basic/use-mdx.mdx
@@ -12,10 +12,9 @@ MDX 是 Markdown 的超集，这意味着你可以像往常一样编写 Markdown
 
 ## 使用组件
 
-当你想在 Markdown 文件中使用 React 组件时，你应该使用 `.mdx` 扩展名来命名你的文件。记得在 `rspress.config.ts` 的[路由配置中排除它们](/api/config/config-basic#routeexclude)。例如：
+当你想在 Markdown 文件中使用 React 组件时，你应该使用 `.mdx` 扩展名来命名你的文件。例如：
 
-```mdx
-// docs/index.mdx
+```mdx title="index.mdx"
 import { CustomComponent } from './custom';
 
 # Hello World
@@ -23,35 +22,35 @@ import { CustomComponent } from './custom';
 <CustomComponent />
 ```
 
-如果不想配置 `route.exclude`，可以将组件放到 `docs` 以外的相邻目录，例如：
+所有的 mdx 文件也被视为组件，它们可以被互相引用：
 
 ```mdx
-// <root>/docs/index.mdx
+import Foo from './shared/foo.mdx';
+
+# Hello world
+
+<Foo />
+```
+
+::: tip
+
+相关组件需要通过 [route.exclude](/api/config/config-basic#routeexclude) 配置从路由信息中排除。
+
+你也可以将组件放到 [root](/api/config/config-basic#root) 以外的相邻目录，例如：
+
+```mdx
+// <cwd>/docs/index.mdx
 import { Button } from '../components/button';
 
 # Button
 
 <Button />
 
-// <root>/components/button.mdx
+// <cwd>/components/button.mdx
 export Button = () => <button />;
 ```
 
-更进一步地，所有的 mdx 文件都是组件，它们可以直接被引用：
-
-
-```mdx
-import License from './license';
-import Contributing from './contributing'; // 在路由配置中排除这两个被引用的文件
-
-# Hello world
-
-<License />
-
----
-
-<Contributing />
-```
+:::
 
 ## Front Matter
 


### PR DESCRIPTION
## Summary
Add link and example for `using components` in pages.


<details>
<summary> Preview `en` </summary>

![d688d9fb-483a-4963-8d72-4357edfeb6f8](https://github.com/user-attachments/assets/b8e1b4db-1f88-41c4-b6af-55bf8e6ac642)

</details>

<details>
<summary> Preview `cn` </summary>

![image](https://github.com/user-attachments/assets/4e5dd5dd-da7e-4367-bec5-5589a83286d7)
</details>

## Related Issue

close: #1284 
<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
