### PR TITLE
fix: use rspress-dev as debug mode for source build plugin

### DIFF
--- a/packages/core/src/node/PluginDriver.ts
+++ b/packages/core/src/node/PluginDriver.ts
@@ -4,7 +4,7 @@ import type {
   RspressPlugin,
   RouteMeta,
 } from '@rspress/shared';
-import { isDebugMode } from '@rspress/shared';
+import { isDevDebugMode } from '@rspress/shared';
 import { pluginContainerSyntax } from '@rspress/plugin-container-syntax';
 
 export class PluginDriver {
@@ -59,7 +59,7 @@ export class PluginDriver {
     // Support the container syntax in markdown/mdx, such as :::tip
     this.addPlugin(pluginContainerSyntax());
 
-    if (isDebugMode()) {
+    if (isDevDebugMode()) {
       const SourceBuildPlugin = await import(
         // @ts-expect-error need moduleResolution: Node16, NodeNext or Bundler to get type declerations work
         '@rspress/theme-default/node/source-build-plugin.js'

--- a/packages/shared/src/runtime-utils/index.ts
+++ b/packages/shared/src/runtime-utils/index.ts
@@ -30,6 +30,8 @@ export const isDebugMode = () => {
   return ['rsbuild', 'builder', '*'].some(key => values.includes(key));
 };
 
+export const isDevDebugMode = () => process.env.DEBUG === 'rspress-dev';
+
 export const cleanUrl = (url: string): string =>
   url.replace(HASH_REGEXP, '').replace(QUERY_REGEXP, '');
 


### PR DESCRIPTION
## Summary

Avoid to influence normal debug behaviour at users side.

This is a temporary solution.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
