### PR TITLE
feat(theme-default): adjust the color contrast in dark mode

### DIFF
--- a/packages/document/docs/en/guide/start/introduction.mdx
+++ b/packages/document/docs/en/guide/start/introduction.mdx
@@ -38,7 +38,7 @@ At the same time, Rspress internally also applies many other build optimization 
 
 In order to ensure the flexibility of content development, Rspress chooses to support the MDX content format.
 
-Because MDX actually represents a componentized content organization method behind it. On the one hand, documents are components, so we can reuse document fragments between different documents. On the other hand, any custom React components can be introduced in the document, greatly releasing the imagination of document development.
+MDX represents a method of componentized content organization. In other words, documents serve as components, allowing for the reuse of document fragments across different documents. Additionally, custom React components can be incorporated into documents, significantly enhancing the flexibility of document development.
 
 ### Basic Capabilities of Documentation Site
 

--- a/packages/theme-default/src/styles/vars.css
+++ b/packages/theme-default/src/styles/vars.css
@@ -52,7 +52,7 @@
 }
 
 .dark {
-  --rp-c-bg: #23272f;
+  --rp-c-bg: #191D24;
   --rp-c-bg-soft: #292e37;
   --rp-c-bg-mute: #343a46;
   --rp-c-bg-alt: #000;
@@ -60,7 +60,7 @@
   --rp-c-divider: rgba(84, 84, 84, 0.65);
   --rp-c-divider-light: rgba(84, 84, 84, 0.48);
 
-  --rp-c-text-1: rgba(255, 255, 255, 0.87);
+  --rp-c-text-1: rgba(255, 255, 255, 1);
   --rp-c-text-2: rgba(235, 235, 235, 0.56);
   --rp-c-text-3: rgba(235, 235, 235, 0.38);
   --rp-c-text-4: rgba(235, 235, 235, 0.18);

--- a/packages/theme-default/src/styles/vars.css
+++ b/packages/theme-default/src/styles/vars.css
@@ -60,7 +60,8 @@
   --rp-c-divider: rgba(84, 84, 84, 0.65);
   --rp-c-divider-light: rgba(84, 84, 84, 0.48);
 
-  --rp-c-text-1: rgba(255, 255, 255, 1);
+
+  --rp-c-text-1: rgba(255, 255, 245, 0.93);
   --rp-c-text-2: rgba(235, 235, 235, 0.56);
   --rp-c-text-3: rgba(235, 235, 235, 0.38);
   --rp-c-text-4: rgba(235, 235, 235, 0.18);


### PR DESCRIPTION
## Summary

Improve the color contrast of default theme in dark mode.

According to [WebAIM](https://webaim.org/resources/contrastchecker/), the default color contrast for Rspress is low at 11, which makes the docs difficult to read. Here I changed the default theme color to improve the contrast ratio to 16.

Here i changed the default theme color to improve the contrast to 16. 


![image](https://github.com/user-attachments/assets/f4f21684-9123-4fe9-8f1e-55c93143f402)

Some data for reference:

|Site| Contrast (by WebAIM)|
|----|--------------|
|NextJS|17.93|
|ReactJS|13.95|
|Rspress (before this PR)|11.65|
|Rspress (after this PR)| 16.9|

![CleanShot 2024-10-08 at 14 57 04@2x](https://github.com/user-attachments/assets/af84c0cc-34db-4776-9110-463a4dd1269b)

![CleanShot 2024-10-08 at 14 57 16@2x](https://github.com/user-attachments/assets/d29b40d0-b3d1-4e31-97b7-c724a78f6453)


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
