### PR TITLE
fix: remove built-in override browserslist

### DIFF
--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -86,16 +86,6 @@ async function createInternalBuildConfig(
     return icon;
   };
 
-  // Using latest browserslist in development to improve build performance
-  const webBrowserslist = isProduction()
-    ? ['chrome >= 87', 'edge >= 88', 'firefox >= 78', 'safari >= 14']
-    : [
-        'last 1 chrome version',
-        'last 1 firefox version',
-        'last 1 safari version',
-      ];
-  const ssrBrowserslist = ['node >= 14'];
-
   const [detectCustomIconAlias, reactCSRAlias, reactSSRAlias] =
     await Promise.all([
       detectCustomIcon(CUSTOM_THEME_DIR),
@@ -266,7 +256,6 @@ async function createInternalBuildConfig(
         },
         output: {
           target: 'web',
-          overrideBrowserslist: webBrowserslist,
           distPath: {
             root: csrOutDir,
           },
@@ -290,7 +279,6 @@ async function createInternalBuildConfig(
               output: {
                 emitAssets: false,
                 target: 'node',
-                overrideBrowserslist: ssrBrowserslist,
                 distPath: {
                   root: ssrOutDir,
                 },


### PR DESCRIPTION
## Summary

close: #1514 

Use default value of browserslist of Rsbuild, see https://rsbuild.dev/guide/advanced/browserslist#default-browserslist.

Now users can set browserslist in `builderConfig.output.overrideBrowserslist`.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
