### PR TITLE
chore: rename `@modern-js/plugin-rspress` to `@rspress/modern-js-plugin`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,9 +5,7 @@
   "linked": [],
   "access": "restricted",
   "baseBranch": "main",
-  "fixed": [
-    ["@rspress/*", "rspress", "create-rspress", "@modern-js/plugin-rspress"]
-  ],
+  "fixed": [["@rspress/*", "rspress", "create-rspress"]],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true,
     "updateInternalDependents": "always"

--- a/e2e/fixtures/modern-js/modern.config.ts
+++ b/e2e/fixtures/modern-js/modern.config.ts
@@ -1,5 +1,5 @@
 import { moduleTools, defineConfig } from '@modern-js/module-tools';
-import { modulePluginDoc } from '@modern-js/plugin-rspress';
+import { modulePluginDoc } from '@rspress/modern-js-plugin';
 
 export default defineConfig({
   plugins: [

--- a/e2e/fixtures/modern-js/package.json
+++ b/e2e/fixtures/modern-js/package.json
@@ -26,7 +26,7 @@
     "@arco-design/web-react": "^2.65.0"
   },
   "devDependencies": {
-    "@modern-js/plugin-rspress": "workspace:*",
+    "@rspress/modern-js-plugin": "workspace:*",
     "@types/node": "^18.11.17",
     "@types/react": "~18.3.18",
     "react": "^18.3.1",

--- a/packages/modern-plugin-rspress/package.json
+++ b/packages/modern-plugin-rspress/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@modern-js/plugin-rspress",
+  "name": "@rspress/modern-js-plugin",
   "description": "A Modern.js plugin to integrate rspress",
-  "homepage": "https://modernjs.dev",
+  "homepage": "https://rspress.dev",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,7 +295,7 @@ importers:
         specifier: ^2.65.0
         version: 2.65.0(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
-      '@modern-js/plugin-rspress':
+      '@rspress/modern-js-plugin':
         specifier: workspace:*
         version: link:../../../packages/modern-plugin-rspress
       '@types/node':


### PR DESCRIPTION
## Summary

In this PR, `@modern-js/plugin-rspress` package which used to generate module doc in Modern.js Module projects is renamed to `@rspress/modern-js-plugin` for better npm permission management.

Since we no longer recommend creating new Modern.js Module projects, as we have developed Rslib based on Rsbuild, which is the next-generation Library development tool that will provide better build performance and plugin ecosystem, we will remove `@rspress/modern-js-plugin` in Rspress 2.0.

Users who previously used this plugin can continue to use the old version or switch to the new package name.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
