### PR TITLE
fix(plugin-preview): dev-server is not running

### DIFF
--- a/packages/plugin-preview/src/index.ts
+++ b/packages/plugin-preview/src/index.ts
@@ -51,7 +51,7 @@ export function pluginPreview(options?: Options): RspressPlugin {
       : [];
   const getRouteMeta = () => routeMeta;
   let lastDemos: typeof demos;
-  let devServer: StartServerResult;
+  let devServer: StartServerResult | undefined;
   let clientConfig: RsbuildConfig;
   const port = devPort;
   return {
@@ -93,6 +93,7 @@ export function pluginPreview(options?: Options): RspressPlugin {
       }
       lastDemos = cloneDeep(demos);
       await devServer?.server?.close();
+      devServer = undefined;
       const sourceEntry = generateEntry(demos, framework, position);
       const outDir = join(config.outDir ?? 'doc_build', '~demo');
       if (Object.keys(sourceEntry).length === 0) {
@@ -186,6 +187,7 @@ export function pluginPreview(options?: Options): RspressPlugin {
             });
             api.onCloseDevServer(async () => {
               await devServer?.server?.close();
+              devServer = undefined;
             });
           },
         },


### PR DESCRIPTION
## Summary

Fix plugin-preview dev-server close, but not assign empty, next afterBuild close error.
![image](https://github.com/user-attachments/assets/0d0f3763-bac0-4847-9d17-9acc58a29203)

![image](https://github.com/user-attachments/assets/a70d35a0-4c0c-4a88-bc8c-6f59dfdb92af)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
