### PR TITLE
[WIP] build: use Rslib to build packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ node_modules/
 .sonarlint
 
 dist/
+dist-rslib/
 coverage/
 release/
 output/

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@modern-js/module-tools": "2.59.0",
     "@modern-js/tsconfig": "2.59.0",
     "@playwright/test": "1.46.0",
+    "@rslib/core": "latest",
     "@types/cross-spawn": "^6.0.2",
     "@types/fs-extra": "11.0.4",
     "@types/node": "^18.11.17",
@@ -67,5 +68,10 @@
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
+  },
+  "pnpm": {
+    "overrides": {
+      "@rslib/core": "link:../rslib/packages/core"
+    }
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,7 @@
   "scripts": {
     "dev": "modern build -w",
     "build": "modern build",
+    "build:rslib": "rslib build",
     "build:watch": "modern build -w",
     "test": "vitest run",
     "reset": "rimraf ./**/node_modules",

--- a/packages/cli/rslib.config.ts
+++ b/packages/cli/rslib.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      format: 'esm',
+      syntax: 'es2023',
+      //   dts: {
+      //     bundle: true,
+      //     distPath: 'dist-rslib',
+      //   },
+      output: {
+        distPath: {
+          root: 'dist-rslib',
+        },
+        target: 'node',
+      },
+    },
+  ],
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,8 @@
   "scripts": {
     "dev": "modern build -w",
     "build": "modern build",
+    "build:rslib:wip": "rslib build",
+    "--wip--": "tailwind",
     "reset": "rimraf ./**/node_modules",
     "test": "vitest run --passWithNoTests"
   },

--- a/packages/create-rspress/package.json
+++ b/packages/create-rspress/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "dev": "modern build -w",
     "build": "modern build",
+    "build:rslib": "rslib build",
     "build:watch": "modern build -w",
     "reset": "rimraf ./**/node_modules",
     "new": "modern new",

--- a/packages/create-rspress/rslib.config.ts
+++ b/packages/create-rspress/rslib.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      format: 'esm',
+      syntax: 'es2023',
+      //   dts: {
+      //     bundle: true,
+      //     distPath: 'dist-rslib',
+      //   },
+      output: {
+        distPath: {
+          root: 'dist-rslib',
+        },
+        target: 'node',
+      },
+    },
+  ],
+});

--- a/packages/modern-plugin-rspress/package.json
+++ b/packages/modern-plugin-rspress/package.json
@@ -21,7 +21,7 @@
   "main": "./dist/index.js",
   "scripts": {
     "new": "modern new",
-    "build": "modern build",
+    "build:rslib": "rslib build",
     "dev": "modern build --watch"
   },
   "dependencies": {

--- a/packages/modern-plugin-rspress/rslib.config.ts
+++ b/packages/modern-plugin-rspress/rslib.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      format: 'cjs',
+      syntax: 'es2020',
+      //   dts: {
+      //     bundle: true,
+      //     distPath: 'dist-rslib',
+      //   },
+      output: {
+        distPath: {
+          root: 'dist-rslib',
+        },
+        target: 'node',
+      },
+      tools: {
+        rspack: {
+          module: {
+            parser: {
+              'javascript/auto': {
+                wrappedContextRecursive: false,
+              },
+              javascript: {
+                wrappedContextRecursive: false,
+              },
+              'javascript/dynamic': {
+                wrappedContextRecursive: false,
+              },
+              'javascript/esm': {
+                wrappedContextRecursive: false,
+              },
+            },
+          },
+        },
+      },
+    },
+  ],
+});

--- a/packages/plugin-api-docgen/package.json
+++ b/packages/plugin-api-docgen/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "dev": "modern build -w",
     "build": "modern build",
+    "build:rslib": "rslib build",
     "reset": "rimraf ./**/node_modules",
     "test": "vitest run --passWithNoTests"
   },

--- a/packages/plugin-api-docgen/rslib.config.ts
+++ b/packages/plugin-api-docgen/rslib.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      format: 'cjs',
+      syntax: 'es2020',
+      //   dts: {
+      //     bundle: true,
+      //     distPath: 'dist-rslib',
+      //   },
+      output: {
+        sourceMap: {
+          js: 'source-map',
+        },
+        distPath: {
+          root: 'dist-rslib',
+        },
+        target: 'node',
+      },
+    },
+  ],
+});

--- a/packages/plugin-auto-nav-sidebar/package.json
+++ b/packages/plugin-auto-nav-sidebar/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "dev": "modern build -w",
     "build": "modern build",
+    "build:rslib": "rslib build",
     "reset": "rimraf ./**/node_modules",
     "test": "vitest run --passWithNoTests"
   },

--- a/packages/plugin-auto-nav-sidebar/rslib.config.ts
+++ b/packages/plugin-auto-nav-sidebar/rslib.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      format: 'esm',
+      syntax: 'es2020',
+      //   dts: {
+      //     bundle: true,
+      //     distPath: 'dist-rslib',
+      //   },
+      output: {
+        sourceMap: {
+          js: 'source-map',
+        },
+        distPath: {
+          root: 'dist-rslib',
+        },
+        target: 'node',
+      },
+    },
+  ],
+});

--- a/packages/plugin-client-redirects/package.json
+++ b/packages/plugin-client-redirects/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "dev": "modern build -w",
     "build": "modern build",
+    "build:rslib": "rslib build",
     "reset": "rimraf ./**/node_modules",
     "test": "vitest run --passWithNoTests"
   },

--- a/packages/plugin-client-redirects/rslib.config.ts
+++ b/packages/plugin-client-redirects/rslib.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      format: 'esm',
+      syntax: 'es2020',
+      output: {
+        sourceMap: {
+          js: 'source-map',
+        },
+        distPath: {
+          root: 'dist-rslib',
+        },
+        target: 'node',
+      },
+    },
+  ],
+});

--- a/packages/plugin-container-syntax/package.json
+++ b/packages/plugin-container-syntax/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "dev": "modern build -w",
     "build": "modern build",
+    "build:rslib": "rslib build",
     "reset": "rimraf ./**/node_modules",
     "test": "vitest run --passWithNoTests"
   },

--- a/packages/plugin-container-syntax/rslib.config.ts
+++ b/packages/plugin-container-syntax/rslib.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      format: 'esm',
+      syntax: 'es2020',
+      output: {
+        sourceMap: {
+          js: 'source-map',
+        },
+        distPath: {
+          root: 'dist-rslib',
+        },
+        target: 'node',
+      },
+    },
+  ],
+});

--- a/packages/plugin-last-updated/package.json
+++ b/packages/plugin-last-updated/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "dev": "modern build -w",
     "build": "modern build",
+    "build:rslib": "rslib build",
     "reset": "rimraf ./**/node_modules",
     "test": "vitest run --passWithNoTests"
   },

--- a/packages/plugin-last-updated/rslib.config.ts
+++ b/packages/plugin-last-updated/rslib.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      format: 'esm',
+      syntax: 'es2020',
+      output: {
+        sourceMap: {
+          js: 'source-map',
+        },
+        distPath: {
+          root: 'dist-rslib',
+        },
+        target: 'node',
+      },
+    },
+  ],
+});

--- a/packages/plugin-medium-zoom/package.json
+++ b/packages/plugin-medium-zoom/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "dev": "modern build -w",
     "build": "modern build",
+    "build:rslib": "rslib build",
     "reset": "rimraf ./**/node_modules",
     "test": "vitest run --passWithNoTests"
   },

--- a/packages/plugin-medium-zoom/rslib.config.ts
+++ b/packages/plugin-medium-zoom/rslib.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      format: 'esm',
+      syntax: 'es2020',
+      output: {
+        sourceMap: {
+          js: 'source-map',
+        },
+        distPath: {
+          root: 'dist-rslib',
+        },
+        target: 'node',
+      },
+    },
+  ],
+});

--- a/packages/plugin-playground/package.json
+++ b/packages/plugin-playground/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "dev": "modern build -w",
     "build": "modern build",
+    "build:rslib": "rslib build",
     "reset": "rimraf ./**/node_modules",
     "test": "vitest run --passWithNoTests"
   },

--- a/packages/plugin-playground/rslib.config.ts
+++ b/packages/plugin-playground/rslib.config.ts
@@ -1,0 +1,70 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      format: 'cjs',
+      syntax: 'es2020',
+      source: {
+        entry: { index: './src/cli/index.ts' },
+      },
+      output: {
+        sourceMap: {
+          js: 'source-map',
+        },
+        distPath: {
+          root: 'dist-rslib/cli/cjs',
+        },
+        target: 'node',
+      },
+    },
+    {
+      format: 'esm',
+      syntax: 'es2020',
+      source: {
+        entry: { index: './src/cli/index.ts' },
+      },
+      output: {
+        sourceMap: {
+          js: 'source-map',
+        },
+        distPath: {
+          root: 'dist-rslib/cli/esm',
+        },
+        target: 'node',
+      },
+    },
+    {
+      format: 'cjs',
+      syntax: 'es2020',
+      source: {
+        entry: { index: './src/web/index.ts' },
+      },
+      output: {
+        sourceMap: {
+          js: 'source-map',
+        },
+        distPath: {
+          root: 'dist-rslib/web/cjs',
+        },
+        target: 'web',
+      },
+    },
+    {
+      format: 'esm',
+      syntax: 'es2020',
+      source: {
+        entry: { index: './src/web/index.ts' },
+      },
+      output: {
+        sourceMap: {
+          js: 'source-map',
+        },
+        distPath: {
+          root: 'dist-rslib/web/esm',
+        },
+        target: 'web',
+      },
+    },
+  ],
+});

--- a/packages/plugin-preview/package.json
+++ b/packages/plugin-preview/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "dev": "modern build -w",
     "build": "modern build",
+    "build:rslib": "rslib build",
     "reset": "rimraf ./**/node_modules",
     "test": "vitest run --passWithNoTests"
   },

--- a/packages/plugin-preview/rslib.config.ts
+++ b/packages/plugin-preview/rslib.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      format: 'cjs',
+      syntax: 'es2020',
+      output: {
+        sourceMap: {
+          js: 'source-map',
+        },
+        distPath: {
+          root: 'dist-rslib',
+        },
+        target: 'node',
+      },
+    },
+    {
+      format: 'cjs',
+      syntax: 'es2020',
+      source: {
+        entry: {
+          utils: './src/utils.ts',
+        },
+      },
+      output: {
+        sourceMap: {
+          js: 'source-map',
+        },
+        distPath: {
+          root: 'dist-rslib',
+        },
+        target: 'node',
+      },
+    },
+  ],
+});

--- a/packages/plugin-rss/package.json
+++ b/packages/plugin-rss/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "dev": "modern build -w",
     "build": "modern build",
+    "build:rslib": "rslib build",
     "reset": "rimraf ./**/node_modules",
     "test": "vitest run --passWithNoTests"
   },

--- a/packages/plugin-rss/rslib.config.ts
+++ b/packages/plugin-rss/rslib.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      format: 'cjs',
+      syntax: 'es2020',
+    },
+    {
+      format: 'esm',
+      syntax: 'es2020',
+    },
+  ],
+  output: {
+    distPath: {
+      root: 'dist-rslib',
+    },
+    sourceMap: {
+      js: 'source-map',
+    },
+    target: 'node',
+  },
+});

--- a/packages/plugin-shiki/package.json
+++ b/packages/plugin-shiki/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "dev": "modern build -w",
     "build": "modern build",
+    "build:rslib": "rslib build",
     "reset": "rimraf ./**/node_modules",
     "test": "vitest run --passWithNoTests"
   },

--- a/packages/plugin-shiki/rslib.config.ts
+++ b/packages/plugin-shiki/rslib.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      format: 'esm',
+      syntax: 'es2020',
+      output: {
+        sourceMap: {
+          js: 'source-map',
+        },
+        distPath: {
+          root: 'dist-rslib',
+        },
+        target: 'node',
+      },
+    },
+  ],
+});

--- a/packages/plugin-typedoc/package.json
+++ b/packages/plugin-typedoc/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "dev": "modern build -w",
     "build": "modern build",
+    "build:rslib": "rslib build",
     "reset": "rimraf ./**/node_modules",
     "test": "vitest run --passWithNoTests"
   },

--- a/packages/plugin-typedoc/rslib.config.ts
+++ b/packages/plugin-typedoc/rslib.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      format: 'esm',
+      syntax: 'es2020',
+      output: {
+        sourceMap: {
+          js: 'source-map',
+        },
+        distPath: {
+          root: 'dist-rslib/es',
+        },
+        target: 'node',
+      },
+    },
+    {
+      format: 'cjs',
+      syntax: 'es2020',
+      output: {
+        sourceMap: {
+          js: 'source-map',
+        },
+        distPath: {
+          root: 'dist-rslib/lib',
+        },
+        target: 'node',
+      },
+    },
+  ],
+});

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -24,6 +24,8 @@
   "scripts": {
     "dev": "modern build -w",
     "build": "modern build",
+    "build:rslib:wip": "rslib build",
+    "--wip--": "export * from external module",
     "reset": "rimraf ./**/node_modules",
     "test": "echo nothing"
   },

--- a/packages/runtime/rslib.config.ts
+++ b/packages/runtime/rslib.config.ts
@@ -1,0 +1,51 @@
+import { defineConfig } from '@rslib/core';
+
+// Useless, in bundleless mode, all dependencies are treated as external.
+const COMMON_EXTERNALS = [
+  '@theme',
+  'virtual-search-index-hash',
+  'virtual-site-data',
+  'virtual-global-styles',
+  'virtual-global-components',
+  'virtual-search-hooks',
+  '@/runtime',
+  '@runtime',
+  'virtual-i18n-text',
+  'virtual-prism-languages',
+];
+
+const CJS_EXTERNALS = ['virtual-routes-ssr', 'virtual-routes'];
+
+export default defineConfig({
+  lib: [
+    {
+      format: 'esm',
+      bundle: false,
+      syntax: 'es2020',
+      source: {
+        entry: {
+          index: ['./src/**'],
+        },
+      },
+      output: {
+        externals: {
+          ...COMMON_EXTERNALS.reduce((acc, name) => {
+            acc[name] = `${name}`;
+            return acc;
+          }, {}),
+          ...CJS_EXTERNALS.reduce((acc, name) => {
+            acc[name] = `commonjs ${name}`;
+            return acc;
+          }, {}),
+        },
+        sourceMap: {
+          js: 'source-map',
+        },
+        distPath: {
+          root: 'dist-rslib/es',
+        },
+        target: 'node',
+      },
+    },
+  ],
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -44,6 +44,8 @@
   "scripts": {
     "dev": "modern build -w",
     "build": "modern build",
+    "build:rslib:wip": "rslib build",
+    "--wip--": "export * from external module",
     "build:watch": "modern build -w",
     "test": "vitest run",
     "reset": "rimraf ./**/node_modules",

--- a/packages/shared/rslib.config.ts
+++ b/packages/shared/rslib.config.ts
@@ -1,0 +1,45 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      format: 'esm',
+      bundle: false,
+      syntax: 'es2023',
+      source: {
+        entry: {
+          index: [
+            'src/index.ts',
+            'src/logger.ts',
+            'src/fs-extra.ts',
+            'src/chalk.ts',
+            'src/execa.ts',
+            'src/node-utils.ts',
+          ],
+        },
+      },
+    },
+    {
+      format: 'cjs',
+      bundle: false,
+      syntax: 'es2023',
+      source: {
+        entry: {
+          index: [
+            'src/index.ts',
+            'src/logger.ts',
+            'src/fs-extra.ts',
+            'src/chalk.ts',
+            'src/execa.ts',
+            'src/node-utils.ts',
+          ],
+        },
+      },
+    },
+  ],
+  output: {
+    distPath: {
+      root: 'dist-rslib',
+    },
+  },
+});

--- a/packages/theme-default/package.json
+++ b/packages/theme-default/package.json
@@ -28,6 +28,8 @@
   "scripts": {
     "dev": "modern build -w",
     "build": "modern build",
+    "build:rslib:wip": "rslib build",
+    "--wip--": "SVGR and tailwindcss is not ready",
     "reset": "rimraf ./**/node_modules",
     "test": "echo nothing"
   },

--- a/packages/theme-default/rslib.config.ts
+++ b/packages/theme-default/rslib.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [],
+  output: {
+    distPath: {
+      root: 'dist-rslib',
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@rslib/core': link:../rslib/packages/core
+
 importers:
 
   .:
@@ -23,6 +26,9 @@ importers:
       '@playwright/test':
         specifier: 1.46.0
         version: 1.46.0
+      '@rslib/core':
+        specifier: link:../rslib/packages/core
+        version: link:../rslib/packages/core
       '@types/cross-spawn':
         specifier: ^6.0.2
         version: 6.0.2


### PR DESCRIPTION
## Summary

This PR is far from complete, it's just here to document the migration process and identify potential issues (see the @rslib/core is even linked for debugging :P ). When this PR is ready for review, Rspress will be built by Rslib.

So far, just by looking at the output, the package can't be built is marked by `"--wip--"` and the reason is attached.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
