### PR TITLE
perf(cli): enable Node.js compile cache

### DIFF
--- a/packages/cli/bin/rspress.js
+++ b/packages/cli/bin/rspress.js
@@ -1,3 +1,15 @@
 #!/usr/bin/env node
-// eslint-disable-next-line import/no-useless-path-segments, node/file-extension-in-import
+import nodeModule from 'node:module';
+
+// enable on-disk code caching of all modules loaded by Node.js
+// requires Nodejs >= 22.8.0
+const { enableCompileCache } = nodeModule;
+if (enableCompileCache) {
+  try {
+    enableCompileCache();
+  } catch {
+    // ignore errors
+  }
+}
+
 import('../dist/index.js');


### PR DESCRIPTION
## Summary

Enable Node.js 22 new compile cache in Rspress CLI, this makes Node.js startup faster.

- before:

<img width="874" alt="Screenshot 2024-11-04 at 16 17 15" src="https://github.com/user-attachments/assets/15c145a5-685d-4dff-bd01-2fd30d9f24ba">

- after:

<img width="867" alt="Screenshot 2024-11-04 at 16 17 03" src="https://github.com/user-attachments/assets/54a4f190-8213-4799-9647-f5dc2e451d18">

## Related Links

- https://nodejs.org/id/blog/release/v22.8.0
- https://github.com/nodejs/node/pull/54501
- https://github.com/web-infra-dev/rsbuild/pull/3627
- https://github.com/web-infra-dev/rspack/pull/8331

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
