### PR TITLE
feat: preload search index when page is idle

### DIFF
--- a/packages/theme-default/src/components/Search/SearchPanel.tsx
+++ b/packages/theme-default/src/components/Search/SearchPanel.tsx
@@ -245,6 +245,17 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
     }
   }, [focused]);
 
+  // Preload the search index when the page is idle
+  useEffect(() => {
+    if ('requestIdleCallback' in window) {
+      window.requestIdleCallback(() => {
+        if (!pageSearcherRef.current) {
+          initPageSearcher();
+        }
+      });
+    }
+  }, []);
+
   useEffect(() => {
     const { currentLang, currentVersion } = pageSearcherConfigRef.current ?? {};
     const isLangChanged = lang !== currentLang;


### PR DESCRIPTION
## Summary

Currently Rspress only fetches the search index file when the user focused on the search panel.

This PR allows Rspress to preload the search index when the page is idle, which should improve the search experience.

![image](https://github.com/user-attachments/assets/1a0052da-0997-475e-9fcd-760e957e7dc2)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
