### PR TITLE
fix(plugin-preview): should use correct default previewMode

### DIFF
--- a/packages/plugin-preview/src/index.ts
+++ b/packages/plugin-preview/src/index.ts
@@ -38,7 +38,7 @@ export function pluginPreview(options?: Options): RspressPlugin {
     previewCodeTransform = ({ code }: { code: string }) => code,
   } = options ?? {};
   const previewMode =
-    (options?.previewMode ?? isMobile) ? 'iframe' : 'internal';
+    options?.previewMode ?? (isMobile ? 'iframe' : 'internal');
   const {
     devPort = 7890,
     framework = 'react',


### PR DESCRIPTION
## Summary

Should use correct default `previewMode`.

`isMobile` should be removed in Rspress 2.0

## Related Issue

closes: #1714 

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
