### PR TITLE
fix: support highlight alias to itself

### DIFF
--- a/e2e/fixtures/prism-sytax-highlighter/doc/index.md
+++ b/e2e/fixtures/prism-sytax-highlighter/doc/index.md
@@ -19,3 +19,13 @@ int main(int argc, const char * argv[]) {
     return 0;
 }
 ```
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("Hello, World!")
+}
+```

--- a/e2e/fixtures/prism-sytax-highlighter/rspress.config.ts
+++ b/e2e/fixtures/prism-sytax-highlighter/rspress.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
       ['js', 'javascript'],
       ['oc', 'objectivec'],
       ['mdx', 'tsx'],
+      ['go', 'go'],
     ],
   },
 });

--- a/e2e/tests/prism-sytax-highlighter.test.ts
+++ b/e2e/tests/prism-sytax-highlighter.test.ts
@@ -21,11 +21,14 @@ test.describe('markdown highlight test', async () => {
   test('does highlight work', async ({ page }) => {
     await page.goto(`http://localhost:${appPort}`);
 
-    const text = await page
+    const textOc = await page
       .locator('.language-objectivec .token.macro.directive-hash')
       .evaluate(node => node.textContent);
 
-    expect(text).toBe('#');
+    const tokenGo = await page.locator('.language-go .token').count();
+
+    expect(textOc).toBe('#');
+    expect(tokenGo).toBe(14);
   });
 
   test('alias content match', async ({ page }) => {

--- a/packages/core/src/node/runtimeModule/siteData/highlightLanguages.ts
+++ b/packages/core/src/node/runtimeModule/siteData/highlightLanguages.ts
@@ -42,8 +42,9 @@ export function handleHighlightLanguages(
           temp.push(lang);
         }
 
-        highlightLanguages.add(name);
+        // delete first, user may config alias to itself like ['go', 'go']
         highlightLanguages.delete(lang);
+        highlightLanguages.add(name);
         return;
       }
 

--- a/packages/core/tests/__snapshots__/prismLanguages.test.ts.snap
+++ b/packages/core/tests/__snapshots__/prismLanguages.test.ts.snap
@@ -2,6 +2,9 @@
 
 exports[`automatic import of prism languages > prism languages aliases should be configurable to users 1`] = `
 "export const aliases = {
+  "go": [
+    "go"
+  ],
   "javascript": [
     "js"
   ],
@@ -13,7 +16,9 @@ exports[`automatic import of prism languages > prism languages aliases should be
   ]
 };
     export const languages = {
-      "javascript": require(
+      "go": require(
+          "react-syntax-highlighter/dist/cjs/languages/prism/go"
+        ).default,"javascript": require(
           "react-syntax-highlighter/dist/cjs/languages/prism/javascript"
         ).default,"objectivec": require(
           "react-syntax-highlighter/dist/cjs/languages/prism/objectivec"

--- a/packages/core/tests/prismLanguages.test.ts
+++ b/packages/core/tests/prismLanguages.test.ts
@@ -13,6 +13,7 @@ describe('automatic import of prism languages', () => {
         highlightLanguages: [
           ['js', 'javascript'],
           ['oc', 'objectivec'],
+          ['go', 'go'],
         ],
       },
     },

--- a/packages/core/tests/prismLanguages/index.mdx
+++ b/packages/core/tests/prismLanguages/index.mdx
@@ -23,8 +23,18 @@ int main(int argc, const char * argv[]) {
 }
 ```
 
+```go
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("Hello, World!")
+}
+```
+
 # 内置组件
 
-import InternalComponents from './extend'
+import InternalComponents from './extend';
 
 <InternalComponents />


### PR DESCRIPTION
## Summary

user may config alias to itself like ['go', 'go'], we should handle this case.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
