### PR TITLE
fix(core): supersede require with import statement in ESM output

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -23,14 +23,7 @@ export default defineConfig({
         distPath: {
           root: './dist',
         },
-        externals: [
-          {
-            'react-syntax-highlighter/dist/cjs/languages/prism/supported-languages':
-              'commonjs react-syntax-highlighter/dist/cjs/languages/prism/supported-languages',
-          },
-          'jsdom',
-          'tailwindcss',
-        ],
+        externals: ['jsdom', 'tailwindcss'],
       },
     },
     {
@@ -47,9 +40,6 @@ export default defineConfig({
       output: {
         distPath: {
           root: './dist',
-        },
-        externals: {
-          '@rspress/mdx-rs': 'commonjs @rspress/mdx-rs',
         },
       },
       source: {

--- a/packages/core/src/node/mdx/loader.ts
+++ b/packages/core/src/node/mdx/loader.ts
@@ -172,8 +172,7 @@ export default async function mdxLoader(
         frontmatter,
       } as PageMeta;
     } else {
-      const { compile } = require('@rspress/mdx-rs');
-
+      const { compile } = await import('@rspress/mdx-rs');
       const { toc, links, title, code } = await compile({
         value: preprocessedContent,
         filepath,

--- a/packages/core/src/node/runtimeModule/siteData/highlightLanguages.ts
+++ b/packages/core/src/node/runtimeModule/siteData/highlightLanguages.ts
@@ -1,12 +1,14 @@
+import { createRequire } from 'node:module';
 import { DEFAULT_HIGHLIGHT_LANGUAGES } from '@rspress/shared';
 import picocolors from 'picocolors';
 
+const require = createRequire(import.meta.url);
 let supportedLanguages: Set<string>;
 
 export function handleHighlightLanguages(
   highlightLanguages: Set<string>,
   defaultLanguages: (string | [string, string])[],
-): Record<string, string[]> {
+) {
   // Automatically import prism languages
   const aliases: Record<string, string[]> = {};
   if (highlightLanguages.size) {

--- a/packages/core/src/node/runtimeModule/siteData/highlightLanguages.ts
+++ b/packages/core/src/node/runtimeModule/siteData/highlightLanguages.ts
@@ -8,7 +8,7 @@ let supportedLanguages: Set<string>;
 export function handleHighlightLanguages(
   highlightLanguages: Set<string>,
   defaultLanguages: (string | [string, string])[],
-) {
+): Record<string, string[]> {
   // Automatically import prism languages
   const aliases: Record<string, string[]> = {};
   if (highlightLanguages.size) {


### PR DESCRIPTION
## Summary

Remove possible `require` statement reserved in ESM output, and clean Rslib config by the way.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
