### PR TITLE
refactor(theme): `Sidebar` isActive algorithm should be same with `Route` match

### DIFF
--- a/packages/core/src/runtime/App.tsx
+++ b/packages/core/src/runtime/App.tsx
@@ -41,7 +41,10 @@ export async function initPageData(routePath: string): Promise<PageData> {
         p
           .replace(/\/$/, '')
           .toLowerCase();
-      return isEqualPath(normalize(page.routePath), normalize(routePath));
+      return isEqualPath(
+        normalize(page.routePath),
+        normalize(matchedRoute.path),
+      );
     });
 
     // FIXME: when sidebar item is configured as link string, the sidebar text won't updated when page title changed

--- a/packages/core/src/runtime/clientEntry.tsx
+++ b/packages/core/src/runtime/clientEntry.tsx
@@ -1,9 +1,4 @@
-import {
-  BrowserRouter,
-  DataContext,
-  ThemeContext,
-  normalizeRoutePath,
-} from '@rspress/runtime';
+import { BrowserRouter, DataContext, ThemeContext } from '@rspress/runtime';
 import { isProduction } from '@rspress/shared';
 import { useMemo, useState } from 'react';
 import siteData from 'virtual-site-data';
@@ -18,9 +13,8 @@ export async function renderInBrowser() {
   const container = document.getElementById('root')!;
 
   const enhancedApp = async () => {
-    const initialPageData = await initPageData(
-      normalizeRoutePath(window.location.pathname),
-    );
+    const initialPageData = await initPageData(window.location.pathname);
+    console.log(initialPageData, 22222222222);
     return function RootApp() {
       const [data, setData] = useState(initialPageData);
       const [theme, setTheme] = useThemeState();

--- a/packages/core/src/runtime/clientEntry.tsx
+++ b/packages/core/src/runtime/clientEntry.tsx
@@ -14,7 +14,7 @@ export async function renderInBrowser() {
 
   const enhancedApp = async () => {
     const initialPageData = await initPageData(window.location.pathname);
-    console.log(initialPageData, 22222222222);
+
     return function RootApp() {
       const [data, setData] = useState(initialPageData);
       const [theme, setTheme] = useThemeState();

--- a/packages/plugin-preview/static/global-components/common/mobile-operation.tsx
+++ b/packages/plugin-preview/static/global-components/common/mobile-operation.tsx
@@ -57,11 +57,6 @@ export default (props: {
 
   const onClickOutside = useCallback(
     (e: MouseEvent) => {
-      console.log(
-        !contains(triggerRef.current, e.target),
-        triggerRef.current,
-        e.target,
-      );
       if (!contains(triggerRef.current, e.target)) {
         setShowQRCode(false);
       }

--- a/packages/runtime/rslib.config.ts
+++ b/packages/runtime/rslib.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
     {
       bundle: false,
       source: {
-        entry: { index: 'src/**' },
+        entry: { index: ['src/**', '!src/**.test.ts'] },
       },
       dts: true,
       format: 'esm',

--- a/packages/runtime/src/Content.tsx
+++ b/packages/runtime/src/Content.tsx
@@ -1,17 +1,12 @@
-// @ts-expect-error __VIRTUAL_ROUTES__ will be determined at build time
-import { routes } from '__VIRTUAL_ROUTES__';
-/* eslint-disable @typescript-eslint/no-var-requires */
-/* eslint-disable @typescript-eslint/no-require-imports */
 import { type ReactElement, type ReactNode, Suspense, memo } from 'react';
-import { matchRoutes, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import siteData from 'virtual-site-data';
 import { useViewTransition } from './hooks';
-import { normalizeRoutePath } from './utils';
+import { pathnameToRouteService } from './route';
 
 function TransitionContentImpl(props: { el: ReactElement }) {
   let element = props.el;
   if (siteData?.themeConfig?.enableContentAnimation) {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
     element = useViewTransition(props.el);
   }
   return element;
@@ -24,14 +19,11 @@ const TransitionContent = memo(
 
 export const Content = ({ fallback = <></> }: { fallback?: ReactNode }) => {
   const { pathname } = useLocation();
-  const matched = matchRoutes(
-    routes as typeof import('virtual-routes')['routes'],
-    normalizeRoutePath(pathname),
-  );
+  const matched = pathnameToRouteService(pathname);
   if (!matched) {
     return <div></div>;
   }
-  const routesElement = matched[0].route.element;
+  const routesElement = matched.element;
 
   // React 17 Suspense SSR is not supported
   if (!process.env.__REACT_GTE_18__ && process.env.__SSR__) {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,5 +1,14 @@
-export * from './hooks';
-export * from './Content';
+export {
+  DataContext,
+  ThemeContext,
+  useDark,
+  useI18n,
+  useLang,
+  usePageData,
+  useVersion,
+  useViewTransition,
+} from './hooks';
+export { Content } from './Content';
 export {
   normalizeHrefInRuntime,
   normalizeImagePath,
@@ -9,7 +18,6 @@ export {
   removeTrailingSlash,
   normalizeSlash,
   isProduction,
-  normalizeRoutePath,
   isEqualPath,
 } from './utils';
 export {
@@ -19,5 +27,6 @@ export {
   BrowserRouter,
   useSearchParams,
 } from 'react-router-dom';
+export { pathnameToRouteService } from './route';
 export { Helmet } from 'react-helmet-async';
 export { NoSSR } from './NoSSR';

--- a/packages/runtime/src/route.test.ts
+++ b/packages/runtime/src/route.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import { pathnameToRouteService } from './route';
+
+vi.mock('__VIRTUAL_ROUTES__', () => {
+  const element = vi.fn();
+  const routes = [
+    {
+      path: '/api/config',
+      element,
+      filePath: 'api/config.mdx',
+      preload: async () => {},
+      lang: '',
+      version: '',
+    },
+    {
+      path: '/api/config/',
+      element,
+      filePath: 'api/config/index.mdx',
+      preload: async () => {},
+      lang: '',
+      version: '',
+    },
+    {
+      path: '/',
+      element,
+      filePath: 'index.mdx',
+      preload: async () => {},
+      lang: '',
+      version: '',
+    },
+  ];
+  return { routes };
+});
+
+describe('pathnameToRouteService', () => {
+  it('0. /api/config', () => {
+    const pathname = '/api/config';
+    // currently we do not support both /api/config.mdx and /api/config/index.mdx
+    expect(pathnameToRouteService(pathname)?.path).toMatchInlineSnapshot(
+      `"/api/config/"`,
+    );
+  });
+
+  it('1. /api/config.html', () => {
+    const pathname = '/api/config.html';
+    expect(pathnameToRouteService(pathname)?.path).toMatchInlineSnapshot(
+      `"/api/config/"`,
+    );
+  });
+
+  it('2. /api/config/', () => {
+    const pathname = '/api/config/';
+    expect(pathnameToRouteService(pathname)?.path).toMatchInlineSnapshot(
+      `"/api/config/"`,
+    );
+  });
+
+  it('3. /api/config/index', () => {
+    const pathname = '/api/config/index';
+    expect(pathnameToRouteService(pathname)?.path).toMatchInlineSnapshot(
+      `"/api/config/"`,
+    );
+  });
+  it('4. /api/config/index.html', () => {
+    const pathname = '/api/config/index.html';
+    expect(pathnameToRouteService(pathname)?.path).toMatchInlineSnapshot(
+      `"/api/config/"`,
+    );
+  });
+});

--- a/packages/runtime/src/route.ts
+++ b/packages/runtime/src/route.ts
@@ -9,15 +9,24 @@ function normalizeRoutePath(routePath: string) {
     .replace(/\/index$/, '/');
 }
 
+const cache = new Map<string, Route>();
 /**
  * this is a bridge of two core features Sidebar and RouteService
  * @param pathname useLocation().pathname
  * @returns
  */
 export function pathnameToRouteService(pathname: string): Route | undefined {
+  const cacheItem = cache.get(pathname);
+  if (cacheItem) {
+    return cacheItem;
+  }
   const matched = matchRoutes(
     routes as typeof import('virtual-routes')['routes'],
     normalizeRoutePath(pathname),
   );
-  return matched?.[0]?.route;
+  const route: Route | undefined = matched?.[0]?.route;
+  if (route) {
+    cache.set(pathname, route);
+  }
+  return route;
 }

--- a/packages/runtime/src/route.ts
+++ b/packages/runtime/src/route.ts
@@ -1,0 +1,23 @@
+import type { Route } from '@rspress/shared';
+// @ts-expect-error __VIRTUAL_ROUTES__ will be determined at build time
+import { routes } from '__VIRTUAL_ROUTES__';
+import { matchRoutes } from 'react-router-dom';
+
+function normalizeRoutePath(routePath: string) {
+  return decodeURIComponent(routePath)
+    .replace(/\.html$/, '')
+    .replace(/\/index$/, '/');
+}
+
+/**
+ * this is a bridge of two core features Sidebar and RouteService
+ * @param pathname useLocation().pathname
+ * @returns
+ */
+export function pathnameToRouteService(pathname: string): Route | undefined {
+  const matched = matchRoutes(
+    routes as typeof import('virtual-routes')['routes'],
+    normalizeRoutePath(pathname),
+  );
+  return matched?.[0]?.route;
+}

--- a/packages/runtime/src/utils.ts
+++ b/packages/runtime/src/utils.ts
@@ -12,12 +12,6 @@ import {
 } from '@rspress/shared';
 import siteData from 'virtual-site-data';
 
-export function normalizeRoutePath(routePath: string) {
-  return decodeURIComponent(routePath)
-    .replace(/\.html$/, '')
-    .replace(/\/index$/, '/');
-}
-
 export function withBase(url = '/'): string {
   return rawWithBase(url, siteData.base);
 }

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -18,5 +18,6 @@
       "path": "../shared"
     }
   ],
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/packages/theme-default/src/components/Link/index.tsx
+++ b/packages/theme-default/src/components/Link/index.tsx
@@ -1,8 +1,7 @@
 import {
   isEqualPath,
-  matchRoutes,
   normalizeHrefInRuntime as normalizeHref,
-  normalizeRoutePath,
+  pathnameToRouteService,
   useLocation,
   useNavigate,
   withBase,
@@ -11,7 +10,6 @@ import { isExternalUrl } from '@rspress/shared';
 import nprogress from 'nprogress';
 import type React from 'react';
 import type { ComponentProps } from 'react';
-import { routes } from 'virtual-routes';
 import { scrollToTarget } from '../../logic';
 import styles from './index.module.scss';
 
@@ -73,15 +71,12 @@ export function Link(props: LinkProps) {
 
     // handle normal link
     if (!process.env.__SSR__ && !inCurrentPage) {
-      const matchedRoutes = matchRoutes(
-        routes,
-        normalizeRoutePath(withBaseUrl),
-      );
-      if (matchedRoutes?.length) {
+      const matchedRoute = pathnameToRouteService(withBaseUrl);
+      if (matchedRoute) {
         const timer = setTimeout(() => {
           nprogress.start();
         }, 200);
-        await matchedRoutes[0].route.preload();
+        await matchedRoute.preload();
         clearTimeout(timer);
         nprogress.done();
       }

--- a/packages/theme-default/src/components/Search/logic/providers/LocalProvider.ts
+++ b/packages/theme-default/src/components/Search/logic/providers/LocalProvider.ts
@@ -20,6 +20,8 @@ import { LOCAL_INDEX, type Provider, type SearchQuery } from '../Provider';
 import type { SearchOptions } from '../types';
 import { normalizeTextCase } from '../util';
 
+console.log(searchIndexHash, 1111);
+
 type FlexSearchDocumentWithType = Document<PageIndexInfo, true>;
 
 interface PageIndexForFlexSearch extends PageIndexInfo {
@@ -52,7 +54,7 @@ export class LocalProvider implements Provider {
   #cyrillicIndex?: FlexSearchDocumentWithType;
 
   async #getPages(lang: string, version: string): Promise<PageIndexInfo[]> {
-    const searchIndexGroupID = `${version}###${lang}`;
+    const searchIndexGroupID = `${version ?? ''}###${lang ?? ''}`;
     const searchIndexVersion = version ? `.${version.replace('.', '_')}` : '';
     const searchIndexLang = lang ? `.${lang}` : '';
     const searchIndexURL = `${removeTrailingSlash(__WEBPACK_PUBLIC_PATH__)}/static/${SEARCH_INDEX_NAME}${searchIndexVersion}${searchIndexLang}.${searchIndexHash[searchIndexGroupID]}.json`;

--- a/packages/theme-default/src/components/Search/logic/providers/LocalProvider.ts
+++ b/packages/theme-default/src/components/Search/logic/providers/LocalProvider.ts
@@ -20,8 +20,6 @@ import { LOCAL_INDEX, type Provider, type SearchQuery } from '../Provider';
 import type { SearchOptions } from '../types';
 import { normalizeTextCase } from '../util';
 
-console.log(searchIndexHash, 1111);
-
 type FlexSearchDocumentWithType = Document<PageIndexInfo, true>;
 
 interface PageIndexForFlexSearch extends PageIndexInfo {

--- a/packages/theme-default/src/components/Sidebar/utils.ts
+++ b/packages/theme-default/src/components/Sidebar/utils.ts
@@ -1,14 +1,13 @@
-import { matchRoutes, removeBase, useLocation } from '@rspress/runtime';
+import { pathnameToRouteService, useLocation } from '@rspress/runtime';
 import {
   type SidebarDivider as ISidebarDivider,
   type SidebarItem as ISidebarItem,
   type SidebarSectionHeader as ISidebarSectionHeader,
   type NormalizedSidebarGroup,
   isExternalUrl,
-  normalizeSlash,
 } from '@rspress/shared';
-import { routes } from 'virtual-routes';
-import { isActive, useLocaleSiteData } from '../../logic';
+import { useCallback } from 'react';
+import { isActive } from '../../logic/getSidebarDataGroup';
 
 export const isSidebarDivider = (
   item:
@@ -45,30 +44,22 @@ export const isSideBarCustomLink = (
 };
 
 export const preloadLink = (link: string) => {
-  const match = matchRoutes(routes, link);
-  if (match?.length) {
-    const { route } = match[0];
+  const route = pathnameToRouteService(link);
+  if (route) {
     route.preload();
   }
 };
 
 export const useActiveMatcher = () => {
-  const localesData = useLocaleSiteData();
-  const langRoutePrefix = normalizeSlash(localesData.langRoutePrefix || '');
-
   const { pathname: rawPathname } = useLocation();
 
-  const pathname = decodeURIComponent(rawPathname);
-  const removeLangPrefix = (path: string) => {
-    return path.replace(langRoutePrefix, '');
-  };
-  const activeMatcher = (link: string) => {
-    return isActive(
-      removeBase(removeLangPrefix(pathname)),
-      removeLangPrefix(link),
-      true,
-    );
-  };
+  const activeMatcher = useCallback(
+    (link: string) => {
+      const pathname = decodeURIComponent(rawPathname);
+      return isActive(link, pathname);
+    },
+    [rawPathname],
+  );
 
   return activeMatcher;
 };

--- a/packages/theme-default/src/global.d.ts
+++ b/packages/theme-default/src/global.d.ts
@@ -20,12 +20,6 @@ declare module '*.svg' {
   export default ReactComponent;
 }
 
-declare module 'virtual-routes' {
-  export { Route } from 'node/route/RouteService';
-
-  export const routes: Route[];
-}
-
 declare module 'virtual-search-hooks' {
   import type {
     BeforeSearch,

--- a/packages/theme-default/src/logic/getSidebarDataGroup.test.ts
+++ b/packages/theme-default/src/logic/getSidebarDataGroup.test.ts
@@ -3,8 +3,17 @@ import { getSidebarDataGroup } from './getSidebarDataGroup';
 
 vi.mock('@rspress/runtime', () => {
   return {
-    isEqualPath: () => true,
     withBase: (arg0: string) => arg0,
+    pathnameToRouteService: (arg0: string) => {
+      const map: Record<string, any> = {
+        '/guide/getting-started': '/guide/getting-started',
+        '/api/react.use': '/api/react.use',
+        '/api/react.use.html': '/api/react.use',
+      };
+      return {
+        path: map[arg0],
+      };
+    },
   };
 });
 
@@ -30,6 +39,27 @@ describe('getSidebarDataGroup', () => {
           {
             "link": "/guide/getting-started",
             "text": "Getting Started",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('when using api-extractor', async () => {
+    expect(
+      getSidebarDataGroup(
+        {
+          '/api/react': [{ link: '/api/react.use', text: 'react.use' }],
+        },
+        '/api/react.use.html',
+      ),
+    ).toMatchInlineSnapshot(`
+      {
+        "group": "react.use",
+        "items": [
+          {
+            "link": "/api/react.use",
+            "text": "react.use",
           },
         ],
       }

--- a/packages/theme-default/src/logic/utils.ts
+++ b/packages/theme-default/src/logic/utils.ts
@@ -1,26 +1,4 @@
-import { isEqualPath } from '@rspress/runtime';
 import htmr from 'htmr';
-import React from 'react';
-
-export function isActive(
-  currentPath: string,
-  targetLink?: string,
-  strict = false,
-) {
-  if (!targetLink) {
-    return false;
-  }
-  if (strict) {
-    return (
-      isEqualPath(currentPath, targetLink) ||
-      isEqualPath(currentPath, `${targetLink}/index`)
-    );
-  }
-
-  return (
-    isEqualPath(currentPath, targetLink) || currentPath.startsWith(targetLink)
-  );
-}
 
 export function isMobileDevice() {
   return window.innerWidth <= 1024;


### PR DESCRIPTION
## Summary

We currently have two matching algorithms for sidebar

```ts
{
	'/': [],
	'/guide': [
		{
			text: 'Getting Started',
			link: '/guide/getting-started',
		},
	],
},
```
#### 1. `matchPath(sidebarKey, pathname)` in `getSidebarGroupData(pathname: string)`

decide which **sidebarGroup** would show, and it will calculate with these keys `'/'`, `'/guide'` one by one

https://github.com/web-infra-dev/rspress/blob/fb81b996c5630b826ee6f5df7e1a6920d9d48e52/packages/theme-default/src/logic/getSidebarDataGroup.ts#L22-L42


#### 2. `match(sidebarGroup, pathname)`

decide which **sidebarItem** is active,

to match `item.link` recursively

```ts
{
	text: 'Getting Started',
	link: '/guide/getting-started',
},
```


## some code changes

1. unify all `pathname -> routePath` logic to `pathnameToRouteService`

it is a core function which bridge `Route` and `Sidebar`

2. use `pathnameToRouteService` to decide which sidebar is active

In rspress, we calculating it repeatedly

This  `pathnameToRouteService`  should be the above algorithm 2,  it comes froms `react-router-dom`

Of course, Sidebar `isActive` should use the same logic with Route

3. be compatible to `api-extractor` generated path

for rspeedy

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
