### PR TITLE
refactor: use esm mdx-loader rather than cjs

### DIFF
--- a/packages/core/loader.cjs
+++ b/packages/core/loader.cjs
@@ -1,8 +1,0 @@
-module.exports = function (code) {
-  const callback = this.async();
-  // Cause the loader core logic is esm module, so we need to use dynamic import to load it.
-  // eslint-disable-next-line node/file-extension-in-import
-  import('./dist/loader.js').then(({ default: loader }) => {
-    return loader.call(this, this, code, callback);
-  });
-};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,9 +44,7 @@
     "src/shared",
     "index.html",
     "runtime.ts",
-    "theme.ts",
-    "loader.cjs",
-    "compiled"
+    "theme.ts"
   ],
   "scripts": {
     "build": "modern build",

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -219,7 +219,7 @@ async function createInternalBuildConfig(
           .options(swcLoaderOptions)
           .end()
           .use('mdx-loader')
-          .loader(require.resolve('../loader.cjs'))
+          .loader(require.resolve('./loader.js'))
           .options({
             config,
             docDirectory: userDocRoot,

--- a/packages/core/src/node/mdx/loader.ts
+++ b/packages/core/src/node/mdx/loader.ts
@@ -89,15 +89,15 @@ export function createCheckPageMetaUpdateFn() {
 const checkPageMetaUpdate = createCheckPageMetaUpdateFn();
 
 export default async function mdxLoader(
-  context: Rspack.LoaderContext<LoaderOptions>,
+  this: Rspack.LoaderContext<LoaderOptions>,
   source: string,
-  callback: Rspack.LoaderContext['callback'],
 ) {
-  context.cacheable(true);
+  this.cacheable(true);
+  const callback = this.async();
 
-  const options = context.getOptions();
-  const filepath = context.resourcePath;
-  const { alias } = context._compiler.options.resolve;
+  const options = this.getOptions();
+  const filepath = this.resourcePath;
+  const { alias } = this._compiler.options.resolve;
   const { config, docDirectory, checkDeadLinks, routeService, pluginDriver } =
     options;
 
@@ -116,7 +116,7 @@ export default async function mdxLoader(
     alias as Record<string, string>,
   );
 
-  deps.forEach(dep => context.addDependency(dep));
+  deps.forEach(dep => this.addDependency(dep));
 
   // Resolve side effects caused by flattenMdxContent.
   // Perhaps this problem should be solved within flattenMdxContent?

--- a/packages/plugin-preview/package.json
+++ b/packages/plugin-preview/package.json
@@ -13,8 +13,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
-    "static",
-    "mdx-meta-loader.cjs"
+    "static"
   ],
   "scripts": {
     "build": "rslib build",


### PR DESCRIPTION
## Summary

Rspack supports esm loader now, so let us migrate the cjs loader to esm loader

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
