### PR TITLE
fix: incorrect code link color

### DIFF
--- a/packages/theme-default/src/styles/code.css
+++ b/packages/theme-default/src/styles/code.css
@@ -20,18 +20,19 @@
   --rp-code-line-number-color: rgba(60, 60, 60, 0.33);
 }
 
-.rspress-doc :not(pre, h1, h2, h3, h4, h5, h6) > code
-{
+.rspress-doc :not(pre, h1, h2, h3, h4, h5, h6) > code {
   font-size: var(--rp-code-font-size);
 }
 
-.rspress-doc :not(pre, div) > code
-{
+.rspress-doc :not(pre, div) > code {
   padding: 3px 6px;
   border-radius: var(--rp-radius-small);
-  color: var(--rp-c-text-code);
   background-color: var(--rp-c-text-code-bg);
   overflow-wrap: break-word;
+}
+
+.rspress-doc :not(pre, div, a) > code {
+  color: var(--rp-c-text-code);
 }
 
 .rspress-doc h1 > code,
@@ -119,7 +120,6 @@
 .rspress-doc [class^='language-'] .rspress-code-content {
   position: relative;
 }
-
 
 .rspress-doc [class^='language-'] .rspress-code-content span.highlighted {
   background-color: var(--rp-code-line-highlight-color);


### PR DESCRIPTION
## Summary

Fix incorrect code link color.

- Input:

```md
[`This is code link`](https://rsbuild.dev/)

[This is link](https://rsbuild.dev/)

`This is code`
```

- before this PR:

<img width="635" alt="Screenshot 2024-11-05 at 11 21 07" src="https://github.com/user-attachments/assets/a5262f5a-4278-4893-b872-c95659746315">

- with this PR:

<img width="625" alt="Screenshot 2024-11-05 at 11 27 04" src="https://github.com/user-attachments/assets/947534ac-996c-435b-b267-76fbe6b3871c">

## Related Issue

We have fixed this issue in https://github.com/web-infra-dev/rspress/pull/1016, but it is broken again. I think LightningCSS changed the CSS priority and caused this bug.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
