### PR TITLE
fix: correctly iterate over plugins when using `removePlugin`

### DIFF
--- a/packages/core/src/node/PluginDriver.ts
+++ b/packages/core/src/node/PluginDriver.ts
@@ -108,13 +108,22 @@ export class PluginDriver {
   async modifyConfig() {
     let config = this.#config;
 
-    for (const plugin of this.#plugins) {
+    for (let i = 0; i < this.#plugins.length; i++) {
+      const plugin = this.#plugins[i];
       if (typeof plugin.config === 'function') {
         config = await plugin.config(
           config || {},
           {
             addPlugin: this.addPlugin.bind(this),
-            removePlugin: this.removePlugin.bind(this),
+            removePlugin: (pluginName: string) => {
+              const index = this.#plugins.findIndex(
+                item => item.name === pluginName,
+              );
+              this.removePlugin(pluginName);
+              if (index <= i) {
+                i--;
+              }
+            },
           },
           this.#isProd,
         );


### PR DESCRIPTION
## Summary

When calling modifyConfig, if some plugins call `removePlugin` or `addPlugin`, the index of the plugin in `this.#plugins` will change. Since `addPlugin` uses `push`, it will not affect the index of other plugins. If it is `removePlugin`, it is necessary to consider whether the plugin to be removed is before the current traversal index. If so, the plugins after the index will move forward 1 in `this.#plugins`. If not, there will be no impact.

## Related Issue

Closes #1487
<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
