### PR TITLE
chore: remove unused modern config file

### DIFF
--- a/modern.config.js
+++ b/modern.config.js
@@ -1,5 +1,0 @@
-import { monorepoTools } from '@modern-js/monorepo-tools';
-
-module.exports = {
-  plugins: [monorepoTools()],
-};


### PR DESCRIPTION
## Summary

Remove unused modern config file as `@modern-js/monorepo-tools` has been removed:

https://github.com/web-infra-dev/rspress/pull/918

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
