### PR TITLE
perf: remove `react-transition-group` dependency

### DIFF
--- a/e2e/fixtures/custom-plugin/package.json
+++ b/e2e/fixtures/custom-plugin/package.json
@@ -13,7 +13,6 @@
     "@rspress/shared": "workspace:*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-transition-group": "4.4.5",
     "rspress": "workspace:*",
     "solid-js": "^1.9.3"
   },

--- a/e2e/fixtures/plugin-preview/package.json
+++ b/e2e/fixtures/plugin-preview/package.json
@@ -13,7 +13,6 @@
     "@rspress/shared": "workspace:*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-transition-group": "4.4.5",
     "rspress": "workspace:*",
     "solid-js": "^1.9.3"
   },

--- a/packages/theme-default/package.json
+++ b/packages/theme-default/package.json
@@ -48,8 +48,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-helmet-async": "^1.3.0",
-    "react-syntax-highlighter": "^15.6.1",
-    "react-transition-group": "4.4.5"
+    "react-syntax-highlighter": "^15.6.1"
   },
   "devDependencies": {
     "@modern-js/plugin-tailwindcss": "2.62.0",

--- a/packages/theme-default/src/components/LocalSideBar/index.scss
+++ b/packages/theme-default/src/components/LocalSideBar/index.scss
@@ -54,6 +54,16 @@
   overflow: scroll;
   box-shadow: var(--rp-shadow-1);
   border: 1px solid var(--rp-c-divider-light);
+  opacity: 0;
+  transform: translateY(-20px);
+  visibility: hidden;
+  transition: all 0.3s ease-out;
+
+  &-show {
+    opacity: 1;
+    transform: translateY(0);
+    visibility: visible;
+  }
 }
 
 .fly-in-enter {

--- a/packages/theme-default/src/components/LocalSideBar/index.tsx
+++ b/packages/theme-default/src/components/LocalSideBar/index.tsx
@@ -6,7 +6,6 @@ import { Sidebar, Toc } from '@theme';
 import './index.scss';
 import type { UISwitchResult } from '../../logic/useUISwitch';
 import { SvgWrapper } from '../SvgWrapper';
-import { CSSTransition } from 'react-transition-group';
 
 export function SideMenu({
   outlineTitle,
@@ -93,24 +92,15 @@ export function SideMenu({
               </div>
             </button>
 
-            <CSSTransition
-              in={isTocOpen}
-              timeout={300}
-              unmountOnExit
-              classNames="fly-in"
-              nodeRef={tocContainerRef}
+            <div
+              className={`rspress-local-toc-container ${isTocOpen ? 'rspress-local-toc-container-show' : ''}`}
             >
-              <div
-                className="rspress-local-toc-container"
-                ref={tocContainerRef}
-              >
-                <Toc
-                  onItemClick={() => {
-                    setIsTocOpen(false);
-                  }}
-                />
-              </div>
-            </CSSTransition>
+              <Toc
+                onItemClick={() => {
+                  setIsTocOpen(false);
+                }}
+              />
+            </div>
           </Fragment>
         ) : null}
       </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,9 +210,6 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
-      react-transition-group:
-        specifier: 4.4.5
-        version: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rspress:
         specifier: workspace:*
         version: link:../../../packages/cli
@@ -406,9 +403,6 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
-      react-transition-group:
-        specifier: 4.4.5
-        version: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rspress:
         specifier: workspace:*
         version: link:../../../packages/cli
@@ -1448,9 +1442,6 @@ importers:
       react-syntax-highlighter:
         specifier: ^15.6.1
         version: 15.6.1(react@18.3.1)
-      react-transition-group:
-        specifier: 4.4.5
-        version: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@modern-js/plugin-tailwindcss':
         specifier: 2.62.0


### PR DESCRIPTION
## Summary

Remove `react-transition-group` dependency to reduce bundle size.

- before (550kB)

<img width="739" alt="Screenshot 2024-11-17 at 20 06 46" src="https://github.com/user-attachments/assets/7254eb07-5548-404d-b0b6-57269b8079b5">

- after (543kB)

<img width="730" alt="Screenshot 2024-11-17 at 20 06 17" src="https://github.com/user-attachments/assets/64cb4152-5e93-48ff-9940-e28a0ee718c1">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
