### PR TITLE
fix: langRoutePrefix should end with slash

### DIFF
--- a/packages/theme-default/src/logic/useLocaleSiteData.ts
+++ b/packages/theme-default/src/logic/useLocaleSiteData.ts
@@ -1,4 +1,4 @@
-import type { NormalizedLocales } from '@rspress/shared';
+import { addTrailingSlash, type NormalizedLocales } from '@rspress/shared';
 import { usePageData } from '@rspress/runtime';
 
 export function useLocaleSiteData(): NormalizedLocales {
@@ -26,6 +26,6 @@ export function useLocaleSiteData(): NormalizedLocales {
 
   return {
     ...localeInfo,
-    langRoutePrefix: lang === defaultLang ? '/' : lang,
+    langRoutePrefix: lang === defaultLang ? '/' : addTrailingSlash(lang),
   } as NormalizedLocales;
 }


### PR DESCRIPTION
## Summary

`langRoutePrefix` is used at https://github.com/web-infra-dev/rspress/blob/ae1bf881bbed54b13c7f31d457eb9984806c50d3/packages/theme-default/src/components/Nav/NavBarTitle.tsx#L47

Without the trailing slash, for located pages, it renders `/zh` for example, which means `/zh.html` but it should be `/zh/index.html` actually. And this change matches the default `langRoutePrefix` (`/`).

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
