### PR TITLE
chore: add margin bottom for overview page h1

### DIFF
--- a/packages/theme-default/src/components/Overview/index.tsx
+++ b/packages/theme-default/src/components/Overview/index.tsx
@@ -311,9 +311,7 @@ export function Overview(props: {
   return (
     <div className="overview-index mx-auto px-8">
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between mb-10">
-        <h1 className="text-3xl leading-10 tracking-tight sm:mb-0">
-          {overviewTitle}
-        </h1>
+        <h1 className="text-3xl leading-10 tracking-tight">{overviewTitle}</h1>
         {/* Added search input */}
         <SearchInput
           query={query}

--- a/packages/theme-default/src/components/Overview/index.tsx
+++ b/packages/theme-default/src/components/Overview/index.tsx
@@ -310,8 +310,8 @@ export function Overview(props: {
 
   return (
     <div className="overview-index mx-auto px-8">
-      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between">
-        <h1 className="text-3xl leading-10 tracking-tight mb-4 sm:mb-0">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between mb-10">
+        <h1 className="text-3xl leading-10 tracking-tight sm:mb-0">
           {overviewTitle}
         </h1>
         {/* Added search input */}


### PR DESCRIPTION
## Summary

align with margin-bottom of h1 in basic page

### before
![image](https://github.com/user-attachments/assets/ffd0c227-4bfd-4d06-a48f-83045ab4f721)

### after
![image](https://github.com/user-attachments/assets/bb439293-53ea-4fc7-9b51-91bda69a3925)


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
