### PR TITLE
chore: downgraden pnpm to 9.12.0 to avoid renovate break

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "engines": {
     "node": ">=16.18.1"
   },
-  "packageManager": "pnpm@9.13.2",
+  "packageManager": "pnpm@9.12.0",
   "lint-staged": {
     "*.{ts,tsx,js,jsx,mjs,cjs}": [
       "biome check . --apply --organize-imports-enabled=false --no-errors-on-unmatched"


### PR DESCRIPTION
## Summary

https://github.com/pnpm/pnpm/issues/7951#issuecomment-2438065169

Latest version of pnpm changed some behaviour, and the renovate generated PR will remove `pnpmfileChecksum` filed in lockfile which will cause no frozen lockfile error that breaks CI.

![image](https://github.com/user-attachments/assets/21c5774a-c16d-4eab-aee1-eed2fa02911a)


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
