### PR TITLE
ci(corepack): fix corepack key id mismatch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install Pnpm
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@latest --force
           corepack enable
 
       - name: Setup Node.js

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,9 @@ jobs:
           fetch-depth: 1
 
       - name: Install Pnpm
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest
+          corepack enable
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,9 @@ jobs:
           ref: ${{ github.event.inputs.branch }}
 
       - name: Install Pnpm
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest
+          corepack enable
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install Pnpm
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@latest --force
           corepack enable
 
       - name: Setup Node.js

--- a/.github/workflows/test-Windows.yml
+++ b/.github/workflows/test-Windows.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install Pnpm
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@latest --force
           corepack enable
 
       - name: Check skip CI

--- a/.github/workflows/test-Windows.yml
+++ b/.github/workflows/test-Windows.yml
@@ -38,7 +38,9 @@ jobs:
           fetch-depth: 1
 
       - name: Install Pnpm
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest
+          corepack enable
 
       - name: Check skip CI
         shell: bash

--- a/.github/workflows/test-macOS.yml
+++ b/.github/workflows/test-macOS.yml
@@ -33,7 +33,9 @@ jobs:
           fetch-depth: 1
 
       - name: Install Pnpm
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest
+          corepack enable
 
       - name: Check skip CI
         run: echo "RESULT=$(node ./scripts/skipCI.js)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-macOS.yml
+++ b/.github/workflows/test-macOS.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install Pnpm
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@latest --force
           corepack enable
 
       - name: Check skip CI


### PR DESCRIPTION
## Summary


Add `npm install -g corepack@latest --force` before `corepack enable` to fix corepack key id mismatch issue.

> `--force` to prevent windows install error

![image](https://github.com/user-attachments/assets/47a73c6c-240e-4c15-bf7b-1e23f8b1c54d)


## Related Links

https://github.com/nodejs/corepack/issues/612

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
