### PR TITLE
fix(style): improve work break for a tags

### DIFF
--- a/packages/theme-default/src/components/Overview/index.module.scss
+++ b/packages/theme-default/src/components/Overview/index.module.scss
@@ -84,7 +84,7 @@
   margin-top: 8px;
   color: var(--rp-c-text-code);
   transition: color 0.5s;
-  word-break: break-all;
+  overflow-wrap: break-word;
 }
 
 .overview-group-li {

--- a/packages/theme-default/src/layout/DocLayout/docComponents/index.module.scss
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/index.module.scss
@@ -66,7 +66,7 @@
 
 .inline-link {
   display: inline;
-  word-break: break-all;
+  overflow-wrap: break-word;
 }
 
 // For the className injected by shiki rehype plugin


### PR DESCRIPTION
## Summary

The `word-break: break-all` has been deprecated, see https://developer.mozilla.org/en-US/docs/Web/CSS/word-break.

Using `overflow-wrap: break-word` is more conservative, it only breaking words when necessary, while `word-break: break-all` is more aggressive and will break words at any opportunity.

## Related Issue

- https://github.com/web-infra-dev/rspress/pull/369

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
