### PR TITLE
fix(theme): Overview component cannot be used when using base

### DIFF
--- a/.changeset/gold-spiders-hide.md
+++ b/.changeset/gold-spiders-hide.md
@@ -1,0 +1,7 @@
+---
+'@rspress/plugin-auto-nav-sidebar': patch
+'@rspress/theme-default': patch
+'@rspress/shared': patch
+---
+
+fix the empty overview

--- a/e2e/fixtures/nested-overview/rspress.config.ts
+++ b/e2e/fixtures/nested-overview/rspress.config.ts
@@ -2,5 +2,6 @@ import * as path from 'node:path';
 import { defineConfig } from 'rspress/config';
 
 export default defineConfig({
+  base: '/base-url',
   root: path.join(__dirname, 'doc'),
 });

--- a/e2e/tests/nested-overview.test.ts
+++ b/e2e/tests/nested-overview.test.ts
@@ -22,9 +22,12 @@ test.describe('Nested overview page', async () => {
   test('Should load nested overview page correctly - level 1', async ({
     page,
   }) => {
-    await page.goto(`http://localhost:${appPort}/basic-level-1/index.html`, {
-      waitUntil: 'networkidle',
-    });
+    await page.goto(
+      `http://localhost:${appPort}/base-url/basic-level-1/index.html`,
+      {
+        waitUntil: 'networkidle',
+      },
+    );
 
     const h2 = await page.$$('.overview-index h2');
     const h2Texts = await Promise.all(h2.map(element => element.textContent()));
@@ -39,7 +42,7 @@ test.describe('Nested overview page', async () => {
     page,
   }) => {
     await page.goto(
-      `http://localhost:${appPort}/basic-level-1/level-2/index.html`,
+      `http://localhost:${appPort}/base-url/basic-level-1/level-2/index.html`,
       {
         waitUntil: 'networkidle',
       },
@@ -58,7 +61,7 @@ test.describe('Nested overview page', async () => {
     page,
   }) => {
     await page.goto(
-      `http://localhost:${appPort}/basic-level-1/level-2/level-3/index.html`,
+      `http://localhost:${appPort}/base-url/basic-level-1/level-2/level-3/index.html`,
       {
         waitUntil: 'networkidle',
       },

--- a/packages/plugin-auto-nav-sidebar/src/walk.ts
+++ b/packages/plugin-auto-nav-sidebar/src/walk.ts
@@ -251,9 +251,15 @@ export async function scanSideMeta(
           tag,
         } satisfies SidebarSectionHeader;
       }
+
       return {
         text: label ?? '',
-        link: link && isExternalUrl(link) ? link : withBase(link, routePrefix),
+        link:
+          typeof link === 'undefined'
+            ? ''
+            : isExternalUrl(link)
+              ? link
+              : withBase(link, routePrefix),
         tag,
         context,
       } satisfies SidebarItem;

--- a/packages/shared/src/runtime-utils/index.ts
+++ b/packages/shared/src/runtime-utils/index.ts
@@ -258,11 +258,11 @@ export function withoutLang(path: string, langs: string[]) {
   return addLeadingSlash(path.replace(langRegexp, ''));
 }
 
-export function withoutBase(path: string, base = '') {
+export function withoutBase(path: string, base: string) {
   return addLeadingSlash(path).replace(normalizeSlash(base), '');
 }
 
-export function withBase(url = '/', base = ''): string {
+export function withBase(url: string, base: string): string {
   const normalizedUrl = addLeadingSlash(url);
   const normalizedBase = normalizeSlash(base);
   // Avoid adding base path repeatly

--- a/packages/theme-default/src/components/Overview/utils.ts
+++ b/packages/theme-default/src/components/Overview/utils.ts
@@ -1,10 +1,10 @@
-import {
-  type NormalizedSidebarGroup,
-  type SidebarDivider,
-  type SidebarItem,
-  withBase,
+import type {
+  NormalizedSidebarGroup,
+  SidebarDivider,
+  SidebarItem,
 } from '@rspress/shared';
 import { isSidebarDivider } from '../Sidebar/utils';
+import { withBase } from '@rspress/runtime';
 
 function removeIndex(link: string) {
   if (link.endsWith('/index')) {


### PR DESCRIPTION
## Summary
empty Overview when using base together
<img width="1236" alt="image" src="https://github.com/user-attachments/assets/d04fa34d-6b8d-4973-9c10-b83daf7d848a">

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
