### PR TITLE
chore(CI): fix missing permission for provenance

### DIFF
--- a/.github/workflows/pr-label.yaml
+++ b/.github/workflows/pr-label.yaml
@@ -7,6 +7,7 @@ on:
       - edited
 
 permissions:
+  # Permits `github/issue-labeler` to add a label to a pull request
   pull-requests: write
   contents: read
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,10 @@ on:
         required: true
         default: 'main'
 
+permissions:
+  # Provenance generation in GitHub Actions requires "write" access to the "id-token"
+  id-token: write
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
## Summary

Provenance generation in GitHub Actions requires "write" access to the "id-token" and I should not delete it.

<img width="953" alt="Screenshot 2024-12-24 at 17 17 11" src="https://github.com/user-attachments/assets/1edb8a8c-e096-43be-8a7f-030b58454db4" />

I have added comment to prompt the role of this permission.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
