### PR TITLE
perf(shared): move `mergeDocConfig` to node utils

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -106,7 +106,6 @@
     "./src/theme-default/styles/index.ts"
   ],
   "files": [
-    "bin",
     "dist",
     "src/runtime",
     "src/theme-default",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,2 +1,3 @@
 export * from './node';
 export * from '@rspress/shared';
+export { mergeDocConfig } from '@rspress/shared/node-utils';

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -54,7 +54,6 @@
     "./src/theme-default/styles/index.ts"
   ],
   "files": [
-    "bin",
     "dist",
     "src",
     "runtime.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -56,18 +56,15 @@
     "execa": "5.1.1",
     "fs-extra": "11.2.0",
     "gray-matter": "4.0.3",
+    "lodash-es": "^4.17.21",
     "unified": "^10.1.2"
   },
   "devDependencies": {
     "@types/fs-extra": "11.0.4",
-    "@types/interpret": "^1.1.3",
     "@types/jest": "~29.5.14",
-    "@types/lodash": "^4.17.13",
     "@types/lodash-es": "^4.17.12",
     "@types/node": "^18.11.17",
     "@types/react": "^18.3.12",
-    "@types/rechoir": "^0.6.4",
-    "lodash-es": "^4.17.21",
     "medium-zoom": "1.1.0",
     "rimraf": "^3.0.2",
     "typescript": "^5.5.3"
@@ -80,7 +77,6 @@
   },
   "license": "MIT",
   "files": [
-    "bin",
     "dist"
   ]
 }

--- a/packages/shared/src/node-utils.ts
+++ b/packages/shared/src/node-utils.ts
@@ -1,1 +1,2 @@
 export * from './node-utils/loadFrontMatter';
+export { mergeDocConfig } from './node-utils/merge';

--- a/packages/shared/src/node-utils/merge.ts
+++ b/packages/shared/src/node-utils/merge.ts
@@ -1,0 +1,19 @@
+import { mergeWith } from 'lodash-es';
+import type { UserConfig } from '@/types';
+
+const castArray = <T>(value: T | T[]): T[] =>
+  Array.isArray(value) ? value : [value];
+
+export const mergeDocConfig = (...configs: UserConfig[]): UserConfig =>
+  mergeWith({}, ...configs, (target: UserConfig, source: UserConfig) => {
+    const pair = [target, source];
+    if (pair.some(item => item === undefined)) {
+      // fallback to lodash default merge behavior
+      return undefined;
+    }
+    if (pair.some(item => Array.isArray(item))) {
+      return [...castArray(target), ...castArray(source)];
+    }
+    // fallback to lodash default merge behavior
+    return undefined;
+  });

--- a/packages/shared/src/runtime-utils/index.ts
+++ b/packages/shared/src/runtime-utils/index.ts
@@ -1,6 +1,3 @@
-import { castArray, isArray, isUndefined, mergeWith } from 'lodash-es';
-import type { UserConfig } from '@/types';
-
 export const QUERY_REGEXP = /\?.*$/s;
 export const HASH_REGEXP = /#.*$/s;
 export const MDX_REGEXP = /\.mdx?$/;
@@ -213,14 +210,6 @@ export function replaceVersion(
   );
 }
 
-export const omit = (obj: Record<string, unknown>, keys: string[]) => {
-  const ret = { ...obj };
-  for (const key of keys) {
-    delete ret[key];
-  }
-  return ret;
-};
-
 export const parseUrl = (
   url: string,
 ): {
@@ -288,21 +277,3 @@ export function removeBase(url: string, base: string) {
     '',
   );
 }
-
-export function withoutHash(url: string) {
-  return url.split('#')[0];
-}
-
-export const mergeDocConfig = (...configs: UserConfig[]): UserConfig =>
-  mergeWith({}, ...configs, (target: UserConfig, source: UserConfig) => {
-    const pair = [target, source];
-    if (pair.some(isUndefined)) {
-      // fallback to lodash default merge behavior
-      return undefined;
-    }
-    if (pair.some(isArray)) {
-      return [...castArray(target), ...castArray(source)];
-    }
-    // fallback to lodash default merge behavior
-    return undefined;
-  });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1346,6 +1346,9 @@ importers:
       gray-matter:
         specifier: 4.0.3
         version: 4.0.3
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
       unified:
         specifier: ^10.1.2
         version: 10.1.2
@@ -1353,15 +1356,9 @@ importers:
       '@types/fs-extra':
         specifier: 11.0.4
         version: 11.0.4
-      '@types/interpret':
-        specifier: ^1.1.3
-        version: 1.1.3
       '@types/jest':
         specifier: ~29.5.14
         version: 29.5.14
-      '@types/lodash':
-        specifier: ^4.17.13
-        version: 4.17.13
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
@@ -1371,12 +1368,6 @@ importers:
       '@types/react':
         specifier: ^18.3.12
         version: 18.3.12
-      '@types/rechoir':
-        specifier: ^0.6.4
-        version: 0.6.4
-      lodash-es:
-        specifier: ^4.17.21
-        version: 4.17.21
       medium-zoom:
         specifier: 1.1.0
         version: 1.1.0
@@ -2874,9 +2865,6 @@ packages:
   '@types/html-to-text@9.0.4':
     resolution: {integrity: sha512-pUY3cKH/Nm2yYrEmDlPR1mR7yszjGx4DrwPjQ702C4/D5CwHuZTgZdIdwPkRbcuhs7BAh2L5rg3CL5cbRiGTCQ==}
 
-  '@types/interpret@1.1.3':
-    resolution: {integrity: sha512-uBaBhj/BhilG58r64mtDb/BEdH51HIQLgP5bmWzc5qCtFMja8dCk/IOJmk36j0lbi9QHwI6sbtUNGuqXdKCAtQ==}
-
   '@types/istanbul-lib-coverage@2.0.4':
     resolution: {integrity: sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==}
 
@@ -2945,9 +2933,6 @@ packages:
 
   '@types/react@18.3.12':
     resolution: {integrity: sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==}
-
-  '@types/rechoir@0.6.4':
-    resolution: {integrity: sha512-qpb56wvjUSuJQwZzDcmQEFudUsolIabyOE9aP9Wr5s1EYlWQ/4Zz7XSjr69gDhWY5PBX/+M62ZLQgQyUzTiPAA==}
 
   '@types/stack-utils@2.0.1':
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
@@ -7583,10 +7568,6 @@ snapshots:
 
   '@types/html-to-text@9.0.4': {}
 
-  '@types/interpret@1.1.3':
-    dependencies:
-      '@types/node': 18.11.17
-
   '@types/istanbul-lib-coverage@2.0.4': {}
 
   '@types/istanbul-lib-report@3.0.0':
@@ -7654,10 +7635,6 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.5
       csstype: 3.1.3
-
-  '@types/rechoir@0.6.4':
-    dependencies:
-      '@types/interpret': 1.1.3
 
   '@types/stack-utils@2.0.1': {}
 


### PR DESCRIPTION
## Summary

`mergeDocConfig` is only used by Node.js code, so it can be moved from `shared/src/runtime-utils` to `shared/src/node-utils`. This can reduce runtime code and remove lodash methods.

This PR also removed some unused `bin` from `files` field.

- before (464kB):

![image](https://github.com/user-attachments/assets/77a1673c-01c2-4040-87bf-6e68c38579d9)

- after (453kB):

<img width="791" alt="Screenshot 2024-11-20 at 22 08 07" src="https://github.com/user-attachments/assets/dc9ba745-9436-4956-b823-187509c5e59a">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
