### PR TITLE
chore(shared): remove unused `execa.ts` module

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "cross-env": "^7.0.3",
     "cross-spawn": "^7.0.6",
     "cspell-ban-words": "^0.0.4",
-    "execa": "8.0.1",
     "fs-extra": "11.3.0",
     "get-port": "5.1.1",
     "heading-case": "^0.1.4",

--- a/packages/shared/src/execa.ts
+++ b/packages/shared/src/execa.ts
@@ -1,2 +1,0 @@
-export * from 'execa';
-export { default } from 'execa';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       cspell-ban-words:
         specifier: ^0.0.4
         version: 0.0.4
-      execa:
-        specifier: 8.0.1
-        version: 8.0.1
       fs-extra:
         specifier: 11.3.0
         version: 11.3.0


### PR DESCRIPTION
## Summary

- Remove the unused `execa.ts` module, see https://github.com/web-infra-dev/rspress/pull/1773/files for related changes.
- Remove the `execa` dependency in the monorepo root, it's not used.

## TODO

Considering that `plugin-lasted-updated`  is a dependency of the Rspress core, perhaps `plugin-lasted-updated` can remove the `execa` to reduce dependencies.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
