### PR TITLE
fix: remove margin-left for single a tag in SocialLinks component

### DIFF
--- a/packages/theme-default/src/components/SocialLinks/index.module.scss
+++ b/packages/theme-default/src/components/SocialLinks/index.module.scss
@@ -12,6 +12,10 @@
   }
 }
 
+a:only-child .social-links-icon {
+  margin-left: 0;
+}
+
 @media (max-width: 768px) {
   .menu-item:before {
     display: none;

--- a/packages/theme-default/src/components/SocialLinks/index.module.scss
+++ b/packages/theme-default/src/components/SocialLinks/index.module.scss
@@ -12,12 +12,12 @@
   }
 }
 
-a:only-child .social-links-icon {
-  margin-left: 0;
-}
-
 @media (max-width: 768px) {
   .menu-item:before {
     display: none;
+  }
+
+  a:only-child .social-links-icon {
+    margin-left: 0rem;
   }
 }


### PR DESCRIPTION
This commit fixes an issue where a single <a> tag in the SocialLinks component would have an unwanted margin-left, causing misalignment. The issue is resolved by using the :only-child pseudo-class to remove the margin-left when there is
only one <a> tag.

Updated index.module.scss to include the necessary CSS selector.