### PR TITLE
fix: aside text should break word

### DIFF
--- a/packages/theme-default/src/components/Aside/index.scss
+++ b/packages/theme-default/src/components/Aside/index.scss
@@ -20,4 +20,5 @@
   padding: 0px 12px;
   font-size: 0.8125rem;
   line-height: 1.25rem;
+  word-break: break-all;
 }

--- a/packages/theme-default/src/components/Aside/index.scss
+++ b/packages/theme-default/src/components/Aside/index.scss
@@ -20,5 +20,5 @@
   padding: 0px 12px;
   font-size: 0.8125rem;
   line-height: 1.25rem;
-  word-break: break-all;
+  overflow-wrap: break-word;
 }


### PR DESCRIPTION
## Summary

### Before

![image](https://github.com/user-attachments/assets/4701c19a-4a4c-4c72-a4b2-42d13ab6e0be)

### After

![image](https://github.com/user-attachments/assets/c64837b0-489c-4b14-8fe9-72873a4ecdf3)


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
