### PR TITLE
fix(CLI): remove node flag from shebang

### DIFF
--- a/packages/cli/bin/rspress.js
+++ b/packages/cli/bin/rspress.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --experimental-fetch
+#!/usr/bin/env node
 import nodeModule from 'node:module';
 
 // enable on-disk code caching of all modules loaded by Node.js


### PR DESCRIPTION
## Summary

Remove the node flag from shebang as it may not work in some environments.

## Related Issue

https://github.com/web-infra-dev/rspress/pull/1662#issuecomment-2561590553

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
