### PR TITLE
chore: remove chunk name TODO

### DIFF
--- a/packages/core/src/node/route/RouteService.ts
+++ b/packages/core/src/node/route/RouteService.ts
@@ -250,8 +250,6 @@ export class RouteService {
     routeMeta: RouteMeta[],
     isStaticImport: boolean,
   ) {
-    // TODO: webpackChunkName need fix https://github.com/web-infra-dev/rspack/issues/4664
-
     return `
 import React from 'react';
 import { lazyWithPreload } from "react-lazy-with-preload";


### PR DESCRIPTION
## Summary

This TODO comment was introduced in https://github.com/web-infra-dev/rspress/commit/ac0bfb0e2838ccbfd7482e830c2ca39a18f07df3#diff-ca2dde319beb6f6b3cd12a0dbe21569c4b89adb8c0cd50b9cac1197522d3ec10R236-R245.

I tried to add the `/* webpackChunkName: "${route.pageName}" */` back, but it caused two problems:

1. The async chunk name may conflict with the initial chunks.

![image](https://github.com/user-attachments/assets/03036fd8-648f-4232-aced-9cc3684bf486)

2. The generated chunk name is quite long and increases the bundle size:

![image](https://github.com/user-attachments/assets/d39fce8e-63e9-4bd7-98fa-d83cf51412ad)

Therefore, I prefer to remove this TODO comment and keep using the default deterministic chunkId of Rspack.

## Related Issue

- https://rspack.dev/config/optimization#optimizationchunkids

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
