### PR TITLE
fix(plugin-client-redirects): missing `@rspress/shared` dependency

### DIFF
--- a/packages/plugin-client-redirects/package.json
+++ b/packages/plugin-client-redirects/package.json
@@ -23,11 +23,13 @@
   "engines": {
     "node": ">=14.17.6"
   },
+  "dependencies": {
+    "@rspress/shared": "workspace:*"
+  },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.48.0",
     "@modern-js/tsconfig": "2.63.0",
     "@rslib/core": "0.1.1",
-    "@rspress/shared": "workspace:*",
     "@types/node": "^18.11.17",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -987,6 +987,9 @@ importers:
       '@rspress/runtime':
         specifier: workspace:^1.37.3
         version: link:../runtime
+      '@rspress/shared':
+        specifier: workspace:*
+        version: link:../shared
     devDependencies:
       '@microsoft/api-extractor':
         specifier: ^7.48.0
@@ -997,9 +1000,6 @@ importers:
       '@rslib/core':
         specifier: 0.1.1
         version: 0.1.1(@microsoft/api-extractor@7.48.0(@types/node@18.11.17))(typescript@5.5.3)
-      '@rspress/shared':
-        specifier: workspace:*
-        version: link:../shared
       '@types/node':
         specifier: ^18.11.17
         version: 18.11.17


### PR DESCRIPTION
## Summary

Fix plugin-client-redirects missing `@rspress/shared` dependency:

<img width="940" alt="Screenshot 2024-12-02 at 15 25 36" src="https://github.com/user-attachments/assets/d4c09e72-0cc9-4519-aa0a-7a8628435b56">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
