### PR TITLE
chore(infra): implement click to reference by tsconfig.reference

### DIFF
--- a/packages/cli/src/update.ts
+++ b/packages/cli/src/update.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { pathExists } from '@rspress/shared/fs-extra';
+import fse from '@rspress/shared/fs-extra';
 import { logger } from '@rspress/shared/logger';
 
 type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun';
@@ -16,7 +16,7 @@ const lockfileMap: Record<string, PackageManager> = {
 async function getPackageManager(rootPath: string) {
   let packageManager: PackageManager = 'npm';
   for (const file of Object.keys(lockfileMap)) {
-    if (await pathExists(path.join(rootPath, file))) {
+    if (await fse.pathExists(path.join(rootPath, file))) {
       packageManager = lockfileMap[file];
       break;
     }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -17,5 +17,13 @@
     "runtime.ts",
     "theme.ts"
   ],
-  "exclude": ["**/node_modules"]
+  "exclude": ["**/node_modules"],
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    }
+  ]
 }

--- a/packages/core/src/node/runtimeModule/siteData/index.ts
+++ b/packages/core/src/node/runtimeModule/siteData/index.ts
@@ -107,7 +107,7 @@ export async function siteDataVMPlugin(context: FactoryContext) {
     pages.map(async pageData => pluginDriver.extendPageData(pageData)),
   );
 
-  const siteData: SiteData = {
+  const siteData: Omit<SiteData, 'root'> = {
     title: userConfig?.title || '',
     description: userConfig?.description || '',
     icon: userConfig?.icon || '',

--- a/packages/core/src/node/utils/flattenMdxContent.ts
+++ b/packages/core/src/node/utils/flattenMdxContent.ts
@@ -91,7 +91,7 @@ export async function flattenMdxContent(
   let result = content;
 
   try {
-    ast = processor.parse(content) as Root;
+    ast = processor.parse(content) as unknown as Root;
   } catch (e) {
     // Fallback: if mdx parse failed, just return the content
     return { flattenContent: content, deps };
@@ -99,7 +99,7 @@ export async function flattenMdxContent(
 
   const importNodes = ast.children
     .filter(node => node.type === ('mdxjsEsm' as any))
-    .flatMap(node => (node.data?.estree as ESTree)?.body || [])
+    .flatMap(node => ((node.data as any)?.estree as ESTree)?.body || [])
     .filter(node => node.type === 'ImportDeclaration');
   for (const importNode of importNodes) {
     // import Comp from './a';

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,13 +1,16 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
-    "declaration": false,
     "strict": false,
+    "declaration": true,
+    "noEmit": false,
+    "declarationDir": "dist",
     "module": "ESNext",
     "target": "ESNext",
     "jsx": "react-jsx",
     "baseUrl": "src",
-    "rootDir": ".",
+    "rootDir": "src",
+    "composite": true,
     "lib": ["ESNext", "DOM"],
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -17,11 +20,29 @@
       "@/theme-default/*": ["./theme-default/*"]
     }
   },
-  "include": [
-    "src",
-    "vitest.config.ts",
-    "./modern.config.ts",
-    "./tailwind.config.ts"
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../plugin-auto-nav-sidebar"
+    },
+    {
+      "path": "../plugin-last-updated"
+    },
+    {
+      "path": "../plugin-container-syntax"
+    },
+    {
+      "path": "../plugin-medium-zoom"
+    },
+    {
+      "path": "../shared"
+    },
+    {
+      "path": "../theme-default"
+    },
+    {
+      "path": "../runtime"
+    }
   ],
   "exclude": ["runtime.ts", "theme.ts", "node_modules"]
 }

--- a/packages/modern-plugin-rspress/tests/tsconfig.json
+++ b/packages/modern-plugin-rspress/tests/tsconfig.json
@@ -5,7 +5,7 @@
     "jsx": "preserve",
     "baseUrl": "./",
     "outDir": "./out",
-    "emitDeclarationOnly": true,
+    "noEmit": false,
     "isolatedModules": true,
     "paths": {},
     "types": ["node", "jest"]

--- a/packages/modern-plugin-rspress/tsconfig.json
+++ b/packages/modern-plugin-rspress/tsconfig.json
@@ -1,9 +1,22 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
-    "declaration": false,
+    "declaration": true,
+    "noEmit": false,
+    "outDir": "dist",
     "jsx": "preserve",
     "baseUrl": "./"
   },
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../plugin-api-docgen"
+    },
+    {
+      "path": "../plugin-preview"
+    }
+  ],
   "include": ["src", "static", "rslib.config.ts"]
 }

--- a/packages/plugin-api-docgen/tsconfig.json
+++ b/packages/plugin-api-docgen/tsconfig.json
@@ -1,26 +1,29 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
-    "declaration": false,
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
     "module": "ESNext",
     "target": "ESNext",
     "jsx": "react-jsx",
     "baseUrl": "src",
-    "rootDir": ".",
+    "rootDir": "src",
     "lib": ["ESNext", "DOM"],
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "noEmit": true,
     "paths": {
       "@/*": ["./*"]
     }
   },
-  "include": [
-    "src",
-    "vitest.config.ts",
-    "index.d.ts",
-    "mdx-meta-loader.cjs",
-    "static/"
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    }
   ],
+  "include": ["src"],
   "exclude": ["runtime.d.ts", "theme.d.ts", "node_modules", "dist"]
 }

--- a/packages/plugin-auto-nav-sidebar/tsconfig.json
+++ b/packages/plugin-auto-nav-sidebar/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
-    "declaration": false,
+    "declaration": true,
+    "noEmit": false,
+    "composite": true,
+    "outDir": "dist",
+    "noImplicitAny": false,
     "module": "ESNext",
     "target": "ESNext",
     "jsx": "react-jsx",
@@ -14,6 +18,11 @@
       "@/*": ["./*"]
     }
   },
+  "references": [
+    {
+      "path": "../shared"
+    }
+  ],
   "include": ["src", "vitest.config.ts", "index.d.ts", "rslib.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/plugin-client-redirects/tsconfig.json
+++ b/packages/plugin-client-redirects/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
-    "declaration": false,
+    "composite": true,
+    "declaration": true,
     "module": "ESNext",
     "target": "ESNext",
     "jsx": "react-jsx",
@@ -14,6 +15,11 @@
       "@/*": ["./*"]
     }
   },
+  "references": [
+    {
+      "path": "../shared"
+    }
+  ],
   "include": ["src", "vitest.config.ts", "index.d.ts", "rslib.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/plugin-container-syntax/tsconfig.json
+++ b/packages/plugin-container-syntax/tsconfig.json
@@ -1,12 +1,13 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
-    "declaration": false,
+    "composite": true,
+    "declaration": true,
     "module": "ESNext",
     "target": "ESNext",
     "jsx": "react-jsx",
     "baseUrl": "src",
-    "rootDir": ".",
+    "rootDir": "src",
     "lib": ["ESNext", "DOM"],
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -14,6 +15,11 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["src", "vitest.config.ts", "index.d.ts", "rslib.config.ts"],
+  "references": [
+    {
+      "path": "../shared"
+    }
+  ],
+  "include": ["src"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/plugin-last-updated/tsconfig.json
+++ b/packages/plugin-last-updated/tsconfig.json
@@ -1,12 +1,14 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
-    "declaration": false,
+    "declaration": true,
+    "composite": true,
     "module": "ESNext",
     "target": "ESNext",
     "jsx": "react-jsx",
+    "outDir": "dist",
     "baseUrl": "src",
-    "rootDir": ".",
+    "rootDir": "src",
     "lib": ["ESNext", "DOM"],
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -14,6 +16,11 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["src", "vitest.config.ts", "index.d.ts", "rslib.config.ts"],
+  "references": [
+    {
+      "path": "../shared"
+    }
+  ],
+  "include": ["src"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/plugin-medium-zoom/tsconfig.json
+++ b/packages/plugin-medium-zoom/tsconfig.json
@@ -1,12 +1,15 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
-    "declaration": false,
+    "declaration": true,
+    "noEmit": false,
+    "outDir": "dist",
+    "composite": true,
     "module": "ESNext",
     "target": "ESNext",
     "jsx": "react-jsx",
     "baseUrl": "src",
-    "rootDir": ".",
+    "rootDir": "src",
     "lib": ["ESNext", "DOM"],
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -14,6 +17,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["src", "vitest.config.ts", "index.d.ts", "rslib.config.ts"],
+  "include": ["src"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/plugin-playground/tsconfig.json
+++ b/packages/plugin-playground/tsconfig.json
@@ -1,12 +1,15 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
-    "declaration": false,
+    "declaration": true,
+    "composite": true,
+    "noEmit": false,
+    "outDir": "dist",
     "module": "ESNext",
     "target": "ESNext",
     "jsx": "react-jsx",
     "baseUrl": "src",
-    "rootDir": ".",
+    "rootDir": "src",
     "lib": ["ESNext", "DOM"],
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -14,6 +17,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["src", "vitest.config.ts", "index.d.ts", "rslib.config.ts"],
+  "include": ["src"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/plugin-preview/tsconfig.json
+++ b/packages/plugin-preview/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
-    "declaration": false,
+    "composite": true,
+    "noEmit": false,
+    "declaration": true,
+    "declarationDir": "dist",
     "module": "ESNext",
     "target": "ESNext",
     "jsx": "react-jsx",
@@ -10,7 +13,6 @@
     "lib": ["ESNext", "DOM"],
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "noEmit": true,
     "paths": {
       "@/*": ["./*"]
     }
@@ -22,6 +24,14 @@
     "mdx-meta-loader.cjs",
     "static/",
     "rslib.config.ts"
+  ],
+  "references": [
+    {
+      "path": "../shared"
+    },
+    {
+      "path": "../theme-default"
+    }
   ],
   "exclude": ["runtime.d.ts", "theme.d.ts", "node_modules", "dist"]
 }

--- a/packages/plugin-rss/tsconfig.json
+++ b/packages/plugin-rss/tsconfig.json
@@ -11,6 +11,7 @@
   "include": ["src"],
   "references": [
     { "path": "./tsconfig.runtime.json" },
-    { "path": "./tsconfig.tools.json" }
+    { "path": "./tsconfig.tools.json" },
+    { "path": "../runtime" }
   ]
 }

--- a/packages/plugin-rss/tsconfig.runtime.json
+++ b/packages/plugin-rss/tsconfig.runtime.json
@@ -2,13 +2,13 @@
   "extends": "@modern-js/tsconfig/react",
   "compilerOptions": {
     "composite": true,
-    "declaration": false,
+    "declaration": true,
+    "noEmit": false,
     "module": "ESNext",
     "target": "ESNext",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "moduleResolution": "Bundler",
-    "noEmit": true,
     "jsx": "react-jsx"
   },
   "include": ["static"]

--- a/packages/plugin-rss/tsconfig.tools.json
+++ b/packages/plugin-rss/tsconfig.tools.json
@@ -3,12 +3,12 @@
   "compilerOptions": {
     "composite": true,
     "declaration": true,
+    "noEmit": false,
     "module": "ESNext",
     "target": "ES2020",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "moduleResolution": "bundler",
-    "noEmit": true
+    "moduleResolution": "bundler"
   },
   "include": ["modern.config.ts", "vitest.config.ts"]
 }

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -1,11 +1,20 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "declarationDir": "dist",
     "rootDir": "src",
     "baseUrl": ".",
     "skipLibCheck": true,
     "jsx": "react-jsx",
     "esModuleInterop": true
   },
-  "include": ["./src/**/*"]
+  "references": [
+    {
+      "path": "../shared"
+    }
+  ],
+  "include": ["src"]
 }

--- a/packages/shared/modern.config.ts
+++ b/packages/shared/modern.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, moduleTools } from '@modern-js/module-tools';
 
-export default defineConfig({
+const config: ReturnType<typeof defineConfig> = defineConfig({
   plugins: [moduleTools()],
   buildConfig: [
     {
@@ -31,3 +31,5 @@ export default defineConfig({
     },
   ],
 });
+
+export default config;

--- a/packages/shared/src/execa.ts
+++ b/packages/shared/src/execa.ts
@@ -1,2 +1,0 @@
-export * from 'execa';
-export { default } from 'execa';

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,15 +1,20 @@
 {
   "extends": "@modern-js/tsconfig/base",
-  "declaration": true,
   "compilerOptions": {
+    "composite": true,
+    "declarationDir": "dist",
+    "noEmit": false,
+    "declaration": true,
+    "outDir": "dist",
     "module": "ESNext",
     "target": "ESNext",
+    "rootDir": "src",
     "baseUrl": "./",
     "paths": {
       "@/*": ["./src/*"]
     },
     "isolatedModules": true
   },
-  "include": ["src", "vitest.config.ts", "modern.config.ts"],
+  "include": ["src"],
   "exclude": ["**/node_modules"]
 }

--- a/packages/theme-default/tsconfig.json
+++ b/packages/theme-default/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
-    "declaration": false,
+    "declaration": true,
+    "noEmit": false,
+    "declarationDir": "dist",
+    "composite": true,
     "strict": true,
     "module": "ESNext",
     "target": "ESNext",
@@ -20,6 +23,14 @@
     "vitest.config.ts",
     "./modern.config.ts",
     "./tailwind.config.ts"
+  ],
+  "references": [
+    {
+      "path": "../runtime"
+    },
+    {
+      "path": "../shared"
+    }
   ],
   "exclude": ["theme.ts", "node_modules"]
 }


### PR DESCRIPTION
## Summary

this is a trick for implementing "click to reference" of ts-language-server

tsc will build the `.d.ts.map` in memory

so we need to set `rootDir: "src"` `"outDir: "dist""` `composite: true` and tsconfig.reference just like Rsbuild repo

![img_v3_02iv_0cb9e632-dd84-465c-bf86-39fe0f25b46g](https://github.com/user-attachments/assets/79829347-5371-4834-9278-be3df929f16f)


BTW, fix some type error when debugging references


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
