### PR TITLE
docs: `head` config only takes effect in production mode

### DIFF
--- a/packages/document/docs/en/api/config/config-basic.mdx
+++ b/packages/document/docs/en/api/config/config-basic.mdx
@@ -187,7 +187,7 @@ export default defineConfig({
 - Type: `string` | `[string, Record<string, string>]` | `(route) => string | [string, Record<string, string>] | undefined`
 - Can be appended per page via [frontmatter](./config-frontmatter.mdx#head)
 
-Additional elements to render in the `<head>` tag in the page HTML.
+Used to set additional elements rendered in the `<head>` tag of the page's HTML in production mode.
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';

--- a/packages/document/docs/zh/api/config/config-basic.mdx
+++ b/packages/document/docs/zh/api/config/config-basic.mdx
@@ -187,7 +187,7 @@ export default defineConfig({
 - Type: `string` | `[string, Record<string, string>]` | `(route) => string | [string, Record<string, string>] | undefined`
 - 也可以通过 [frontmatter](./config-frontmatter.mdx#head) 针对每个页面设置
 
-页面 HTML 的 `<head>` 标签中呈现的附加元素。
+用于设置生产模式下页面 HTML 的 `<head>` 标签中呈现的附加元素。
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';


### PR DESCRIPTION
## Summary

update docs, `head` config only takes effect in production mode.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
