### PR TITLE
fix(plugin-preview): do not ignore node_modules in `watchOptions`

### DIFF
--- a/.changeset/old-rings-warn.md
+++ b/.changeset/old-rings-warn.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+release

--- a/packages/plugin-preview/src/index.ts
+++ b/packages/plugin-preview/src/index.ts
@@ -173,6 +173,11 @@ export function pluginPreview(options?: Options): RspressPlugin {
 
           chain.resolve.extensions.prepend('.md').prepend('.mdx');
         },
+        rspack: {
+          watchOptions: {
+            ignored: /\.git/,
+          },
+        },
       },
       plugins: [
         {


### PR DESCRIPTION
## Summary

The preview components is located in `node_modules/.rspress/virtual-demo/`.

We should watch `node_modules` to enable hot update in preview block.

## Related Issue

fix: #1652 

https://github.com/web-infra-dev/rsbuild/pull/4058
<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
