### PR TITLE
refactor(deps): migrate chalk to picocolors

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,7 +46,8 @@
     "@rspress/core": "workspace:*",
     "@rspress/shared": "workspace:*",
     "cac": "^6.7.14",
-    "chokidar": "^3.6.0"
+    "chokidar": "^3.6.0",
+    "picocolors": "^1.1.1"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.49.2",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,10 +1,10 @@
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { build, dev, serve } from '@rspress/core';
-import chalk from '@rspress/shared/chalk';
 import { logger } from '@rspress/shared/logger';
 import { cac } from 'cac';
 import chokidar from 'chokidar';
+import picocolors from 'picocolors';
 import { loadConfigFile, resolveDocRoot } from './config/loadConfigFile';
 import update from './update';
 
@@ -78,7 +78,7 @@ cli
             }
             isRestarting = true;
             console.log(
-              `\n✨ ${eventName} ${chalk.green(
+              `\n✨ ${eventName} ${picocolors.green(
                 path.relative(cwd, filepath),
               )}, dev server will restart...\n`,
             );

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -77,6 +77,7 @@
     "lodash-es": "^4.17.21",
     "mdast-util-mdxjs-esm": "^1.3.1",
     "memfs": "^4.17.0",
+    "picocolors": "^1.1.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-helmet-async": "^1.3.0",

--- a/packages/core/src/node/build.ts
+++ b/packages/core/src/node/build.ts
@@ -11,8 +11,8 @@ import {
   normalizeSlash,
   withBase,
 } from '@rspress/shared';
-import chalk from '@rspress/shared/chalk';
 import { logger } from '@rspress/shared/logger';
+import picocolors from 'picocolors';
 import type { HelmetData } from 'react-helmet-async';
 import { PluginDriver } from './PluginDriver';
 import {
@@ -100,7 +100,7 @@ export async function renderPages(
         // see: https://github.com/web-infra-dev/rspress/issues/1317
         if (typeof ssgConfig === 'object' && ssgConfig.strict) {
           logger.error(
-            `Failed to load SSG bundle: ${chalk.yellow(ssrBundlePath)}.`,
+            `Failed to load SSG bundle: ${picocolors.yellow(ssrBundlePath)}.`,
           );
           throw e;
         }
@@ -108,7 +108,7 @@ export async function renderPages(
         // fallback to CSR
         logger.error(e);
         logger.warn(
-          `Failed to load SSG bundle: ${chalk.yellow(ssrBundlePath)}, fallback to CSR.`,
+          `Failed to load SSG bundle: ${picocolors.yellow(ssrBundlePath)}, fallback to CSR.`,
         );
       }
     }
@@ -149,14 +149,14 @@ export async function renderPages(
             } catch (e) {
               if (typeof ssgConfig === 'object' && ssgConfig.strict) {
                 logger.error(
-                  `Page "${chalk.yellow(routePath)}" SSG rendering failed.`,
+                  `Page "${picocolors.yellow(routePath)}" SSG rendering failed.`,
                 );
                 throw e;
               }
 
               // fallback to CSR
               logger.warn(
-                `Page "${chalk.yellow(routePath)}" SSG rendering error: ${e.message}, fallback to CSR.`,
+                `Page "${picocolors.yellow(routePath)}" SSG rendering error: ${e.message}, fallback to CSR.`,
               );
             }
           }
@@ -221,7 +221,7 @@ export async function renderPages(
     await emptyDir(join(outputPath, 'html'));
 
     const totalTime = Date.now() - startTime;
-    logger.success(`Pages rendered in ${chalk.yellow(totalTime)} ms.`);
+    logger.success(`Pages rendered in ${picocolors.yellow(totalTime)} ms.`);
   } catch (e) {
     logger.error(`Pages render error: ${e.stack}`);
     throw e;

--- a/packages/core/src/node/runtimeModule/siteData/highlightLanguages.ts
+++ b/packages/core/src/node/runtimeModule/siteData/highlightLanguages.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_HIGHLIGHT_LANGUAGES } from '@rspress/shared';
-import chalk from '@rspress/shared/chalk';
+import picocolors from 'picocolors';
 
 let supportedLanguages: Set<string>;
 
@@ -26,7 +26,7 @@ export function handleHighlightLanguages(
       } else if (useDeprecatedTypeWarning) {
         // Deprecated warning
         console.log(
-          `${chalk.yellowBright(
+          `${picocolors.yellowBright(
             'warning',
           )} Automatic import is supported. \`highlightLanguages\` is now used only as alias, and string types will be ignored. \n`,
         );

--- a/packages/core/src/node/searchIndex.ts
+++ b/packages/core/src/node/searchIndex.ts
@@ -3,8 +3,8 @@ import fs from 'node:fs/promises';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import path, { join } from 'node:path';
 import { SEARCH_INDEX_NAME, type UserConfig, isSCM } from '@rspress/shared';
-import chalk from '@rspress/shared/chalk';
 import { logger } from '@rspress/shared/logger';
+import picocolors from 'picocolors';
 import { OUTPUT_DIR, TEMP_DIR, isProduction } from './constants';
 
 export async function writeSearchIndex(config: UserConfig) {
@@ -54,13 +54,13 @@ export async function writeSearchIndex(config: UserConfig) {
       });
 
       logger.info(
-        chalk.green(
+        picocolors.green(
           `[doc-tools] Search index uploaded to ${apiUrl}, indexName: ${indexName}`,
         ),
       );
     } catch (e) {
       logger.info(
-        chalk.red(
+        picocolors.red(
           `[doc-tools] Upload search index \`${indexName}\` failed:\n ${e}`,
         ),
       );

--- a/packages/shared/modern.config.ts
+++ b/packages/shared/modern.config.ts
@@ -4,12 +4,7 @@ const config: ReturnType<typeof defineConfig> = defineConfig({
   plugins: [moduleTools()],
   buildConfig: [
     {
-      input: [
-        'src/index.ts',
-        'src/logger.ts',
-        'src/chalk.ts',
-        'src/node-utils.ts',
-      ],
+      input: ['src/index.ts', 'src/logger.ts', 'src/node-utils.ts'],
       target: 'esnext',
       format: 'esm',
       buildType: 'bundle',
@@ -17,12 +12,7 @@ const config: ReturnType<typeof defineConfig> = defineConfig({
       autoExtension: true,
     },
     {
-      input: [
-        'src/index.ts',
-        'src/logger.ts',
-        'src/chalk.ts',
-        'src/node-utils.ts',
-      ],
+      input: ['src/index.ts', 'src/logger.ts', 'src/node-utils.ts'],
       target: 'esnext',
       format: 'cjs',
       buildType: 'bundle',

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,11 +13,6 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
-    "./chalk": {
-      "types": "./dist/chalk.d.ts",
-      "import": "./dist/chalk.mjs",
-      "require": "./dist/chalk.js"
-    },
     "./logger": {
       "types": "./dist/logger.d.ts",
       "import": "./dist/logger.mjs",
@@ -46,7 +41,6 @@
   },
   "dependencies": {
     "@rsbuild/core": "1.2.3",
-    "chalk": "5.4.1",
     "gray-matter": "4.0.3",
     "lodash-es": "^4.17.21",
     "unified": "^10.1.2"

--- a/packages/shared/src/chalk.ts
+++ b/packages/shared/src/chalk.ts
@@ -1,2 +1,0 @@
-export * from 'chalk';
-export { default } from 'chalk';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -674,6 +674,9 @@ importers:
       chokidar:
         specifier: ^3.6.0
         version: 3.6.0
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
     devDependencies:
       '@microsoft/api-extractor':
         specifier: ^7.49.2
@@ -771,6 +774,9 @@ importers:
       memfs:
         specifier: ^4.17.0
         version: 4.17.0
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1515,9 +1521,6 @@ importers:
       '@rsbuild/core':
         specifier: 1.2.3
         version: 1.2.3
-      chalk:
-        specifier: 5.4.1
-        version: 5.4.1
       gray-matter:
         specifier: 4.0.3
         version: 4.0.3


### PR DESCRIPTION
## Summary

for bundle size, and maintainability

44.2 kB -> 6kb

We currently do not integrate prebundle. When integrating prebundle after migrating Rslib, we can consider picocolors.

## Related Issue

<!--- Provide link of related issues -->

https://github.com/web-infra-dev/rspress/pull/1773

https://github.com/web-infra-dev/rspress/pull/1787

https://github.com/web-infra-dev/rspress/pull/1809

https://github.com/web-infra-dev/rspress/pull/1805

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
