### PR TITLE
fix(theme): fix highlight effect when operating with keyboard (#1364)

### DIFF
--- a/packages/theme-default/src/components/Search/SearchPanel.tsx
+++ b/packages/theme-default/src/components/Search/SearchPanel.tsx
@@ -61,6 +61,13 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
   const pageSearcherConfigRef = useRef<PageSearcherConfig | null>(null);
   const searchResultRef = useRef(null);
   const searchResultTabRef = useRef(null);
+  const mousePositionRef = useRef<{
+    pageX: number | null;
+    pageY: number | null;
+  }>({
+    pageX: null,
+    pageY: null,
+  });
 
   // only scroll after keydown arrow up and arrow down.
   const [canScroll, setCanScroll] = useState(false);
@@ -394,9 +401,22 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
                       key={`${suggestion.title}-${suggestionIndex}`}
                       suggestion={suggestion}
                       isCurrent={suggestionIndex === currentSuggestionIndex}
-                      setCurrentSuggestionIndex={() => {
+                      setCurrentSuggestionIndex={event => {
+                        if (
+                          mousePositionRef.current.pageX === event.pageX &&
+                          mousePositionRef.current.pageY === event.pageY
+                        ) {
+                          return;
+                        }
+
                         setCanScroll(false);
                         setCurrentSuggestionIndex(suggestionIndex);
+                      }}
+                      onMouseMove={event => {
+                        mousePositionRef.current = {
+                          pageX: event.pageX,
+                          pageY: event.pageY,
+                        };
                       }}
                       closeSearch={() => {
                         clearSearchState();

--- a/packages/theme-default/src/components/Search/SuggestItem.tsx
+++ b/packages/theme-default/src/components/Search/SuggestItem.tsx
@@ -22,11 +22,15 @@ export function SuggestItem({
   setCurrentSuggestionIndex,
   inCurrentDocIndex,
   scrollTo,
+  onMouseMove,
 }: {
   suggestion: DefaultMatchResultItem;
   closeSearch: () => void;
   isCurrent: boolean;
-  setCurrentSuggestionIndex: () => void;
+  setCurrentSuggestionIndex: (
+    event: React.MouseEvent<HTMLLIElement, MouseEvent>,
+  ) => void;
+  onMouseMove: (event: React.MouseEvent<HTMLLIElement, MouseEvent>) => void;
   inCurrentDocIndex: boolean;
   scrollTo: (top: number, height: number) => void;
 }) {
@@ -118,6 +122,7 @@ export function SuggestItem({
       key={suggestion.link}
       className={`${styles.suggestItem} ${isCurrent ? styles.current : ''}`}
       onMouseEnter={setCurrentSuggestionIndex}
+      onMouseMove={onMouseMove}
       ref={selfRef}
     >
       <a

--- a/packages/theme-default/src/components/Search/index.module.scss
+++ b/packages/theme-default/src/components/Search/index.module.scss
@@ -172,7 +172,6 @@
     }
   }
 
-  &:hover,
   &.current {
     > a {
       background-color: var(--rp-c-brand);


### PR DESCRIPTION
## Summary

fix the problem that when switching the search data up and down by the keyboard's arrow keys, the highlighting effect conflicts with the mouse hover effect, and the highlighted elements are messed up.

closes: [#1364](https://github.com/web-infra-dev/rspress/issues/1364)

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
