### PR TITLE
refactor: remove prebundle package's `.d.ts`

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@modern-js/tsconfig/base",
   "declaration": true,
   "compilerOptions": {
+    "moduleResolution": "bundler",
     "module": "ESNext",
     "target": "ESNext",
     "baseUrl": "./",

--- a/packages/core/src/node/PluginDriver.ts
+++ b/packages/core/src/node/PluginDriver.ts
@@ -55,7 +55,6 @@ export class PluginDriver {
 
     if (isDevDebugMode()) {
       const SourceBuildPlugin = await import(
-        // @ts-expect-error need moduleResolution: Node16, NodeNext or Bundler to get type declarations work
         '@rspress/theme-default/node/source-build-plugin.js'
       ).then(
         r => r.SourceBuildPlugin,

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
+    "moduleResolution": "bundler",
     "strict": false,
     "declaration": true,
     "noEmit": false,

--- a/packages/create-rspress/tsconfig.json
+++ b/packages/create-rspress/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@modern-js/tsconfig/base",
   "declaration": true,
   "compilerOptions": {
+    "moduleResolution": "bundler",
     "module": "ESNext",
     "target": "ESNext",
     "baseUrl": "./",

--- a/packages/document/tsconfig.json
+++ b/packages/document/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
     "jsx": "preserve",
+    "moduleResolution": "bundler",
     "paths": {
       "i18n": ["./i18n.json"],
       "@theme": ["./theme"],
@@ -10,8 +11,7 @@
       "@zh/*": ["./docs/zh/*"],
       "@en/*": ["./docs/en/*"]
     },
-    "module": "ESNext",
-    "moduleResolution": "Bundler"
+    "module": "ESNext"
   },
   "include": [
     "./rspress.config.ts",

--- a/packages/modern-plugin-rspress/tsconfig.json
+++ b/packages/modern-plugin-rspress/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
+    "moduleResolution": "bundler",
+    "module": "ESNext",
     "declaration": true,
     "noEmit": false,
     "outDir": "dist",

--- a/packages/plugin-api-docgen/tsconfig.json
+++ b/packages/plugin-api-docgen/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
+    "moduleResolution": "bundler",
     "composite": true,
     "declaration": true,
     "noEmit": false,

--- a/packages/plugin-auto-nav-sidebar/tsconfig.json
+++ b/packages/plugin-auto-nav-sidebar/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
+    "moduleResolution": "bundler",
     "declaration": true,
     "noEmit": false,
     "composite": true,

--- a/packages/plugin-client-redirects/tsconfig.json
+++ b/packages/plugin-client-redirects/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
+    "moduleResolution": "bundler",
     "composite": true,
     "declaration": true,
     "module": "ESNext",

--- a/packages/plugin-container-syntax/tsconfig.json
+++ b/packages/plugin-container-syntax/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
+    "moduleResolution": "bundler",
     "composite": true,
     "declaration": true,
     "module": "ESNext",

--- a/packages/plugin-last-updated/tsconfig.json
+++ b/packages/plugin-last-updated/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
+    "moduleResolution": "bundler",
     "declaration": true,
     "composite": true,
     "module": "ESNext",

--- a/packages/plugin-medium-zoom/tsconfig.json
+++ b/packages/plugin-medium-zoom/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
+    "moduleResolution": "bundler",
     "declaration": true,
     "noEmit": false,
     "outDir": "dist",

--- a/packages/plugin-playground/tsconfig.json
+++ b/packages/plugin-playground/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
+    "moduleResolution": "bundler",
     "declaration": true,
     "composite": true,
     "noEmit": false,

--- a/packages/plugin-preview/tsconfig.json
+++ b/packages/plugin-preview/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
+    "moduleResolution": "bundler",
     "composite": true,
     "noEmit": false,
     "declaration": true,

--- a/packages/plugin-rss/tsconfig.json
+++ b/packages/plugin-rss/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
+    "moduleResolution": "bundler",
     "declaration": false,
     "module": "ESNext",
     "target": "ES2020",
     "esModuleInterop": true,
-    "skipLibCheck": true,
-    "moduleResolution": "bundler"
+    "skipLibCheck": true
   },
   "include": ["src"],
   "references": [

--- a/packages/plugin-shiki/tsconfig.json
+++ b/packages/plugin-shiki/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
+    "moduleResolution": "bundler",
     "declaration": false,
     "module": "ESNext",
     "target": "ESNext",

--- a/packages/plugin-typedoc/tsconfig.json
+++ b/packages/plugin-typedoc/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
+    "moduleResolution": "bundler",
     "declaration": false,
     "module": "ESNext",
     "target": "ESNext",

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
+    "moduleResolution": "bundler",
+    "module": "ESNext",
     "composite": true,
     "declaration": true,
     "noEmit": false,

--- a/packages/shared/chalk.d.ts
+++ b/packages/shared/chalk.d.ts
@@ -1,2 +1,0 @@
-export * from './dist/chalk';
-export { default } from './dist/chalk';

--- a/packages/shared/logger.d.ts
+++ b/packages/shared/logger.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/logger';

--- a/packages/shared/node-utils.d.ts
+++ b/packages/shared/node-utils.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/node-utils';

--- a/packages/theme-default/tsconfig.json
+++ b/packages/theme-default/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
+    "moduleResolution": "bundler",
     "declaration": true,
     "noEmit": false,
     "declarationDir": "dist",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
     "target": "ES2019",
+    "module": "ESNext",
     "declaration": true,
     "outDir": "./dist",
     "jsx": "preserve",


### PR DESCRIPTION
## Summary

this is a hack to set `@rspress/shared/chalk` types, after using `"moduleResolution": "bundler"`, it works

it is hard to be understood

## Related Issue

https://github.com/web-infra-dev/rspress/pull/1773
<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
