### PR TITLE
fix(core): fix writeSearchIndex function use userConfig instead modifiedConfig

### DIFF
--- a/packages/core/src/node/dev.ts
+++ b/packages/core/src/node/dev.ts
@@ -20,9 +20,9 @@ export async function dev(options: DevOptions): Promise<ServerInstance> {
   const isProd = false;
   const pluginDriver = new PluginDriver(config, isProd);
   await pluginDriver.init();
+  const modifiedConfig = await pluginDriver.modifyConfig();
 
   try {
-    const modifiedConfig = await pluginDriver.modifyConfig();
     await pluginDriver.beforeBuild();
 
     // empty temp dir before build
@@ -44,6 +44,6 @@ export async function dev(options: DevOptions): Promise<ServerInstance> {
 
     return server;
   } finally {
-    await writeSearchIndex(config);
+    await writeSearchIndex(modifiedConfig);
   }
 }


### PR DESCRIPTION
problem: dev command make search_index.json write to default outDir when outDir is set in plugin, when search trigger, dev server will halt because search_index.json not exists in final outDir.

## Summary

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
