### PR TITLE
fix: remove `@modern-js/utils` dependency

### DIFF
--- a/.changeset/new-students-promise.md
+++ b/.changeset/new-students-promise.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-rspress': patch
+'@rspress/plugin-api-docgen': patch
+'@rspress/core': patch
+---
+
+fix: remove `@modern-js/utils` dependency

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,6 @@
     "@mdx-js/loader": "2.3.0",
     "@mdx-js/mdx": "2.3.0",
     "@mdx-js/react": "2.3.0",
-    "@modern-js/utils": "2.62.0",
     "@rsbuild/core": "~1.1.1",
     "@rsbuild/plugin-less": "~1.1.0",
     "@rsbuild/plugin-react": "~1.0.7",

--- a/packages/modern-plugin-rspress/package.json
+++ b/packages/modern-plugin-rspress/package.json
@@ -27,10 +27,12 @@
   "dependencies": {
     "@rspress/core": "workspace:*",
     "@rspress/plugin-api-docgen": "workspace:*",
-    "@rspress/plugin-preview": "workspace:*"
+    "@rspress/plugin-preview": "workspace:*",
+    "fast-glob": "^3.2.12",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@modern-js/utils": "2.62.0",
+    "@types/lodash": "^4.17.13",
     "@types/node": "^18.11.17",
     "@types/react": "^18.3.12",
     "react": "^18.3.1",

--- a/packages/modern-plugin-rspress/src/lanchDoc.ts
+++ b/packages/modern-plugin-rspress/src/lanchDoc.ts
@@ -1,5 +1,6 @@
 import { join, relative, resolve } from 'node:path';
-import { fs, fastGlob } from '@modern-js/utils';
+import fs from 'node:fs';
+import fastGlob from 'fast-glob';
 import { pluginPreview } from '@rspress/plugin-preview';
 import type { UserConfig, Sidebar, SidebarGroup } from '@rspress/core';
 import { pluginApiDocgen } from '@rspress/plugin-api-docgen';

--- a/packages/modern-plugin-rspress/src/utils.ts
+++ b/packages/modern-plugin-rspress/src/utils.ts
@@ -1,4 +1,4 @@
-import _ from '@modern-js/utils/lodash';
+import _ from 'lodash';
 
 export const mergeModuleDocConfig = <T>(...configs: T[]): T =>
   _.mergeWith(

--- a/packages/plugin-api-docgen/package.json
+++ b/packages/plugin-api-docgen/package.json
@@ -22,14 +22,14 @@
     "node": ">=14.17.6"
   },
   "dependencies": {
-    "@modern-js/utils": "2.62.0",
+    "@rspress/shared": "workspace:*",
+    "chokidar": "^3.6.0",
     "documentation": "14.0.3",
     "react-docgen-typescript": "2.2.2",
     "react-markdown": "8.0.7",
     "remark-gfm": "3.0.1"
   },
   "devDependencies": {
-    "@rspress/shared": "workspace:*",
     "@types/mdast": "^4.0.4",
     "@types/node": "^18.11.17",
     "@types/react": "^18.3.12",

--- a/packages/plugin-api-docgen/src/docgen.ts
+++ b/packages/plugin-api-docgen/src/docgen.ts
@@ -1,6 +1,8 @@
 import path from 'node:path';
 import type { ComponentDoc, PropItem } from 'react-docgen-typescript';
-import { logger, chokidar, fs } from '@modern-js/utils';
+import fs from 'node:fs';
+import { logger } from '@rspress/shared/logger';
+import chokidar from 'chokidar';
 import {
   withDefaultConfig,
   withCustomConfig,

--- a/packages/plugin-api-docgen/src/index.ts
+++ b/packages/plugin-api-docgen/src/index.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import type { RspressPlugin } from '@rspress/shared';
-import fs from '@modern-js/utils/fs-extra';
+import fs from 'node:fs';
 import type {
   PluginOptions,
   SupportLanguages,
@@ -48,7 +48,7 @@ export function pluginApiDocgen(options?: PluginOptions): RspressPlugin {
       await Promise.all(
         pages.map(async page => {
           const { _filepath, lang } = page;
-          let content = await fs.readFile(_filepath, 'utf-8');
+          let content = await fs.promises.readFile(_filepath, 'utf-8');
           let matchResult = new RegExp(apiCompRegExp).exec(content);
           if (!matchResult) {
             return;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -596,9 +596,6 @@ importers:
       '@mdx-js/react':
         specifier: 2.3.0
         version: 2.3.0(react@18.3.1)
-      '@modern-js/utils':
-        specifier: 2.62.0
-        version: 2.62.0
       '@rsbuild/core':
         specifier: ~1.1.1
         version: 1.1.1
@@ -834,10 +831,16 @@ importers:
       '@rspress/plugin-preview':
         specifier: workspace:*
         version: link:../plugin-preview
+      fast-glob:
+        specifier: ^3.2.12
+        version: 3.3.2
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
     devDependencies:
-      '@modern-js/utils':
-        specifier: 2.62.0
-        version: 2.62.0
+      '@types/lodash':
+        specifier: ^4.17.13
+        version: 4.17.13
       '@types/node':
         specifier: ^18.11.17
         version: 18.11.17
@@ -859,12 +862,15 @@ importers:
 
   packages/plugin-api-docgen:
     dependencies:
-      '@modern-js/utils':
-        specifier: 2.62.0
-        version: 2.62.0
       '@rspress/core':
         specifier: workspace:^1.37.0
         version: link:../core
+      '@rspress/shared':
+        specifier: workspace:*
+        version: link:../shared
+      chokidar:
+        specifier: ^3.6.0
+        version: 3.6.0
       documentation:
         specifier: 14.0.3
         version: 14.0.3
@@ -878,9 +884,6 @@ importers:
         specifier: 3.0.1
         version: 3.0.1
     devDependencies:
-      '@rspress/shared':
-        specifier: workspace:*
-        version: link:../shared
       '@types/mdast':
         specifier: ^4.0.4
         version: 4.0.4


### PR DESCRIPTION
## Summary

`@modern-js/utils` is an internal package of [Modern.js](https://github.com/web-infra-dev/modern.js), Rspress should not depend on it.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
