### PR TITLE
chore(infra/test): migrate to vitest workspace

### DIFF
--- a/e2e/fixtures/modern-js/tsconfig.json
+++ b/e2e/fixtures/modern-js/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "@/*": ["./src/*"],
       "demo": ["./src"]
     }
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "preview:website": "cd packages/document && npm run preview",
     "test": "pnpm test:unit && pnpm test:e2e",
     "test:e2e": "playwright test",
-    "test:unit": "cross-env NX_DAEMON=false NX_REJECT_UNKNOWN_LOCAL_CACHE=0 nx run-many -t test --exclude @rspress-fixture/*",
+    "test:unit": "npx vitest run",
     "update:modern": "npx taze minor --include /modern-js/ -w -r -l",
     "update:rsbuild": "npx taze minor --include /rsbuild/ -w -r -l"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "preview:website": "cd packages/document && npm run preview",
     "test": "pnpm test:unit && pnpm test:e2e",
     "test:e2e": "playwright test",
-    "test:unit": "npx vitest run",
+    "test:unit": "vitest run",
     "update:modern": "npx taze minor --include /modern-js/ -w -r -l",
     "update:rsbuild": "npx taze minor --include /rsbuild/ -w -r -l"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,8 +38,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build -w",
-    "reset": "rimraf ./**/node_modules",
-    "test": "vitest run"
+    "reset": "rimraf ./**/node_modules"
   },
   "dependencies": {
     "@rsbuild/core": "1.2.3",

--- a/packages/cli/src/config/loadConfigFile.ts
+++ b/packages/cli/src/config/loadConfigFile.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { DEFAULT_CONFIG_NAME, DEFAULT_EXTENSIONS } from '@/constants';
 import type { UserConfig } from '@rspress/core';
 import { logger } from '@rspress/shared/logger';
+import { DEFAULT_CONFIG_NAME, DEFAULT_EXTENSIONS } from '../constants';
 
 const findConfig = (basePath: string): string | undefined => {
   return DEFAULT_EXTENSIONS.map(ext => basePath + ext).find(fs.existsSync);

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -6,9 +6,6 @@
     "module": "ESNext",
     "target": "ESNext",
     "baseUrl": "./",
-    "paths": {
-      "@/*": ["./src/*"]
-    },
     "isolatedModules": true
   },
   "include": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,8 +49,7 @@
   "scripts": {
     "build": "modern build",
     "dev": "modern build -w",
-    "reset": "rimraf ./**/node_modules",
-    "test": "vitest run --passWithNoTests"
+    "reset": "rimraf ./**/node_modules"
   },
   "dependencies": {
     "@mdx-js/loader": "2.3.0",
@@ -109,8 +108,7 @@
     "remark-rehype": "^10.1.0",
     "rimraf": "^3.0.2",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5.5.3",
-    "vitest": "2.1.9"
+    "typescript": "^5.5.3"
   },
   "engines": {
     "node": ">=14.17.6"

--- a/packages/core/src/node/build.ts
+++ b/packages/core/src/node/build.ts
@@ -1,8 +1,6 @@
 import fs from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import type { Route } from '@/node/route/RouteService';
-import { routeService } from '@/node/route/init';
 import {
   type PageData,
   type SSGConfig,
@@ -25,6 +23,8 @@ import {
   TEMP_DIR,
 } from './constants';
 import { initRsbuild } from './initRsbuild';
+import type { Route } from './route/RouteService';
+import { routeService } from './route/init';
 import { writeSearchIndex } from './searchIndex';
 import { checkLanguageParity } from './utils/checkLanguageParity';
 import { renderConfigHead, renderFrontmatterHead } from './utils/renderHead';

--- a/packages/core/src/node/mdx/remarkPlugins/builtin.ts
+++ b/packages/core/src/node/mdx/remarkPlugins/builtin.ts
@@ -1,8 +1,8 @@
 import path from 'node:path';
-import { getASTNodeImport } from '@/node/utils/getASTNodeImport';
 import type { Root } from 'mdast';
 import type { MdxjsEsm } from 'mdast-util-mdxjs-esm';
 import type { Plugin } from 'unified';
+import { getASTNodeImport } from '../../utils';
 
 /**
  * A remark plugin to import all builtin components.

--- a/packages/core/src/node/mdx/remarkPlugins/checkDeadLink.ts
+++ b/packages/core/src/node/mdx/remarkPlugins/checkDeadLink.ts
@@ -1,10 +1,10 @@
 import path from 'node:path';
-import type { RouteService } from '@/node/route/RouteService';
-import { normalizePath } from '@/node/utils';
 import { cleanUrl, isProduction } from '@rspress/shared';
 import { logger } from '@rspress/shared/logger';
 import type { Plugin } from 'unified';
 import { visit } from 'unist-util-visit';
+import type { RouteService } from '../../route/RouteService';
+import { normalizePath } from '../../utils';
 
 export interface DeadLinkCheckOptions {
   root: string;

--- a/packages/core/src/node/mdx/remarkPlugins/normalizeLink.ts
+++ b/packages/core/src/node/mdx/remarkPlugins/normalizeLink.ts
@@ -1,10 +1,10 @@
 import path from 'node:path';
-import { getASTNodeImport } from '@/node/utils/getASTNodeImport';
 import { isExternalUrl, normalizeHref, parseUrl, slash } from '@rspress/shared';
 import type { Root } from 'mdast';
 import type { MdxjsEsm } from 'mdast-util-mdxjs-esm';
 import type { Plugin } from 'unified';
 import { visit } from 'unist-util-visit';
+import { getASTNodeImport } from '../../utils';
 
 interface LinkNode {
   type: string;

--- a/packages/core/src/node/runtimeModule/siteData/extractPageData.ts
+++ b/packages/core/src/node/runtimeModule/siteData/extractPageData.ts
@@ -1,9 +1,5 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { importStatementRegex } from '@/node/constants';
-import type { RouteService } from '@/node/route/RouteService';
-import { flattenMdxContent } from '@/node/utils';
-import { applyReplaceRules } from '@/node/utils/applyReplaceRules';
 import { compile } from '@rspress/mdx-rs';
 import {
   type Header,
@@ -13,6 +9,10 @@ import {
 } from '@rspress/shared';
 import { loadFrontMatter } from '@rspress/shared/node-utils';
 import { htmlToText } from 'html-to-text';
+import { importStatementRegex } from '../../constants';
+import type { RouteService } from '../../route/RouteService';
+import { flattenMdxContent } from '../../utils';
+import { applyReplaceRules } from '../../utils/applyReplaceRules';
 
 export function applyReplaceRulesToNestedObject(
   obj: Record<string, any>,

--- a/packages/core/src/node/runtimeModule/siteData/index.ts
+++ b/packages/core/src/node/runtimeModule/siteData/index.ts
@@ -1,10 +1,10 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { TEMP_DIR, isProduction } from '@/node/constants';
-import { createHash } from '@/node/utils';
 import { SEARCH_INDEX_NAME, type SiteData } from '@rspress/shared';
 import { groupBy } from 'lodash-es';
 import { type FactoryContext, RuntimeModuleID } from '..';
+import { TEMP_DIR, isProduction } from '../../constants';
+import { createHash } from '../../utils';
 import { extractPageData } from './extractPageData';
 import { handleHighlightLanguages } from './highlightLanguages';
 import { normalizeThemeConfig } from './normalizeThemeConfig';

--- a/packages/core/src/node/utils/checkLanguageParity.test.ts
+++ b/packages/core/src/node/utils/checkLanguageParity.test.ts
@@ -1,9 +1,11 @@
 import { logger } from '@rspress/shared/logger';
 import { fs, vol } from 'memfs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { checkLanguageParity } from '../src/node/utils/checkLanguageParity';
+import { checkLanguageParity } from './checkLanguageParity';
 
-vi.mock('node:fs/promises');
+vi.mock('node:fs/promises', () => {
+  return { default: fs.promises };
+});
 vi.mock('@rspress/shared/logger', () => ({
   logger: {
     info: vi.fn(),

--- a/packages/core/src/node/utils/checkLanguageParity.ts
+++ b/packages/core/src/node/utils/checkLanguageParity.ts
@@ -72,7 +72,7 @@ async function collectModuleFiles(
       if (!fileLangMap[baseName]) fileLangMap[baseName] = new Set();
       fileLangMap[baseName].add(lang);
     }
-  } catch {
+  } catch (e) {
     throw new Error(
       `Failed to access directory: ${normalizePath(langModuleDir)}`,
     );

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -14,12 +14,7 @@
     "composite": true,
     "lib": ["ESNext", "DOM"],
     "esModuleInterop": true,
-    "skipLibCheck": true,
-    "paths": {
-      "@/*": ["./*"],
-      "@theme": ["./theme-default"],
-      "@/theme-default/*": ["./theme-default/*"]
-    }
+    "skipLibCheck": true
   },
   "include": ["src"],
   "references": [

--- a/packages/create-rspress/tsconfig.json
+++ b/packages/create-rspress/tsconfig.json
@@ -6,9 +6,6 @@
     "module": "ESNext",
     "target": "ESNext",
     "baseUrl": "./",
-    "paths": {
-      "@/*": ["./src/*"]
-    },
     "isolatedModules": true
   },
   "include": ["src"],

--- a/packages/document/tsconfig.json
+++ b/packages/document/tsconfig.json
@@ -6,8 +6,6 @@
     "paths": {
       "i18n": ["./i18n.json"],
       "@theme": ["./theme"],
-      "@/assets/*": ["./docs/public/*"],
-      "@/components/*": ["./theme/components/*"],
       "@zh/*": ["./docs/zh/*"],
       "@en/*": ["./docs/en/*"]
     },

--- a/packages/modern-plugin-rspress/package.json
+++ b/packages/modern-plugin-rspress/package.json
@@ -40,8 +40,7 @@
     "@types/react": "^18.3.18",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "typescript": "^5.5.3",
-    "vitest": "2.1.9"
+    "typescript": "^5.5.3"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-api-docgen/package.json
+++ b/packages/plugin-api-docgen/package.json
@@ -19,8 +19,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build -w",
-    "reset": "rimraf ./**/node_modules",
-    "test": "vitest run --passWithNoTests"
+    "reset": "rimraf ./**/node_modules"
   },
   "dependencies": {
     "@rspress/shared": "workspace:*",

--- a/packages/plugin-api-docgen/tsconfig.json
+++ b/packages/plugin-api-docgen/tsconfig.json
@@ -12,10 +12,7 @@
     "rootDir": "src",
     "lib": ["ESNext", "DOM"],
     "esModuleInterop": true,
-    "skipLibCheck": true,
-    "paths": {
-      "@/*": ["./*"]
-    }
+    "skipLibCheck": true
   },
   "references": [
     {

--- a/packages/plugin-auto-nav-sidebar/package.json
+++ b/packages/plugin-auto-nav-sidebar/package.json
@@ -26,8 +26,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build -w",
-    "reset": "rimraf ./**/node_modules",
-    "test": "vitest run --passWithNoTests"
+    "reset": "rimraf ./**/node_modules"
   },
   "dependencies": {
     "@rspress/shared": "workspace:*"
@@ -40,8 +39,7 @@
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "react": "^18.3.1",
-    "typescript": "^5.5.3",
-    "vitest": "2.1.9"
+    "typescript": "^5.5.3"
   },
   "engines": {
     "node": ">=14.17.6"

--- a/packages/plugin-auto-nav-sidebar/tsconfig.json
+++ b/packages/plugin-auto-nav-sidebar/tsconfig.json
@@ -14,10 +14,7 @@
     "rootDir": ".",
     "lib": ["ESNext", "DOM"],
     "esModuleInterop": true,
-    "skipLibCheck": true,
-    "paths": {
-      "@/*": ["./*"]
-    }
+    "skipLibCheck": true
   },
   "references": [
     {

--- a/packages/plugin-client-redirects/package.json
+++ b/packages/plugin-client-redirects/package.json
@@ -26,8 +26,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build -w",
-    "reset": "rimraf ./**/node_modules",
-    "test": "vitest run --passWithNoTests"
+    "reset": "rimraf ./**/node_modules"
   },
   "dependencies": {
     "@rspress/shared": "workspace:*"
@@ -40,8 +39,7 @@
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "react": "^18.3.1",
-    "typescript": "^5.5.3",
-    "vitest": "2.1.9"
+    "typescript": "^5.5.3"
   },
   "peerDependencies": {
     "@rspress/runtime": "workspace:^1.41.1"

--- a/packages/plugin-client-redirects/tsconfig.json
+++ b/packages/plugin-client-redirects/tsconfig.json
@@ -11,10 +11,7 @@
     "rootDir": ".",
     "lib": ["ESNext", "DOM"],
     "esModuleInterop": true,
-    "skipLibCheck": true,
-    "paths": {
-      "@/*": ["./*"]
-    }
+    "skipLibCheck": true
   },
   "references": [
     {

--- a/packages/plugin-container-syntax/package.json
+++ b/packages/plugin-container-syntax/package.json
@@ -26,8 +26,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build -w",
-    "reset": "rimraf ./**/node_modules",
-    "test": "vitest run --passWithNoTests"
+    "reset": "rimraf ./**/node_modules"
   },
   "dependencies": {
     "@rspress/shared": "workspace:*"

--- a/packages/plugin-container-syntax/tsconfig.json
+++ b/packages/plugin-container-syntax/tsconfig.json
@@ -11,10 +11,7 @@
     "rootDir": "src",
     "lib": ["ESNext", "DOM"],
     "esModuleInterop": true,
-    "skipLibCheck": true,
-    "paths": {
-      "@/*": ["./*"]
-    }
+    "skipLibCheck": true
   },
   "references": [
     {

--- a/packages/plugin-last-updated/package.json
+++ b/packages/plugin-last-updated/package.json
@@ -26,8 +26,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build -w",
-    "reset": "rimraf ./**/node_modules",
-    "test": "vitest run --passWithNoTests"
+    "reset": "rimraf ./**/node_modules"
   },
   "dependencies": {
     "@rspress/shared": "workspace:*"
@@ -41,8 +40,7 @@
     "@types/react-dom": "^18.3.5",
     "execa": "8.0.1",
     "react": "^18.3.1",
-    "typescript": "^5.5.3",
-    "vitest": "2.1.9"
+    "typescript": "^5.5.3"
   },
   "engines": {
     "node": ">=14.17.6"

--- a/packages/plugin-last-updated/tsconfig.json
+++ b/packages/plugin-last-updated/tsconfig.json
@@ -12,10 +12,7 @@
     "rootDir": "src",
     "lib": ["ESNext", "DOM"],
     "esModuleInterop": true,
-    "skipLibCheck": true,
-    "paths": {
-      "@/*": ["./*"]
-    }
+    "skipLibCheck": true
   },
   "references": [
     {

--- a/packages/plugin-medium-zoom/package.json
+++ b/packages/plugin-medium-zoom/package.json
@@ -26,8 +26,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build -w",
-    "reset": "rimraf ./**/node_modules",
-    "test": "vitest run --passWithNoTests"
+    "reset": "rimraf ./**/node_modules"
   },
   "dependencies": {
     "medium-zoom": "1.1.0"
@@ -41,8 +40,7 @@
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "react": "^18.3.1",
-    "typescript": "^5.5.3",
-    "vitest": "2.1.9"
+    "typescript": "^5.5.3"
   },
   "peerDependencies": {
     "@rspress/runtime": "workspace:^1.41.1"

--- a/packages/plugin-medium-zoom/tsconfig.json
+++ b/packages/plugin-medium-zoom/tsconfig.json
@@ -13,10 +13,7 @@
     "rootDir": "src",
     "lib": ["ESNext", "DOM"],
     "esModuleInterop": true,
-    "skipLibCheck": true,
-    "paths": {
-      "@/*": ["./*"]
-    }
+    "skipLibCheck": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/plugin-playground/package.json
+++ b/packages/plugin-playground/package.json
@@ -31,8 +31,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build -w",
-    "reset": "rimraf ./**/node_modules",
-    "test": "vitest run --passWithNoTests"
+    "reset": "rimraf ./**/node_modules"
   },
   "dependencies": {
     "@mdx-js/mdx": "2.3.0",

--- a/packages/plugin-playground/src/cli/index.ts
+++ b/packages/plugin-playground/src/cli/index.ts
@@ -1,7 +1,5 @@
 import fs from 'node:fs';
 import path, { join } from 'node:path';
-import { DEFAULT_BABEL_URL, DEFAULT_MONACO_URL } from '@/web/constant';
-import { normalizeUrl } from '@/web/utils';
 import type {
   EditorProps as MonacoEditorProps,
   loader,
@@ -9,6 +7,8 @@ import type {
 import type { RouteMeta, RspressPlugin } from '@rspress/shared';
 import type { Code } from 'mdast';
 import { RspackVirtualModulePlugin } from 'rspack-plugin-virtual-module';
+import { DEFAULT_BABEL_URL, DEFAULT_MONACO_URL } from '../web/constant';
+import { normalizeUrl } from '../web/utils';
 import { staticPath } from './constant';
 import { remarkPlugin } from './remarkPlugin';
 import { getNodeAttribute, parseImports } from './utils';

--- a/packages/plugin-playground/tsconfig.json
+++ b/packages/plugin-playground/tsconfig.json
@@ -13,10 +13,7 @@
     "rootDir": "src",
     "lib": ["ESNext", "DOM"],
     "esModuleInterop": true,
-    "skipLibCheck": true,
-    "paths": {
-      "@/*": ["./*"]
-    }
+    "skipLibCheck": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/plugin-preview/package.json
+++ b/packages/plugin-preview/package.json
@@ -18,8 +18,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build -w",
-    "reset": "rimraf ./**/node_modules",
-    "test": "vitest run --passWithNoTests"
+    "reset": "rimraf ./**/node_modules"
   },
   "dependencies": {
     "@rsbuild/core": "1.2.3",

--- a/packages/plugin-preview/tsconfig.json
+++ b/packages/plugin-preview/tsconfig.json
@@ -13,10 +13,7 @@
     "rootDir": ".",
     "lib": ["ESNext", "DOM"],
     "esModuleInterop": true,
-    "skipLibCheck": true,
-    "paths": {
-      "@/*": ["./*"]
-    }
+    "skipLibCheck": true
   },
   "include": [
     "src",

--- a/packages/plugin-rss/package.json
+++ b/packages/plugin-rss/package.json
@@ -27,8 +27,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build -w",
-    "reset": "rimraf ./**/node_modules",
-    "test": "vitest run --passWithNoTests"
+    "reset": "rimraf ./**/node_modules"
   },
   "dependencies": {
     "@rspress/shared": "workspace:*",
@@ -40,8 +39,7 @@
     "@types/node": "^18.11.17",
     "@types/react": "^18.3.18",
     "react": "^18.3.1",
-    "typescript": "^5.5.3",
-    "vitest": "2.1.9"
+    "typescript": "^5.5.3"
   },
   "peerDependencies": {
     "react": ">=17.0.0",

--- a/packages/plugin-shiki/package.json
+++ b/packages/plugin-shiki/package.json
@@ -26,8 +26,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build -w",
-    "reset": "rimraf ./**/node_modules",
-    "test": "vitest run --passWithNoTests"
+    "reset": "rimraf ./**/node_modules"
   },
   "dependencies": {
     "@rspress/shared": "workspace:*",
@@ -45,8 +44,7 @@
     "@types/react-dom": "^18.3.5",
     "react": "^18.3.1",
     "typescript": "^5.5.3",
-    "unified": "^10.1.2",
-    "vitest": "2.1.9"
+    "unified": "^10.1.2"
   },
   "engines": {
     "node": ">=14.17.6"

--- a/packages/plugin-shiki/tsconfig.json
+++ b/packages/plugin-shiki/tsconfig.json
@@ -10,10 +10,7 @@
     "rootDir": ".",
     "lib": ["ESNext", "DOM"],
     "esModuleInterop": true,
-    "skipLibCheck": true,
-    "paths": {
-      "@/*": ["./*"]
-    }
+    "skipLibCheck": true
   },
   "include": ["src", "vitest.config.ts", "index.d.ts", "rslib.config.ts"],
   "exclude": ["node_modules", "dist"]

--- a/packages/plugin-typedoc/package.json
+++ b/packages/plugin-typedoc/package.json
@@ -25,8 +25,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build -w",
-    "reset": "rimraf ./**/node_modules",
-    "test": "vitest run --passWithNoTests"
+    "reset": "rimraf ./**/node_modules"
   },
   "dependencies": {
     "@rspress/shared": "workspace:*",
@@ -41,8 +40,7 @@
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "react": "^18.3.1",
-    "typescript": "^5.5.3",
-    "vitest": "2.1.9"
+    "typescript": "^5.5.3"
   },
   "peerDependencies": {
     "rspress": "workspace:^1.41.1"

--- a/packages/plugin-typedoc/tsconfig.json
+++ b/packages/plugin-typedoc/tsconfig.json
@@ -10,10 +10,7 @@
     "rootDir": ".",
     "lib": ["ESNext", "DOM"],
     "esModuleInterop": true,
-    "skipLibCheck": true,
-    "paths": {
-      "@/*": ["./*"]
-    }
+    "skipLibCheck": true
   },
   "include": ["src", "vitest.config.ts", "index.d.ts", "modern.config.ts"],
   "exclude": ["node_modules", "dist"]

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -38,8 +38,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build -w",
-    "reset": "rimraf ./**/node_modules",
-    "test": "echo nothing"
+    "reset": "rimraf ./**/node_modules"
   },
   "dependencies": {
     "@rspress/shared": "workspace:*",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -33,8 +33,7 @@
   "scripts": {
     "build": "rslib build",
     "build:watch": "rslib build -w",
-    "reset": "rimraf ./**/node_modules",
-    "test": "vitest run"
+    "reset": "rimraf ./**/node_modules"
   },
   "dependencies": {
     "@rsbuild/core": "1.2.3",

--- a/packages/shared/src/node-utils/merge.ts
+++ b/packages/shared/src/node-utils/merge.ts
@@ -1,4 +1,4 @@
-import type { UserConfig } from '@/types';
+import type { UserConfig } from '../types/index';
 
 const castArray = <T>(value: T | T[]): T[] =>
   Array.isArray(value) ? value : [value];

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -10,9 +10,6 @@
     "target": "ESNext",
     "rootDir": "src",
     "baseUrl": "./",
-    "paths": {
-      "@/*": ["./src/*"]
-    },
     "isolatedModules": true
   },
   "include": ["src"],

--- a/packages/theme-default/package.json
+++ b/packages/theme-default/package.json
@@ -41,8 +41,7 @@
   "scripts": {
     "build": "modern build",
     "dev": "modern build -w",
-    "reset": "rimraf ./**/node_modules",
-    "test": "echo nothing"
+    "reset": "rimraf ./**/node_modules"
   },
   "dependencies": {
     "@mdx-js/react": "2.3.0",
@@ -74,8 +73,7 @@
     "@types/react-syntax-highlighter": "^15.5.13",
     "gray-matter": "4.0.3",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5.5.3",
-    "vitest": "2.1.9"
+    "typescript": "^5.5.3"
   },
   "engines": {
     "node": ">=14.17.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -868,9 +868,6 @@ importers:
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
-      vitest:
-        specifier: 2.1.9
-        version: 2.1.9(@types/node@18.11.17)(sass-embedded@1.83.4)(terser@5.31.6)
 
   packages/create-rspress:
     dependencies:
@@ -963,9 +960,6 @@ importers:
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
-      vitest:
-        specifier: 2.1.9
-        version: 2.1.9(@types/node@18.11.17)(sass-embedded@1.83.4)(terser@5.31.6)
 
   packages/plugin-api-docgen:
     dependencies:
@@ -1058,9 +1052,6 @@ importers:
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
-      vitest:
-        specifier: 2.1.9
-        version: 2.1.9(@types/node@18.11.17)(sass-embedded@1.83.4)(terser@5.31.6)
 
   packages/plugin-client-redirects:
     dependencies:
@@ -1095,9 +1086,6 @@ importers:
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
-      vitest:
-        specifier: 2.1.9
-        version: 2.1.9(@types/node@18.11.17)(sass-embedded@1.83.4)(terser@5.31.6)
 
   packages/plugin-container-syntax:
     dependencies:
@@ -1169,9 +1157,6 @@ importers:
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
-      vitest:
-        specifier: 2.1.9
-        version: 2.1.9(@types/node@18.11.17)(sass-embedded@1.83.4)(terser@5.31.6)
 
   packages/plugin-medium-zoom:
     dependencies:
@@ -1209,9 +1194,6 @@ importers:
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
-      vitest:
-        specifier: 2.1.9
-        version: 2.1.9(@types/node@18.11.17)(sass-embedded@1.83.4)(terser@5.31.6)
 
   packages/plugin-playground:
     dependencies:
@@ -1389,9 +1371,6 @@ importers:
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
-      vitest:
-        specifier: 2.1.9
-        version: 2.1.9(@types/node@18.11.17)(sass-embedded@1.83.4)(terser@5.31.6)
 
   packages/plugin-shiki:
     dependencies:
@@ -1438,9 +1417,6 @@ importers:
       unified:
         specifier: ^10.1.2
         version: 10.1.2
-      vitest:
-        specifier: 2.1.9
-        version: 2.1.9(@types/node@18.11.17)(sass-embedded@1.83.4)(terser@5.31.6)
 
   packages/plugin-typedoc:
     dependencies:
@@ -1481,9 +1457,6 @@ importers:
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
-      vitest:
-        specifier: 2.1.9
-        version: 2.1.9(@types/node@18.11.17)(sass-embedded@1.83.4)(terser@5.31.6)
 
   packages/runtime:
     dependencies:
@@ -1655,9 +1628,6 @@ importers:
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
-      vitest:
-        specifier: 2.1.9
-        version: 2.1.9(@types/node@22.10.2)(sass-embedded@1.83.4)(terser@5.31.6)
 
 packages:
 
@@ -12301,24 +12271,6 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@2.1.9(@types/node@22.10.2)(sass-embedded@1.83.4)(terser@5.31.6):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.0
-      es-module-lexer: 1.5.4
-      pathe: 1.1.2
-      vite: 5.4.0(@types/node@22.10.2)(sass-embedded@1.83.4)(terser@5.31.6)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
   vite@5.4.0(@types/node@18.11.17)(sass-embedded@1.83.4)(terser@5.31.6):
     dependencies:
       esbuild: 0.21.5
@@ -12326,17 +12278,6 @@ snapshots:
       rollup: 4.20.0
     optionalDependencies:
       '@types/node': 18.11.17
-      fsevents: 2.3.3
-      sass-embedded: 1.83.4
-      terser: 5.31.6
-
-  vite@5.4.0(@types/node@22.10.2)(sass-embedded@1.83.4)(terser@5.31.6):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.1
-      rollup: 4.20.0
-    optionalDependencies:
-      '@types/node': 22.10.2
       fsevents: 2.3.3
       sass-embedded: 1.83.4
       terser: 5.31.6
@@ -12365,41 +12306,6 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 18.11.17
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vitest@2.1.9(@types/node@22.10.2)(sass-embedded@1.83.4)(terser@5.31.6):
-    dependencies:
-      '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.0(@types/node@18.11.17)(sass-embedded@1.83.4)(terser@5.31.6))
-      '@vitest/pretty-format': 2.1.9
-      '@vitest/runner': 2.1.9
-      '@vitest/snapshot': 2.1.9
-      '@vitest/spy': 2.1.9
-      '@vitest/utils': 2.1.9
-      chai: 5.1.2
-      debug: 4.4.0
-      expect-type: 1.1.0
-      magic-string: 0.30.17
-      pathe: 1.1.2
-      std-env: 3.8.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.1
-      tinypool: 1.0.1
-      tinyrainbow: 1.2.0
-      vite: 5.4.0(@types/node@22.10.2)(sass-embedded@1.83.4)(terser@5.31.6)
-      vite-node: 2.1.9(@types/node@22.10.2)(sass-embedded@1.83.4)(terser@5.31.6)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 22.10.2
     transitivePeerDependencies:
       - less
       - lightningcss

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "paths": {}
   },
   "include": [
-    "vitest.config.ts",
+    "vitest.workspace.ts",
     "playwright.config.ts",
     "./scripts/update-modern.ts"
   ]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,0 @@
-import { defineConfig } from 'vitest/config';
-
-export default defineConfig({
-  test: {
-    root: __dirname,
-    environment: 'node',
-    exclude: ['./e2e/**/*', '**/node_modules/**/*'],
-  },
-});

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,23 @@
+import { Console } from 'node:console';
+import { defineWorkspace } from 'vitest/config';
+
+// Disable color in test
+process.env.NO_COLOR = '1';
+process.env.FORCE_COLOR = '0';
+
+// mock Console
+global.console.Console = Console;
+
+export default defineWorkspace([
+  {
+    test: {
+      name: 'node',
+      globals: true,
+      environment: 'node',
+      testTimeout: 30000,
+      // restoreMocks: true,
+      include: ['packages/**/*.test.ts'],
+      exclude: ['**/node_modules/**'],
+    },
+  },
+]);


### PR DESCRIPTION
## Summary

1. migrate `pnpm --filter './packages/*' run test` to `npx vitest` once

the same as Rsbuild repo

as simple as possible and 8x faster `8s -> 1s`

before

<img width="300" alt="image" src="https://github.com/user-attachments/assets/543baceb-0499-401d-a926-33b1a0d33cfd" />

after

<img width="300" alt="image" src="https://github.com/user-attachments/assets/973dc299-410d-4739-943f-8a69687da078" />



2. remove all the tsconfig `@/` alias

It serves no purpose other than adding unnecessary mental burden

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
