### PR TITLE
fix(plugin-api-docgen): search index should include generated API doc

### DIFF
--- a/e2e/tests/api-docgen.test.ts
+++ b/e2e/tests/api-docgen.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 import path from 'node:path';
 import { getPort, killProcess, runDevCommand } from '../utils/runCommands';
+import { searchInPage } from '../utils/search';
 
 const fixtureDir = path.resolve(__dirname, '../fixtures');
 
@@ -46,5 +47,11 @@ test.describe('api-docgen test', async () => {
     expect(tableContent).toContain('Default Value');
     expect(tableContent).toContain('-');
     expect(tableContent).toContain("'default'");
+  });
+
+  test('search index should include api-docgen result', async ({ page }) => {
+    await page.goto(`http://localhost:${appPort}`);
+    const suggestItems = await searchInPage(page, 'disabled');
+    expect(suggestItems.length).toBe(1);
   });
 });

--- a/e2e/utils/search.ts
+++ b/e2e/utils/search.ts
@@ -1,0 +1,26 @@
+import type { Page } from '@playwright/test';
+import assert from 'node:assert';
+
+async function getSearchButton(page: Page) {
+  const searchButton = await page.$('.rspress-nav-search-button');
+  return searchButton;
+}
+
+/**
+ * @returns suggestItems domList
+ */
+export async function searchInPage(page: Page, searchText: string) {
+  const searchButton = await getSearchButton(page);
+  assert(searchButton);
+
+  await searchButton.click();
+
+  const searchInput = await page.$('.rspress-search-panel-input');
+  assert(searchInput);
+  const isEditable = await searchInput.isEditable();
+  assert(isEditable);
+  await searchInput.focus();
+  await page.keyboard.type(searchText);
+  await page.waitForTimeout(500);
+  return await page.$$('.rspress-search-suggest-item');
+}

--- a/packages/plugin-api-docgen/src/index.ts
+++ b/packages/plugin-api-docgen/src/index.ts
@@ -54,7 +54,11 @@ export function pluginApiDocgen(options?: PluginOptions): RspressPlugin {
             return;
           }
           while (matchResult !== null) {
-            const [matchContent, _matchContent, moduleName] = matchResult;
+            const matchContent = matchResult[0];
+            const moduleName = matchResult[2] ?? matchResult[5] ?? '';
+            if (!moduleName) {
+              return;
+            }
             const apiDoc =
               apiDocMap[moduleName] || apiDocMap[`${moduleName}-${lang}`];
             content = content.replace(matchContent, apiDoc);

--- a/packages/plugin-api-docgen/src/index.ts
+++ b/packages/plugin-api-docgen/src/index.ts
@@ -54,7 +54,7 @@ export function pluginApiDocgen(options?: PluginOptions): RspressPlugin {
             return;
           }
           while (matchResult !== null) {
-            const [matchContent, moduleName] = matchResult;
+            const [matchContent, _matchContent, moduleName] = matchResult;
             const apiDoc =
               apiDocMap[moduleName] || apiDocMap[`${moduleName}-${lang}`];
             content = content.replace(matchContent, apiDoc);

--- a/packages/plugin-api-docgen/src/index.ts
+++ b/packages/plugin-api-docgen/src/index.ts
@@ -56,11 +56,8 @@ export function pluginApiDocgen(options?: PluginOptions): RspressPlugin {
           while (matchResult !== null) {
             const matchContent = matchResult[0];
             const moduleName = matchResult[2] ?? matchResult[5] ?? '';
-            if (!moduleName) {
-              return;
-            }
             const apiDoc =
-              apiDocMap[moduleName] || apiDocMap[`${moduleName}-${lang}`];
+              apiDocMap[moduleName] ?? apiDocMap[`${moduleName}-${lang}`] ?? '';
             content = content.replace(matchContent, apiDoc);
             matchResult = new RegExp(apiCompRegExp).exec(content);
           }

--- a/packages/theme-default/src/components/Search/SearchPanel.tsx
+++ b/packages/theme-default/src/components/Search/SearchPanel.tsx
@@ -468,10 +468,10 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
                     <SvgWrapper icon={SearchSvg} />
                   </label>
                   <input
-                    className={styles.input}
+                    className={`rspress-search-panel-input ${styles.input}`}
                     ref={searchInputRef}
                     placeholder={searchPlaceholderText}
-                    aria-label="Search"
+                    aria-label="SearchPanelInput"
                     autoComplete="off"
                     autoFocus
                     onChange={e => handleQueryChange(e.target.value)}

--- a/packages/theme-default/src/components/Search/SuggestItem.tsx
+++ b/packages/theme-default/src/components/Search/SuggestItem.tsx
@@ -120,7 +120,7 @@ export function SuggestItem({
   return (
     <li
       key={suggestion.link}
-      className={`${styles.suggestItem} ${isCurrent ? styles.current : ''}`}
+      className={`rspress-search-suggest-item ${styles.suggestItem} ${isCurrent ? styles.current : ''}`}
       onMouseEnter={setCurrentSuggestionIndex}
       onMouseMove={onMouseMove}
       ref={selfRef}


### PR DESCRIPTION
## Summary

Regex was used incorrectly.

https://github.com/web-infra-dev/rspress/blob/5ec4787e7d993c924595e3d342211990e87f792f/packages/plugin-api-docgen/src/index.ts#L46-L48

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
