### PR TITLE
fix(runtime): determine virtual routes by config file

### DIFF
--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -258,7 +258,7 @@ async function createInternalBuildConfig(
     environments: {
       web: {
         resolve: {
-          alias: reactCSRAlias,
+          alias: { ...reactCSRAlias, __VIRTUAL_ROUTES__: 'virtual-routes' },
         },
         source: {
           entry: {
@@ -279,7 +279,10 @@ async function createInternalBuildConfig(
         ? {
             node: {
               resolve: {
-                alias: reactSSRAlias,
+                alias: {
+                  ...reactSSRAlias,
+                  __VIRTUAL_ROUTES__: 'virtual-routes-ssr',
+                },
               },
               source: {
                 entry: {

--- a/packages/runtime/src/Content.tsx
+++ b/packages/runtime/src/Content.tsx
@@ -1,3 +1,5 @@
+// @ts-expect-error __VIRTUAL_ROUTES__ will be determined at build time
+import { routes } from '__VIRTUAL_ROUTES__';
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-require-imports */
 import { type ReactElement, type ReactNode, Suspense, memo } from 'react';
@@ -5,10 +7,6 @@ import { matchRoutes, useLocation } from 'react-router-dom';
 import siteData from 'virtual-site-data';
 import { useViewTransition } from './hooks';
 import { normalizeRoutePath } from './utils';
-
-const { routes } = process.env.__SSR__
-  ? (require('virtual-routes-ssr') as typeof import('virtual-routes-ssr'))
-  : (require('virtual-routes') as typeof import('virtual-routes'));
 
 function TransitionContentImpl(props: { el: ReactElement }) {
   let element = props.el;
@@ -26,7 +24,10 @@ const TransitionContent = memo(
 
 export const Content = ({ fallback = <></> }: { fallback?: ReactNode }) => {
   const { pathname } = useLocation();
-  const matched = matchRoutes(routes, normalizeRoutePath(pathname));
+  const matched = matchRoutes(
+    routes as typeof import('virtual-routes')['routes'],
+    normalizeRoutePath(pathname),
+  );
   if (!matched) {
     return <div></div>;
   }


### PR DESCRIPTION
## Summary

Previously, `virtual-routes` and `virtual-routes-ssr` will be bundled in either SSR and non SSR, which will make the routes be eager imported by SSR, although routes are dynamic imported in non SSR.

```js
var __webpack_modules__ = {
    "virtual-routes": function(module) {
        module.exports = require("virtual-routes");
    },
    "virtual-routes-ssr": function(module) {
        module.exports = require("virtual-routes-ssr");
    }
};
```

In this PR, determine the correct module ID as we already know it when initiating the config, which could also remove `require` from ESM code.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
