### PR TITLE
fix: dark mode when hover LinkCard component

### DIFF
--- a/packages/theme-default/src/components/LinkCard/index.module.scss
+++ b/packages/theme-default/src/components/LinkCard/index.module.scss
@@ -3,3 +3,9 @@
   position: absolute;
   inset: 0;
 }
+
+.linkCard {
+  &:hover {
+    background-color: var(--rp-c-bg-mute);
+  }
+}

--- a/packages/theme-default/src/components/LinkCard/index.tsx
+++ b/packages/theme-default/src/components/LinkCard/index.tsx
@@ -25,7 +25,7 @@ export function LinkCard(props: LinkCardProps) {
 
   return (
     <div
-      className="relative border border-gray-400 rounded-lg p-6 flex justify-between items-start hover:border-gray-500 hover:bg-gray-100 transition-all duration-300"
+      className={`relative border border-gray-400 rounded-lg p-6 flex justify-between items-start hover:border-gray-500 transition-all duration-300 ${styles.linkCard}`}
       style={style}
     >
       <div className="flex flex-col">


### PR DESCRIPTION
## Summary

fix: dark mode when hover CardLink component

![20250122160313_rec_](https://github.com/user-attachments/assets/631e5ddd-b880-462d-a7a8-8180cebce259)


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
