### PR TITLE
fix(plugin-preview): dark mode card border color

### DIFF
--- a/packages/plugin-preview/static/global-components/common/index.scss
+++ b/packages/plugin-preview/static/global-components/common/index.scss
@@ -12,14 +12,14 @@
   padding: 16px 0;
 
   &-wrapper {
-    border: 1px solid #e6e6e6;
+    border: 1px solid var(--rp-container-details-border);
     border-radius: var(--rp-radius-small);
   }
 
   &-card {
     padding: 16px;
     position: relative;
-    border: 1px solid #e6e6e6;
+    border: 1px solid var(--rp-container-details-border);
     border-radius: var(--rp-radius-small);
     display: flex;
   }


### PR DESCRIPTION
修改前：
<img width="824" alt="image" src="https://github.com/user-attachments/assets/efd70311-1d44-4737-b633-e462bee1311e">

修改后：
<img width="820" alt="image" src="https://github.com/user-attachments/assets/494c72db-e979-48a3-ad30-1ab896f41303">
