### PR TITLE
fix: use front matter as overview page title

### DIFF
--- a/.changeset/blue-fireants-rescue.md
+++ b/.changeset/blue-fireants-rescue.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+release

--- a/packages/document/docs/en/api/index.mdx
+++ b/packages/document/docs/en/api/index.mdx
@@ -1,3 +1,4 @@
 ---
 overview: true
+title: API Overview
 ---

--- a/packages/document/docs/en/guide/default-theme/overview-page.mdx
+++ b/packages/document/docs/en/guide/default-theme/overview-page.mdx
@@ -33,9 +33,24 @@ overview: true
 ---
 ```
 
+::: note
+
+The title of the overview page can be configured through frontmatter. The default value is `Overview`. After `title` is configured in frontmatter, there is no need to write an H1 title in the markdown content.
+
+```md
+---
+overview: true
+title: Overview
+---
+
+This is an Overview page of our website.
+```
+
+:::
+
 ### 2. Configuring `_meta.json`
 
-The content structure of the preview page will be automatically generated according to `_meta.json` and the corresponding h1, h2 titles of the article. For example, the configuration of `api/_meta.json` is as follows:
+The content structure of the overview page will be automatically generated according to `_meta.json` and the corresponding h1, h2 titles of the article. For example, the configuration of `api/_meta.json` is as follows:
 
 ```json
 [

--- a/packages/document/docs/zh/api/index.mdx
+++ b/packages/document/docs/zh/api/index.mdx
@@ -1,3 +1,4 @@
 ---
 overview: true
+title: API 概览
 ---

--- a/packages/document/docs/zh/guide/default-theme/overview-page.mdx
+++ b/packages/document/docs/zh/guide/default-theme/overview-page.mdx
@@ -33,6 +33,21 @@ overview: true
 ---
 ```
 
+::: note
+
+预览页的标题可以通过 frontmatter 进行配置，默认为 `Overview`，在 frontmatter 中配置了 `title` 后，正文中不需要再写 H1 标题。
+
+```md
+---
+overview: true
+title: Overview
+---
+
+This is an Overview page of our website.
+```
+
+:::
+
 ### 2. 配置 `_meta.json`
 
 预览页面的内容结构会根据 `_meta.json` 及其对应文章的 h1、h2 标题自动生成。比如 `api/_meta.json` 的配置如下：

--- a/packages/theme-default/src/components/Overview/index.tsx
+++ b/packages/theme-default/src/components/Overview/index.tsx
@@ -273,14 +273,14 @@ export function Overview(props: {
       .filter(Boolean);
   }, [groups, query]);
 
+  const overviewTitle = title || 'Overview';
+
   return (
     <div className="overview-index mx-auto px-8">
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between">
-        {!title && (
-          <h1 className="text-3xl leading-10 tracking-tight mb-4 sm:mb-0">
-            Overview
-          </h1>
-        )}
+        <h1 className="text-3xl leading-10 tracking-tight mb-4 sm:mb-0">
+          {overviewTitle}
+        </h1>
         {/* Added search input */}
         <SearchInput query={query} setQuery={setQuery} searchRef={searchRef} />
       </div>


### PR DESCRIPTION
## Summary

A solution to fix https://github.com/web-infra-dev/rspress/pull/1493#discussion_r1804705782

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
