### PR TITLE
chore(CI): specify minimal permissions for issue-labeler

### DIFF
--- a/.github/workflows/pr-label.yaml
+++ b/.github/workflows/pr-label.yaml
@@ -6,6 +6,10 @@ on:
       - opened
       - edited
 
+permissions:
+  issues: write
+  contents: read
+
 jobs:
   change-labeling:
     name: Labeling for changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,6 @@ on:
         required: true
         default: 'main'
 
-permissions:
-  id-token: write
-
 jobs:
   release:
     name: Release


### PR DESCRIPTION
## Summary

- Specify minimal permissions for the `issue-labeler` action.
- Remove unused `id-token: write` permission from `release.yml`.

## Related Links

- https://github.com/github/issue-labeler?tab=readme-ov-file#create-workflow
- https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
