### PR TITLE
chore(workflow): use nx default cache directory

### DIFF
--- a/.github/workflows/test-Windows.yml
+++ b/.github/workflows/test-Windows.yml
@@ -61,7 +61,7 @@ jobs:
         id: nx-cache
         uses: actions/cache@v4
         with:
-          path: .nx-cache
+          path: .nx/cache
           key: nx-${{ github.ref_name }}-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
             nx-${{ github.ref_name }}-${{ runner.os }}

--- a/.github/workflows/test-macOS.yml
+++ b/.github/workflows/test-macOS.yml
@@ -55,7 +55,7 @@ jobs:
         id: nx-cache
         uses: actions/cache@v4
         with:
-          path: .nx-cache
+          path: .nx/cache
           key: nx-${{ github.ref_name }}-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
             nx-${{ github.ref_name }}-${{ runner.os }}

--- a/nx.json
+++ b/nx.json
@@ -4,8 +4,7 @@
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {
-        "cacheableOperations": ["dev", "build", "test"],
-        "cacheDirectory": ".nx-cache"
+        "cacheableOperations": ["dev", "build", "test"]
       }
     }
   },

--- a/packages/core/src/node/route/RouteService.ts
+++ b/packages/core/src/node/route/RouteService.ts
@@ -148,7 +148,7 @@ export class RouteService {
           ...this.#exclude,
           '**/node_modules/**',
           '**/.eslintrc.js',
-          '**/.nx-cache/**',
+          '**/.nx/**',
           `./${PUBLIC_DIR}/**`,
         ],
       })


### PR DESCRIPTION
## Summary

Use the nx default cache directory `.nx/cache` instead of `.nx-cache`.

This change will reduce the number of folders in the root directory.

## Related Issue

- https://nx.dev/recipes/running-tasks/change-cache-location

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
