### PR TITLE
fix(search): for #1867, search codeBlock: false should work

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "husky": "^9.1.7",
     "lint-staged": "~15.4.3",
     "nx": "20.4.0",
+    "path-serializer": "0.3.4",
     "playwright": "1.47.2",
     "prettier": "3.4.2",
     "prettier-plugin-packagejson": "^2.5.8",

--- a/packages/core/src/node/runtimeModule/siteData/extractPageData.test.ts
+++ b/packages/core/src/node/runtimeModule/siteData/extractPageData.test.ts
@@ -1,0 +1,134 @@
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { extractPageData } from './extractPageData';
+
+const fixtureBasicDir = join(__dirname, '../../route/fixtures/basic');
+
+const absolutize = (relativePath: string) => {
+  return join(fixtureBasicDir, `.${relativePath}`);
+};
+
+describe('extractPageData', async () => {
+  it('basic', async () => {
+    const pageData = await extractPageData(
+      [],
+      {},
+      'http://localhost:3000',
+      fixtureBasicDir,
+      // @ts-ignore
+      {
+        getRoutes: () =>
+          Object.values({
+            '/a': {
+              absolutePath: absolutize('/a.mdx'),
+              lang: '',
+              pageName: 'a',
+              relativePath: 'a.mdx',
+              routePath: '/a',
+              version: '',
+            },
+            '/guide/b': {
+              absolutePath: absolutize('/guide/b.mdx'),
+              lang: '',
+              pageName: 'guide_b',
+              relativePath: 'guide/b.mdx',
+              routePath: '/guide/b',
+              version: '',
+            },
+            '/guide/c': {
+              absolutePath: absolutize('/guide/c.tsx'),
+              lang: '',
+              pageName: 'guide_c',
+              relativePath: 'guide/c.tsx',
+              routePath: '/guide/c',
+              version: '',
+            },
+            '/': {
+              absolutePath: absolutize('/index.mdx'),
+              lang: '',
+              pageName: 'index',
+              relativePath: 'index.mdx',
+              routePath: '/',
+              version: '',
+            },
+          }),
+      },
+      new Set(),
+      false,
+    );
+    expect(pageData).toMatchInlineSnapshot(`
+      [
+        {
+          "_filepath": "<ROOT>/packages/core/src/node/route/fixtures/basic/a.mdx",
+          "_html": "<h1 id="page-a">Page a<a aria-hidden="true" href="#page-a">#</a></h1>
+      <p>1111</p>
+      <pre><code>&lt;Hello /&gt;
+      </code></pre>",
+          "_relativePath": "a.mdx",
+          "content": "#
+
+      1111
+
+      ",
+          "domain": "http://localhost:3000",
+          "frontmatter": {
+            "__content": undefined,
+            "title": "Page a",
+          },
+          "id": 0,
+          "lang": "",
+          "routePath": "/a",
+          "title": "Page a",
+          "toc": [],
+          "version": "",
+        },
+        {
+          "_filepath": "<ROOT>/packages/core/src/node/route/fixtures/basic/guide/b.mdx",
+          "_html": "<h1 id="page-b">Page b<a aria-hidden="true" href="#page-b">#</a></h1>",
+          "_relativePath": "guide/b.mdx",
+          "content": "#",
+          "domain": "http://localhost:3000",
+          "frontmatter": {
+            "__content": undefined,
+          },
+          "id": 1,
+          "lang": "",
+          "routePath": "/guide/b",
+          "title": "Page b",
+          "toc": [],
+          "version": "",
+        },
+        {
+          "_filepath": "<ROOT>/packages/core/src/node/route/fixtures/basic/guide/c.tsx",
+          "_html": "",
+          "_relativePath": "guide/c.tsx",
+          "content": "",
+          "domain": "http://localhost:3000",
+          "frontmatter": {},
+          "id": 2,
+          "lang": "",
+          "routePath": "/guide/c",
+          "title": "",
+          "toc": [],
+          "version": "",
+        },
+        {
+          "_filepath": "<ROOT>/packages/core/src/node/route/fixtures/basic/index.mdx",
+          "_html": "<h1 id="homepage">homePage<a aria-hidden="true" href="#homepage">#</a></h1>",
+          "_relativePath": "index.mdx",
+          "content": "#",
+          "domain": "http://localhost:3000",
+          "frontmatter": {
+            "__content": undefined,
+          },
+          "id": 3,
+          "lang": "",
+          "routePath": "/",
+          "title": "homePage",
+          "toc": [],
+          "version": "",
+        },
+      ]
+    `);
+  });
+});

--- a/packages/core/src/node/runtimeModule/siteData/extractPageData.test.ts
+++ b/packages/core/src/node/runtimeModule/siteData/extractPageData.test.ts
@@ -60,20 +60,12 @@ describe('extractPageData', async () => {
       [
         {
           "_filepath": "<ROOT>/packages/core/src/node/route/fixtures/basic/a.mdx",
-          "_html": "<h1 id="page-a">Page a<a aria-hidden="true" href="#page-a">#</a></h1>
-      <p>1111</p>
-      <pre><code>&lt;Hello /&gt;
-      </code></pre>",
+          "_html": "<h1 id="page-a">Page a<a aria-hidden="true" href="#page-a">#</a></h1>",
           "_relativePath": "a.mdx",
-          "content": "#
-
-      1111
-
-      ",
+          "content": "#",
           "domain": "http://localhost:3000",
           "frontmatter": {
             "__content": undefined,
-            "title": "Page a",
           },
           "id": 0,
           "lang": "",

--- a/packages/core/src/node/runtimeModule/siteData/extractPageData.test.ts
+++ b/packages/core/src/node/runtimeModule/siteData/extractPageData.test.ts
@@ -15,7 +15,7 @@ describe('extractPageData', async () => {
       {},
       'http://localhost:3000',
       fixtureBasicDir,
-      // @ts-ignore
+      // @ts-ignore mock RouteService
       {
         getRoutes: () =>
           Object.values({

--- a/packages/core/src/node/runtimeModule/siteData/extractPageData.ts
+++ b/packages/core/src/node/runtimeModule/siteData/extractPageData.ts
@@ -81,7 +81,7 @@ export async function extractPageData(
         content = flattenContent.replace(importStatementRegex, '');
 
         const {
-          html,
+          html: rawHtml,
           title,
           toc: rawToc,
           languages,
@@ -104,18 +104,19 @@ export async function extractPageData(
           return html.replace(
             /<code>([\s\S]*?)<\/\s?code>/gm,
             function (_match: string, innerContent: string) {
-              return innerContent
+              return `<code>${innerContent
                 .replace(/&/g, '&amp;') // Must happen first or else it will escape other just-escaped characters.
                 .replace(/"/g, '&quot;')
                 .replace(/'/g, '&#39;')
                 .replace(/</g, '&lt;')
-                .replace(/>/g, '&gt;');
+                .replace(/>/g, '&gt;')}</code>`;
             },
           );
         }
 
-        const encodedCodeBlockHtml = encodeHtml(String(html));
-        content = htmlToText(encodedCodeBlockHtml, {
+        const html = encodeHtml(String(rawHtml));
+        content = htmlToText(html, {
+          // decodeEntities: true, // default value of decodeEntities is `true`, so that htmlToText can decode &lt; &gt;
           wordwrap: 80,
           selectors: [
             {
@@ -178,7 +179,7 @@ export async function extractPageData(
           ...defaultIndexInfo,
           title: frontmatter.title || title,
           toc,
-          // Stripped frontmatter content
+          // for search index
           content,
           _html: html,
           frontmatter: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       nx:
         specifier: 20.4.0
         version: 20.4.0
+      path-serializer:
+        specifier: 0.3.4
+        version: 0.3.4
       playwright:
         specifier: 1.47.2
         version: 1.47.2
@@ -5396,6 +5399,9 @@ packages:
   path-scurry@1.10.2:
     resolution: {integrity: sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  path-serializer@0.3.4:
+    resolution: {integrity: sha512-bqNF6KKbFn2hrTgybBTqAqjKOneLvpFmvYx43ppm8IcmfgYLh4aMmR35+GnnKYdd0l6gtBlaok+aRR0PSwtGaQ==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -11162,6 +11168,8 @@ snapshots:
     dependencies:
       lru-cache: 10.2.2
       minipass: 7.1.0
+
+  path-serializer@0.3.4: {}
 
   path-type@4.0.0: {}
 

--- a/scripts/test-helper/vitest.setup.ts
+++ b/scripts/test-helper/vitest.setup.ts
@@ -1,0 +1,12 @@
+import path from 'node:path';
+import { createSnapshotSerializer } from 'path-serializer';
+import { expect } from 'vitest';
+
+expect.addSnapshotSerializer(
+  createSnapshotSerializer({
+    root: path.join(__dirname, '../..'),
+    features: {
+      escapeDoubleQuotes: false,
+    },
+  }),
+);

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -18,6 +18,7 @@ export default defineWorkspace([
       // restoreMocks: true,
       include: ['packages/**/*.test.ts'],
       exclude: ['**/node_modules/**'],
+      setupFiles: ['./scripts/test-helper/vitest.setup.ts'],
     },
   },
 ]);


### PR DESCRIPTION
## Summary

a mistake in https://github.com/web-infra-dev/rspress/pull/1867

`encodedHtml` should be `<code>${encodedHtml}</code>`

## Related Issue

https://github.com/web-infra-dev/rspress/pull/1867

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
