### PR TITLE
chore: use `resolve.alias` instead of `source.alias`

### DIFF
--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -150,7 +150,7 @@ async function createInternalBuildConfig(
         root: csrOutDir,
       },
     },
-    source: {
+    resolve: {
       alias: {
         ...detectCustomIconAlias,
         '@mdx-js/react': require.resolve('@mdx-js/react'),
@@ -163,6 +163,8 @@ async function createInternalBuildConfig(
         ),
         '@theme-assets': path.join(DEFAULT_THEME, '../assets'),
       },
+    },
+    source: {
       include: [PACKAGE_ROOT, path.join(cwd, 'node_modules', RSPRESS_TEMP_DIR)],
       define: {
         'process.env.__IS_REACT_18__': JSON.stringify(reactVersion === 18),
@@ -245,11 +247,13 @@ async function createInternalBuildConfig(
     },
     environments: {
       web: {
+        resolve: {
+          alias: reactCSRAlias,
+        },
         source: {
           entry: {
             index: CLIENT_ENTRY,
           },
-          alias: reactCSRAlias,
           define: {
             'process.env.__SSR__': JSON.stringify(false),
           },
@@ -264,11 +268,13 @@ async function createInternalBuildConfig(
       ...(enableSSG
         ? {
             node: {
+              resolve: {
+                alias: reactSSRAlias,
+              },
               source: {
                 entry: {
                   index: SSR_ENTRY,
                 },
-                alias: reactSSRAlias,
                 define: {
                   'process.env.__SSR__': JSON.stringify(true),
                 },

--- a/packages/document/docs/en/api/config/config-build.mdx
+++ b/packages/document/docs/en/api/config/config-build.mdx
@@ -6,12 +6,12 @@
 
 Used to customize the configurations of Rsbuild. For detailed configurations, please refer to [Rsbuild - Config](https://rsbuild.dev/config/).
 
-- Example: Use [source.alias](https://rsbuild.dev/config/source/alias) to configure path aliases:
+- Example: Use [resolve.alias](https://rsbuild.dev/config/resolve/alias) to configure path aliases:
 
 ```ts title="rspress.config.ts"
 export default defineConfig({
   builderConfig: {
-    source: {
+    resolve: {
       alias: {
         '@common': './src/common',
       },

--- a/packages/document/docs/zh/api/config/config-build.mdx
+++ b/packages/document/docs/zh/api/config/config-build.mdx
@@ -6,12 +6,12 @@
 
 用于自定义 Rsbuild 的配置项，完整配置项请查看 [Rsbuild - 配置](https://rsbuild.dev/zh/config/)。
 
-- 示例：使用 [source.alias](https://rsbuild.dev/config/source/alias) 配置路径别名：
+- 示例：使用 [source.alias](https://rsbuild.dev/zh/config/resolve/alias) 配置路径别名：
 
 ```ts title="rspress.config.ts"
 export default defineConfig({
   builderConfig: {
-    source: {
+    resolve: {
       alias: {
         '@common': './src/common',
       },
@@ -20,7 +20,7 @@ export default defineConfig({
 });
 ```
 
-- 示例：使用 [tools.rspack](https://rsbuild.dev/config/tools/rspack) 修改 Rspack 配置，比如注册一个 webpack 或 Rspack 插件。比如：
+- 示例：使用 [tools.rspack](https://rsbuild.dev/zh/config/tools/rspack) 修改 Rspack 配置，比如注册一个 webpack 或 Rspack 插件。比如：
 
 ```ts title="rspress.config.ts"
 export default defineConfig({

--- a/packages/modern-plugin-rspress/src/lanchDoc.ts
+++ b/packages/modern-plugin-rspress/src/lanchDoc.ts
@@ -154,7 +154,7 @@ export async function launchDoc({
         ],
       },
       builderConfig: {
-        source: {
+        resolve: {
           alias: {
             'rspress/runtime': '@rspress/core/runtime',
             'rspress/theme': '@rspress/core/theme',

--- a/packages/theme-default/src/node/source-build-plugin.ts
+++ b/packages/theme-default/src/node/source-build-plugin.ts
@@ -14,7 +14,7 @@ export function SourceBuildPlugin(): RspressPlugin {
   return {
     name: 'theme-default:source-build',
     builderConfig: {
-      source: {
+      resolve: {
         alias: {
           'rspress/theme': path.resolve(ROOT_DIR, './src'),
         },


### PR DESCRIPTION
## Summary

chore: use `resolve.alias` instead of `source.alias`

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
