### PR TITLE
fix: add overflow-wrap to break long words

### DIFF
--- a/packages/theme-default/src/styles/base.css
+++ b/packages/theme-default/src/styles/base.css
@@ -2,7 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-
 *,
 ::before,
 ::after {
@@ -39,6 +38,17 @@ body {
 button:focus,
 button:focus-visible {
   outline: none;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+li,
+p {
+  overflow-wrap: break-word;
 }
 
 .visually-hidden {


### PR DESCRIPTION
## Summary

Add `overflow-wrap` CSS to break long words.

## Related Issue

resolve https://github.com/web-infra-dev/rsbuild/issues/4166

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
