### PR TITLE
chore(CI): reduce playwright install time

### DIFF
--- a/.github/workflows/test-Windows.yml
+++ b/.github/workflows/test-Windows.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: E2E Test
         if: ${{steps.skip-ci.outputs.RESULT != 'true'}}
-        run: npx playwright install --with-deps && pnpm run test:e2e
+        run: npx playwright install --with-deps chromium && pnpm run test:e2e
 
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-macOS.yml
+++ b/.github/workflows/test-macOS.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: E2E Test
         if: ${{steps.skip-ci.outputs.RESULT != 'true'}}
-        run: npx playwright install --with-deps && pnpm run test:e2e
+        run: npx playwright install --with-deps chromium && pnpm run test:e2e
 
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Reduce playwright install time, only `chromium` is required.

## Related Issue

https://playwright.dev/docs/browsers#install-system-dependencies

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
