### PR TITLE
fix(theme): text in button should center

### DIFF
--- a/packages/theme-default/src/components/Button/index.module.scss
+++ b/packages/theme-default/src/components/Button/index.module.scss
@@ -1,10 +1,11 @@
 .button {
-  display: inline-block;
-  text-align: center;
+  display: inline-flex;
+  box-sizing: border-box;
+  align-items: center;
+  justify-content: center;
   font-weight: bold;
   white-space: nowrap;
   height: 48px;
-  line-height: 48px;
 }
 
 .button:active {


### PR DESCRIPTION
## Summary

Text should display in center of button

- before
![image](https://github.com/user-attachments/assets/f4240cea-1468-4a79-b1c4-cbf1415cf2a1)

- after
![image](https://github.com/user-attachments/assets/0bf24d4f-d2e6-41ff-878f-c22d9e0dfeb2)


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
