### PR TITLE
fix(theme-default): Capitalise the 'P' in 'Next page'

### DIFF
--- a/packages/theme-default/src/components/PrevNextPage/index.tsx
+++ b/packages/theme-default/src/components/PrevNextPage/index.tsx
@@ -10,7 +10,7 @@ interface PrevNextPageProps {
 
 export function PrevNextPage(props: PrevNextPageProps) {
   const { type, text, href } = props;
-  const { prevPageText = 'Previous Page', nextPageText = 'Next page' } =
+  const { prevPageText = 'Previous Page', nextPageText = 'Next Page' } =
     useLocaleSiteData();
   const pageText = type === 'prev' ? prevPageText : nextPageText;
   const linkClassName =


### PR DESCRIPTION
## Summary

In the previous/next page links at the bottom of docs pages, the text used to read "Previous Page" (title case) and "Next page" (sentence case). This changes the "Next Page" link to title case so that the two links match style.

![Screenshot of the updated link text](https://github.com/user-attachments/assets/7ed764c7-d020-479a-be9b-f449493ab9c3)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
