### PR TITLE
docs: add `lang` config

### DIFF
--- a/packages/document/docs/en/api/config/config-basic.mdx
+++ b/packages/document/docs/en/api/config/config-basic.mdx
@@ -86,6 +86,31 @@ export default defineConfig({
 
 The framework will find your icon in the `public` directory, of course you can also set it to a CDN address.
 
+## lang
+
+- Type: `string`
+- Default: `""`
+
+Default language of the site. See [Internationalization](/guide/default-theme/i18n) for more details.
+
+```ts title="rspress.config.ts"
+import { defineConfig } from 'rspress/config';
+
+export default defineConfig({
+  lang: 'en',
+  locales: [
+    {
+      lang: 'en',
+      // ...
+    },
+    {
+      lang: 'zh',
+      // ...
+    },
+  ],
+});
+```
+
 ## logo \{#logo-1}
 
 - Type: `string | { dark: string; light: string }`

--- a/packages/document/docs/en/guide/default-theme/i18n.mdx
+++ b/packages/document/docs/en/guide/default-theme/i18n.mdx
@@ -71,15 +71,14 @@ export default defineConfig({
       lang: 'en',
       // The label in nav bar to switch language
       label: 'English',
-      title: 'Modern.js',
-      description: 'Modern.js 文档框架',
+      title: 'Rspress',
+      description: 'Static Site Generator',
     },
     {
       lang: 'zh',
-      // The label in nav bar to switch language
       label: '简体中文',
-      title: 'Modern.js',
-      description: 'Rspress',
+      title: 'Rspress',
+      description: '静态网站生成器',
     },
   ],
   themeConfig: {
@@ -105,17 +104,17 @@ For other international theme parameters, please refer to [API type](/api/config
 
 ## Configure the default language
 
-After configure `locales` data, you need configure the default language of the document via `lang`, as shown in the following example:
+After configure `locales` data, you need configure the default language of the document via [lang](/api/config/config-basic#lang), as shown in the following example:
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';
 
 export default defineConfig({
-  lang: 'zh',
+  lang: 'en',
 });
 ```
 
-This is important because **for routes in the default language, the framework will remove the language prefix**, such as `/zh/guide/getting-started` will be converted to `/guide/getting-started`.
+This is important because **for routes in the default language, the framework will remove the language prefix**, such as `/en/guide/getting-started` will be converted to `/guide/getting-started`.
 
 ## Create documents in different language
 

--- a/packages/document/docs/zh/api/config/config-basic.mdx
+++ b/packages/document/docs/zh/api/config/config-basic.mdx
@@ -86,6 +86,31 @@ export default defineConfig({
 
 框架会在 `public` 目录中找到你的图标，当然你也可以设置成一个 CDN 地址。
 
+## lang
+
+- Type: `string`
+- Default: `""`
+
+站点默认使用的语言。查看 [国际化](/guide/default-theme/i18n) 了解更多。
+
+```ts title="rspress.config.ts"
+import { defineConfig } from 'rspress/config';
+
+export default defineConfig({
+  lang: 'en',
+  locales: [
+    {
+      lang: 'en',
+      // ...
+    },
+    {
+      lang: 'zh',
+      // ...
+    },
+  ],
+});
+```
+
 ## logo \{#logo-1}
 
 - Type: `string | { dark: string; light: string }`

--- a/packages/document/docs/zh/guide/default-theme/i18n.mdx
+++ b/packages/document/docs/zh/guide/default-theme/i18n.mdx
@@ -72,15 +72,14 @@ export default defineConfig({
       lang: 'en',
       // 导航栏切换语言的标签
       label: 'English',
-      title: 'Modern.js',
-      description: 'Modern.js 文档框架',
+      title: 'Rspress',
+      description: 'Static Site Generator',
     },
     {
       lang: 'zh',
-      // 导航栏切换语言的标签
       label: '简体中文',
-      title: 'Modern.js',
-      description: 'Rspress',
+      title: 'Rspress',
+      description: '静态网站生成器',
     },
   ],
   themeConfig: {
@@ -106,17 +105,17 @@ export default defineConfig({
 
 ## 配置默认语言
 
-在配置完 `locales` 之后，你需要通过 `lang` 配置文档的默认语言，如下例子所示:
+在配置完 `locales` 之后，你需要通过 [lang](/api/config/config-basic#lang) 配置文档的默认语言，如下例子所示:
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';
 
 export default defineConfig({
-  lang: 'zh',
+  lang: 'en',
 });
 ```
 
-这很重要，因为**对于默认语言下的路由，框架会去掉语言前缀**，比如 `/zh/guide/getting-started` 会被转换为 `/guide/getting-started`。
+这很重要，因为**对于默认语言下的路由，框架会去掉语言前缀**，比如 `/en/guide/getting-started` 会被转换为 `/guide/getting-started`。
 
 ## 新建不同的语言版本的文档
 

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -54,6 +54,7 @@ export type SSGConfig = boolean | { strict?: boolean };
 export interface UserConfig<ThemeConfig = DefaultThemeConfig> {
   /**
    * The root directory of the site.
+   * @default 'docs'
    */
   root?: string;
   /**
@@ -62,10 +63,12 @@ export interface UserConfig<ThemeConfig = DefaultThemeConfig> {
   logo?: string | { dark: string; light: string };
   /**
    * The text of the logo in nav bar.
+   * @default ''
    */
   logoText?: string;
   /**
    * Base path of the site.
+   * @default '/'
    */
   base?: string;
   /**
@@ -73,15 +76,17 @@ export interface UserConfig<ThemeConfig = DefaultThemeConfig> {
    */
   icon?: string;
   /**
-   * Language of the site.
+   * Default language of the site.
    */
   lang?: string;
   /**
    * Title of the site.
+   * @default 'Rspress'
    */
   title?: string;
   /**
    * Description of the site.
+   * @default ''
    */
   description?: string;
   /**


### PR DESCRIPTION
## Summary

The `lang` config is missing from the documentation.

This pull request includes changes to add the `lang` configuration, and specifying default values for various configuration options.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
