### PR TITLE
fix: remove htmlparser2 and use reg to check valid html elements

### DIFF
--- a/e2e/fixtures/inline-markdown/doc/index.mdx
+++ b/e2e/fixtures/inline-markdown/doc/index.mdx
@@ -1,1 +1,12 @@
-# Hello World
+---
+pageType: home
+
+hero:
+  name: My Site
+  text: A cool website!
+  tagline: This is the tagline
+features:
+  - title: Blazing fast build speed
+    details: The core compilation module is based on the Rust front-end toolchain, providing a more ultimate development experience.
+    icon: <img src="https://assets.rspack.dev/rspress/rspress-logo-480x480.png" />
+---

--- a/e2e/tests/inline-markdown.test.ts
+++ b/e2e/tests/inline-markdown.test.ts
@@ -230,4 +230,18 @@ test.describe('Inline markdown test', async () => {
       );
     }
   });
+
+  test('Should render html like <img> with inline markdown syntax correctly', async ({
+    page,
+  }) => {
+    await page.goto(`http://localhost:${appPort}/`, {
+      waitUntil: 'networkidle',
+    });
+
+    const img = await page.$('img');
+    expect(img).not.toBeNull();
+    expect(await img?.getAttribute('src')).toBe(
+      'https://assets.rspack.dev/rspress/rspress-logo-480x480.png',
+    );
+  });
 });

--- a/packages/theme-default/package.json
+++ b/packages/theme-default/package.json
@@ -41,7 +41,6 @@
     "body-scroll-lock": "4.0.0-beta.0",
     "copy-to-clipboard": "^3.3.3",
     "flexsearch": "0.7.43",
-    "htmlparser2": "^9.1.0",
     "htmr": "^1.0.2",
     "lodash-es": "^4.17.21",
     "nprogress": "^0.2.0",

--- a/packages/theme-default/src/logic/utils.ts
+++ b/packages/theme-default/src/logic/utils.ts
@@ -1,5 +1,4 @@
 import { isEqualPath } from '@rspress/runtime';
-import { parseDocument } from 'htmlparser2';
 import htmr from 'htmr';
 import { isNumber } from 'lodash-es';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -39,8 +38,13 @@ export function renderHtmlOrText(str?: string | number | null) {
   }
 
   // Parse the HTML to check for validity
-  const hasValidHtmlElements = parseDocument(str).children.some(
-    node => node.type === 'tag' && node.children.length > 0,
+  // Regular Expression: The regex /<([a-z]+)([^<]+)*(?:>(.*)<\/\1>|\s*\/>)/i is designed to match basic HTML tags, including self-closing tags.
+  // <([a-z]+): Matches the opening tag and captures the tag name.
+  // ([^<]+)*: Matches any attributes within the tag.
+  // (?:>(.*)<\/\1>|\s*\/>): Matches either a closing tag with content or a self-closing tag.
+  // i Flag: Makes the regex case-insensitive, allowing it to match tags like <IMG> as well as <img>.
+  const hasValidHtmlElements = /<([a-z]+)([^<]+)*(?:>(.*)<\/\1>|\s*\/>)/i.test(
+    str,
   );
 
   if (hasValidHtmlElements) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1416,9 +1416,6 @@ importers:
       flexsearch:
         specifier: 0.7.43
         version: 0.7.43
-      htmlparser2:
-        specifier: ^9.1.0
-        version: 9.1.0
       htmr:
         specifier: ^1.0.2
         version: 1.0.2(react@18.3.1)
@@ -4073,9 +4070,6 @@ packages:
 
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
-
-  htmlparser2@9.1.0:
-    resolution: {integrity: sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==}
 
   htmr@1.0.2:
     resolution: {integrity: sha512-7T9babEHZwECQ2/ouxNPow1uGcKbj/BcbslPGPRxBKIOLNiIrFKq6ELzor7mc4HiexZzdb3izQQLl16bhPR9jw==}
@@ -9002,13 +8996,6 @@ snapshots:
       entities: 2.2.0
 
   htmlparser2@8.0.2:
-    dependencies:
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-      domutils: 3.1.0
-      entities: 4.5.0
-
-  htmlparser2@9.1.0:
     dependencies:
       domelementtype: 2.3.0
       domhandler: 5.0.3


### PR DESCRIPTION
## Summary

use a lighter solution to check html validity in the browser

## Related Issue

<!--- Provide link of related issues -->

close: #1582 
close: #1592

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
