### PR TITLE
chore(CI): update to Node 22

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,10 +30,10 @@ jobs:
       - name: Install Pnpm
         run: corepack enable
 
-      - name: Setup Node.js 18.x
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: 'pnpm'
 
       - name: Install Dependencies

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -24,10 +24,10 @@ jobs:
       - name: Install Pnpm
         run: corepack enable
 
-      - name: Setup Node.js 18
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: 22.x
           cache: 'pnpm'
 
       - name: Install npm v9

--- a/.github/workflows/release-pull-request-with-modernjs.yml
+++ b/.github/workflows/release-pull-request-with-modernjs.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js 18
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: 22.x
           cache: 'pnpm'
 
       - name: Nx Cache

--- a/.github/workflows/release-pull-request-without-modernjs.yml
+++ b/.github/workflows/release-pull-request-without-modernjs.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Install Pnpm
         run: corepack enable
 
-      - name: Setup Node.js 18
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: 22.x
           cache: 'pnpm'
 
       - name: Nx Cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,15 +32,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 25
+          fetch-depth: 5
 
       - name: Install Pnpm
         run: corepack enable
 
-      - name: Setup Node.js 18
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: 22.x
           cache: 'pnpm'
 
       - name: Install npm v9

--- a/.github/workflows/test-Windows.yml
+++ b/.github/workflows/test-Windows.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
         os: [windows-latest] # windows-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 25
+          fetch-depth: 1
 
       - name: Install Pnpm
         run: corepack enable

--- a/.github/workflows/test-macOS.yml
+++ b/.github/workflows/test-macOS.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
         os: [macos-14] # M1 Mac
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 25
+          fetch-depth: 1
 
       - name: Install Pnpm
         run: corepack enable


### PR DESCRIPTION
## Summary

Update to Node 22 (current LTS) to make CI faster.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
