### PR TITLE
perf: remove `node-fetch` polyfill

### DIFF
--- a/packages/cli/bin/rspress.js
+++ b/packages/cli/bin/rspress.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --experimental-fetch
 import nodeModule from 'node:module';
 
 // enable on-disk code caching of all modules loaded by Node.js

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,7 +62,6 @@
     "htmr": "^1.0.2",
     "lodash-es": "^4.17.21",
     "mdast-util-mdxjs-esm": "^1.3.1",
-    "node-fetch": "3.3.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-helmet-async": "^1.3.0",

--- a/packages/core/src/node/searchIndex.ts
+++ b/packages/core/src/node/searchIndex.ts
@@ -2,7 +2,6 @@ import path, { join } from 'node:path';
 import fs from '@rspress/shared/fs-extra';
 import chalk from '@rspress/shared/chalk';
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import fetch from 'node-fetch';
 import { type UserConfig, isSCM, SEARCH_INDEX_NAME } from '@rspress/shared';
 import { logger } from '@rspress/shared/logger';
 import { isProduction, OUTPUT_DIR, TEMP_DIR } from './constants';

--- a/packages/plugin-api-docgen/package.json
+++ b/packages/plugin-api-docgen/package.json
@@ -36,7 +36,6 @@
     "@types/node": "^18.11.17",
     "@types/react": "^18.3.14",
     "@types/react-dom": "^18.3.2",
-    "mdast-util-mdxjs-esm": "^1.3.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.0",

--- a/packages/plugin-playground/package.json
+++ b/packages/plugin-playground/package.json
@@ -50,7 +50,6 @@
     "@types/node": "^18.11.17",
     "@types/react": "^18.3.14",
     "@types/react-dom": "^18.3.2",
-    "mdast-util-mdxjs-esm": "^1.3.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -696,9 +696,6 @@ importers:
       mdast-util-mdxjs-esm:
         specifier: ^1.3.1
         version: 1.3.1
-      node-fetch:
-        specifier: 3.3.2
-        version: 3.3.2
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -942,9 +939,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.2
         version: 18.3.2
-      mdast-util-mdxjs-esm:
-        specifier: ^1.3.1
-        version: 1.3.1
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1185,9 +1179,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.2
         version: 18.3.2
-      mdast-util-mdxjs-esm:
-        specifier: ^1.3.1
-        version: 1.3.1
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -3677,10 +3668,6 @@ packages:
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
-  data-uri-to-buffer@4.0.1:
-    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
-    engines: {node: '>= 12'}
-
   dayjs@1.11.10:
     resolution: {integrity: sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==}
 
@@ -4005,10 +3992,6 @@ packages:
     resolution: {integrity: sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==}
     engines: {node: '>=0.4.0'}
 
-  fetch-blob@3.2.0:
-    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
-    engines: {node: ^12.20 || >= 14.13}
-
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
@@ -4059,10 +4042,6 @@ packages:
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
-
-  formdata-polyfill@4.0.10:
-    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
-    engines: {node: '>=12.20.0'}
 
   framer-motion@11.13.1:
     resolution: {integrity: sha512-F40tpGTHByhn9h3zdBQPcEro+pSLtzARcocbNqAyfBI+u9S+KZuHH/7O9+z+GEkoF3eqFxfvVw0eBDytohwqmQ==}
@@ -4983,14 +4962,6 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
-
-  node-domexception@1.0.0:
-    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
-    engines: {node: '>=10.5.0'}
-
-  node-fetch@3.3.2:
-    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-machine-id@1.1.12:
     resolution: {integrity: sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==}
@@ -6426,10 +6397,6 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
-
-  web-streams-polyfill@3.2.1:
-    resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
-    engines: {node: '>= 8'}
 
   webpack-sources@3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
@@ -8726,8 +8693,6 @@ snapshots:
 
   csstype@3.1.3: {}
 
-  data-uri-to-buffer@4.0.1: {}
-
   dayjs@1.11.10: {}
 
   de-indent@1.0.2:
@@ -9141,11 +9106,6 @@ snapshots:
     dependencies:
       xml-js: 1.6.11
 
-  fetch-blob@3.2.0:
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 3.2.1
-
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -9188,10 +9148,6 @@ snapshots:
       mime-types: 2.1.35
 
   format@0.2.2: {}
-
-  formdata-polyfill@4.0.10:
-    dependencies:
-      fetch-blob: 3.2.0
 
   framer-motion@11.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -10410,14 +10366,6 @@ snapshots:
   nanoid@3.3.7: {}
 
   neo-async@2.6.2: {}
-
-  node-domexception@1.0.0: {}
-
-  node-fetch@3.3.2:
-    dependencies:
-      data-uri-to-buffer: 4.0.1
-      fetch-blob: 3.2.0
-      formdata-polyfill: 4.0.10
 
   node-machine-id@1.1.12: {}
 
@@ -11953,8 +11901,6 @@ snapshots:
       defaults: 1.0.4
 
   web-namespaces@2.0.1: {}
-
-  web-streams-polyfill@3.2.1: {}
 
   webpack-sources@3.2.3: {}
 


### PR DESCRIPTION
## Summary

Remove node-fetch polyfill to reduce 7.45MB install size:

![image](https://github.com/user-attachments/assets/ab796aa8-0a2f-4357-933f-66f22563f6ee)

- In Node.js >= 18, `fetch` is builtin and enabled by default.
- In Node.js 16, `fetch` can be enabled by the `--experimental-fetch` flag, I have updated the `bin` file to enable it.
- In Rspress 2.0 we can remove this flag from the bin file.

## Other Change

This PR also removed `mdast-util-mdxjs-esm` from two packages because they never use it:

<img width="520" alt="Screenshot 2024-12-15 at 10 15 05" src="https://github.com/user-attachments/assets/7f6496e0-6bc0-4fde-a72f-a77068679ef5" />

## TODO

I think the remote search should be redesigned in Rspress 2.0 as it is now a ByteDance SCM only feature.

See: https://github.com/web-infra-dev/rspress/blob/a373b32a6c5fc4db4c11201e2ea1e06b10dd86bc/packages/core/src/node/searchIndex.ts#L42

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
