### PR TITLE
feat(style): use a compact layout when there are many nav items

### DIFF
--- a/packages/theme-default/src/components/Nav/NavMenuSingleItem.tsx
+++ b/packages/theme-default/src/components/Nav/NavMenuSingleItem.tsx
@@ -12,6 +12,7 @@ interface Props {
   langs?: string[];
   base: string;
   rightIcon?: React.ReactNode;
+  shrink?: boolean;
 }
 
 export function NavMenuSingleItem(
@@ -28,7 +29,7 @@ export function NavMenuSingleItem(
         key={item.text}
         className={`rspress-nav-menu-item ${styles.singleItem} ${
           isActive ? styles.activeItem : ''
-        } text-sm font-medium mx-1.5 px-3 py-2 flex items-center`}
+        } text-sm font-medium ${item.shrink ? 'mx-0.5' : 'mx-1.5'} px-3 py-2 flex items-center`}
       >
         <Tag tag={item.tag} />
         {item.text}

--- a/packages/theme-default/src/components/Nav/NavMenuSingleItem.tsx
+++ b/packages/theme-default/src/components/Nav/NavMenuSingleItem.tsx
@@ -12,7 +12,7 @@ interface Props {
   langs?: string[];
   base: string;
   rightIcon?: React.ReactNode;
-  shrink?: boolean;
+  compact?: boolean;
 }
 
 export function NavMenuSingleItem(
@@ -29,7 +29,7 @@ export function NavMenuSingleItem(
         key={item.text}
         className={`rspress-nav-menu-item ${styles.singleItem} ${
           isActive ? styles.activeItem : ''
-        } text-sm font-medium ${item.shrink ? 'mx-0.5' : 'mx-1.5'} px-3 py-2 flex items-center`}
+        } text-sm font-medium ${item.compact ? 'mx-0.5' : 'mx-1.5'} px-3 py-2 flex items-center`}
       >
         <Tag tag={item.tag} />
         {item.text}

--- a/packages/theme-default/src/components/Nav/index.tsx
+++ b/packages/theme-default/src/components/Nav/index.tsx
@@ -69,6 +69,7 @@ export function Nav(props: NavProps) {
               langs={langs}
               base={base}
               key={item.link}
+              shrink={menuItems.length > 5}
               {...item}
             />
           );

--- a/packages/theme-default/src/components/Nav/index.tsx
+++ b/packages/theme-default/src/components/Nav/index.tsx
@@ -69,7 +69,7 @@ export function Nav(props: NavProps) {
               langs={langs}
               base={base}
               key={item.link}
-              shrink={menuItems.length > 5}
+              compact={menuItems.length > 5}
               {...item}
             />
           );

--- a/packages/theme-default/src/components/Search/index.module.scss
+++ b/packages/theme-default/src/components/Search/index.module.scss
@@ -213,7 +213,7 @@
   cursor: pointer;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 960px) {
   .navSearchButton {
     display: none;
   }

--- a/packages/theme-default/src/logic/useNav.ts
+++ b/packages/theme-default/src/logic/useNav.ts
@@ -32,7 +32,7 @@ export function useNavScreen() {
    * Close screen when the user resizes the window wider than tablet size.
    */
   function closeScreenOnTabletWindow() {
-    window.outerWidth >= 960 && closeScreen();
+    window.outerWidth >= 768 && closeScreen();
   }
 
   return {

--- a/packages/theme-default/src/logic/useNav.ts
+++ b/packages/theme-default/src/logic/useNav.ts
@@ -32,7 +32,7 @@ export function useNavScreen() {
    * Close screen when the user resizes the window wider than tablet size.
    */
   function closeScreenOnTabletWindow() {
-    window.outerWidth >= 768 && closeScreen();
+    window.outerWidth >= 960 && closeScreen();
   }
 
   return {


### PR DESCRIPTION
## Summary

Use a compact layout when there are many nav items, this ensures that nav items can be displayed as much as possible on small screens.

- before:

![image](https://github.com/user-attachments/assets/da7c4529-8cc6-443c-b286-a1b4ba958e80)

- after:

![image](https://github.com/user-attachments/assets/a3b9ec8a-05de-4530-a95b-311a162ba6cb)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
