### PR TITLE
fix: codeWrap code element instead

### DIFF
--- a/e2e/tests/plugin-shiki.test.ts
+++ b/e2e/tests/plugin-shiki.test.ts
@@ -32,13 +32,17 @@ test.describe('plugin shiki test', async () => {
     expect(shikiDoms.length).toBe(4);
 
     const firstShikiDom = shikiDoms[0];
+    expect(await firstShikiDom.$eval('pre', node => node.style.overflowX)).toBe(
+      'auto',
+    );
+
     expect(
-      await firstShikiDom.$eval('pre', node => node.style.whiteSpace),
+      await firstShikiDom.$eval('code', node => node.style.whiteSpace),
     ).toBe('pre');
 
     await firstShikiDom.$eval('button', btn => btn.click());
     expect(
-      await firstShikiDom.$eval('pre', node => node.style.whiteSpace),
+      await firstShikiDom.$eval('code', node => node.style.whiteSpace),
     ).toBe('pre-wrap');
   });
 });

--- a/packages/theme-default/src/layout/DocLayout/docComponents/code/index.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/code/index.tsx
@@ -52,14 +52,10 @@ export function Code(props: CodeProps) {
       case 'shiki':
       default:
         return (
-          <pre
-            {...props}
-            style={{
-              whiteSpace: codeWrap ? 'pre-wrap' : 'pre',
-              overflowX: 'auto',
-            }}
-          >
-            <code>{props.children}</code>
+          <pre {...props} style={{ overflowX: 'auto' }}>
+            <code style={{ whiteSpace: codeWrap ? 'pre-wrap' : 'pre' }}>
+              {props.children}
+            </code>
           </pre>
         );
     }


### PR DESCRIPTION
## Summary

## Related Issue

<!--- Provide link of related issues -->

related #1619, #1670

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

---

@Timeless0911 

Sorry, I didn't test on real-word project previously, and just found

<img width="376" alt="image" src="https://github.com/user-attachments/assets/2b8f88f9-005f-4a4b-ba60-464cb951a098" />

So setting `whiteSpace` on `pre` will not work as expected, this PR fixed it.

And this time, I've tested on my own project by copying the `bundle.js` into `node_modules`.