### PR TITLE
Release v1.38.0

### DIFF
--- a/.changeset/gold-spiders-hide.md
+++ b/.changeset/gold-spiders-hide.md
@@ -1,7 +1,0 @@
----
-'@rspress/plugin-auto-nav-sidebar': patch
-'@rspress/theme-default': patch
-'@rspress/shared': patch
----
-
-fix the empty overview

--- a/.changeset/loud-fans-wait.md
+++ b/.changeset/loud-fans-wait.md
@@ -1,6 +1,0 @@
----
-'@rspress/runtime': minor
-'@rspress/core': minor
----
-
-feat: support for React 19

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rspress",
-  "version": "1.37.4",
+  "version": "1.38.0",
   "type": "module",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/core",
-  "version": "1.37.4",
+  "version": "1.38.0",
   "description": "The Rspress Documentation Framework",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {

--- a/packages/create-rspress/package.json
+++ b/packages/create-rspress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rspress",
-  "version": "1.37.4",
+  "version": "1.38.0",
   "description": "Create a new Rspress project",
   "homepage": "https://rspress.dev",
   "repository": {

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/docs",
-  "version": "1.37.4",
+  "version": "1.38.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rspress",

--- a/packages/modern-plugin-rspress/package.json
+++ b/packages/modern-plugin-rspress/package.json
@@ -15,7 +15,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.37.4",
+  "version": "1.38.0",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",

--- a/packages/plugin-api-docgen/package.json
+++ b/packages/plugin-api-docgen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/plugin-api-docgen",
-  "version": "1.37.4",
+  "version": "1.38.0",
   "description": "A plugin for rspress to generate api doc.",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {
@@ -47,7 +47,7 @@
   "peerDependencies": {
     "react": ">=17.0.0",
     "react-router-dom": "^6.8.1",
-    "@rspress/core": "workspace:^1.37.4",
+    "@rspress/core": "workspace:^1.38.0",
     "typescript": "^5.5.3"
   },
   "peerDependenciesMeta": {

--- a/packages/plugin-auto-nav-sidebar/package.json
+++ b/packages/plugin-auto-nav-sidebar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/plugin-auto-nav-sidebar",
-  "version": "1.37.4",
+  "version": "1.38.0",
   "description": "A plugin for rspress to generate navbar and sidebar config automatically.",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {

--- a/packages/plugin-client-redirects/package.json
+++ b/packages/plugin-client-redirects/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/plugin-client-redirects",
-  "version": "1.37.4",
+  "version": "1.38.0",
   "description": "A plugin for rspress to client redirect in docs.",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {
@@ -38,7 +38,7 @@
     "vitest": "2.1.8"
   },
   "peerDependencies": {
-    "@rspress/runtime": "workspace:^1.37.4"
+    "@rspress/runtime": "workspace:^1.38.0"
   },
   "sideEffects": [
     "*.css",

--- a/packages/plugin-container-syntax/package.json
+++ b/packages/plugin-container-syntax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/plugin-container-syntax",
-  "version": "1.37.4",
+  "version": "1.38.0",
   "description": "A remark plugin to support container syntax",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {

--- a/packages/plugin-last-updated/package.json
+++ b/packages/plugin-last-updated/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/plugin-last-updated",
-  "version": "1.37.4",
+  "version": "1.38.0",
   "description": "A plugin for rspress to record the last updated time of the doc.",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {

--- a/packages/plugin-medium-zoom/package.json
+++ b/packages/plugin-medium-zoom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/plugin-medium-zoom",
-  "version": "1.37.4",
+  "version": "1.38.0",
   "description": "A plugin for rspress to zoom images in docs.",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {
@@ -36,7 +36,7 @@
     "vitest": "2.1.8"
   },
   "peerDependencies": {
-    "@rspress/runtime": "workspace:^1.37.4"
+    "@rspress/runtime": "workspace:^1.38.0"
   },
   "sideEffects": [
     "*.css",

--- a/packages/plugin-playground/package.json
+++ b/packages/plugin-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/plugin-playground",
-  "version": "1.37.4",
+  "version": "1.38.0",
   "description": "A plugin for rspress to preview the code block in markdown/mdx file.",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {
@@ -59,7 +59,7 @@
     "unist-util-visit": "^4.1.2"
   },
   "peerDependencies": {
-    "@rspress/core": "workspace:^1.37.4",
+    "@rspress/core": "workspace:^1.38.0",
     "react": ">=17.0.0",
     "react-router-dom": "^6.8.1"
   },

--- a/packages/plugin-preview/package.json
+++ b/packages/plugin-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/plugin-preview",
-  "version": "1.37.4",
+  "version": "1.38.0",
   "description": "A plugin for rspress to preview the code block in markdown/mdx file.",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {
@@ -50,7 +50,7 @@
   "peerDependencies": {
     "react": ">=17.0.0",
     "react-router-dom": "^6.8.1",
-    "@rspress/core": "workspace:^1.37.4"
+    "@rspress/core": "workspace:^1.38.0"
   },
   "files": [
     "dist",

--- a/packages/plugin-rss/package.json
+++ b/packages/plugin-rss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/plugin-rss",
-  "version": "1.37.4",
+  "version": "1.38.0",
   "description": "A plugin for rss generation for rspress",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "react": ">=17.0.0",
-    "rspress": "workspace:^1.37.4"
+    "rspress": "workspace:^1.38.0"
   },
   "files": [
     "dist",

--- a/packages/plugin-shiki/package.json
+++ b/packages/plugin-shiki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/plugin-shiki",
-  "version": "1.37.4",
+  "version": "1.38.0",
   "description": "A plugin for rspress to record the last updated time of the doc.",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {

--- a/packages/plugin-typedoc/package.json
+++ b/packages/plugin-typedoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/plugin-typedoc",
-  "version": "1.37.4",
+  "version": "1.38.0",
   "description": "A plugin for rspress to integrate typedoc",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {
@@ -34,7 +34,7 @@
     "vitest": "2.1.8"
   },
   "peerDependencies": {
-    "rspress": "workspace:^1.37.4"
+    "rspress": "workspace:^1.38.0"
   },
   "sideEffects": [
     "*.css",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/runtime",
-  "version": "1.37.4",
+  "version": "1.38.0",
   "description": "The Runtime of Rspress Documentation Framework",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/shared",
-  "version": "1.37.4",
+  "version": "1.38.0",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/theme-default/package.json
+++ b/packages/theme-default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/theme-default",
-  "version": "1.37.4",
+  "version": "1.38.0",
   "description": "The Default Theme of Rspress Documentation Framework",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -903,7 +903,7 @@ importers:
   packages/plugin-api-docgen:
     dependencies:
       '@rspress/core':
-        specifier: workspace:^1.37.4
+        specifier: workspace:^1.38.0
         version: link:../core
       '@rspress/shared':
         specifier: workspace:*
@@ -1001,7 +1001,7 @@ importers:
   packages/plugin-client-redirects:
     dependencies:
       '@rspress/runtime':
-        specifier: workspace:^1.37.4
+        specifier: workspace:^1.38.0
         version: link:../runtime
       '@rspress/shared':
         specifier: workspace:*
@@ -1100,7 +1100,7 @@ importers:
   packages/plugin-medium-zoom:
     dependencies:
       '@rspress/runtime':
-        specifier: workspace:^1.37.4
+        specifier: workspace:^1.38.0
         version: link:../runtime
       medium-zoom:
         specifier: 1.1.0
@@ -1149,7 +1149,7 @@ importers:
         specifier: ^0.2.0
         version: 0.2.0
       '@rspress/core':
-        specifier: workspace:^1.37.4
+        specifier: workspace:^1.38.0
         version: link:../core
       '@rspress/shared':
         specifier: workspace:*
@@ -1228,7 +1228,7 @@ importers:
         specifier: ~1.0.4
         version: 1.0.4(@babel/core@7.26.0)(@rsbuild/core@1.1.9)(solid-js@1.9.3)
       '@rspress/core':
-        specifier: workspace:^1.37.4
+        specifier: workspace:^1.38.0
         version: link:../core
       '@rspress/shared':
         specifier: workspace:*
@@ -1289,7 +1289,7 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2
       rspress:
-        specifier: workspace:^1.37.4
+        specifier: workspace:^1.38.0
         version: link:../cli
     devDependencies:
       '@rspress/runtime':
@@ -1366,7 +1366,7 @@ importers:
         specifier: workspace:*
         version: link:../shared
       rspress:
-        specifier: workspace:^1.37.4
+        specifier: workspace:^1.38.0
         version: link:../cli
       typedoc:
         specifier: 0.24.8


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v1.38.0 -->

## What's Changed
### New Features 🎉
* feat: enable incremental by default by @ahabhgk in https://github.com/web-infra-dev/rspress/pull/1631
* feat: add support for React 19 by @chenjiahan in https://github.com/web-infra-dev/rspress/pull/1643
### Bug Fixes 🐞
* fix(theme): Overview component cannot be used when using base by @SoonIter in https://github.com/web-infra-dev/rspress/pull/1642
* fix: add overflow-wrap to break long words by @chenjiahan in https://github.com/web-infra-dev/rspress/pull/1650
### Other Changes
* chore(deps): update all patch dependencies by @renovate in https://github.com/web-infra-dev/rspress/pull/1644
* chore(deps): update dependency framer-motion to v11.13.1 by @renovate in https://github.com/web-infra-dev/rspress/pull/1646
* chore(deps): update dependency nx to v20.2.1 by @renovate in https://github.com/web-infra-dev/rspress/pull/1647
* chore(deps): update dependency @rsbuild/plugin-react to ~1.1.0 by @renovate in https://github.com/web-infra-dev/rspress/pull/1645

## New Contributors
* @ahabhgk made their first contribution in https://github.com/web-infra-dev/rspress/pull/1631

**Full Changelog**: https://github.com/web-infra-dev/rspress/compare/v1.37.4...v1.38.0