### PR TITLE
feat: enable Rsbuild CLI shortcuts

### DIFF
--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -135,6 +135,10 @@ async function createInternalBuildConfig(
           middlewares.unshift(serveSearchIndexMiddleware(config));
         },
       ],
+      cliShortcuts: {
+        // does not support restart server yet
+        custom: shortcuts => shortcuts.filter(({ key }) => key !== 'r'),
+      },
     },
     html: {
       title: config?.title ?? DEFAULT_TITLE,


### PR DESCRIPTION
## Summary

Enable the Rsbuild CLI shortcuts feature:

<img width="860" alt="Screenshot 2024-10-09 at 13 32 26" src="https://github.com/user-attachments/assets/39df0493-8d78-4060-bdec-e42bd691d793">

## Related Issue

https://rsbuild.dev/config/dev/cli-shortcuts

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
