### PR TITLE
refactor(Link): unify all the navigate and scroll behavior

### DIFF
--- a/packages/theme-default/src/components/Aside/index.tsx
+++ b/packages/theme-default/src/components/Aside/index.tsx
@@ -1,15 +1,13 @@
 import type { Header } from '@rspress/shared';
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import {
   bindingAsideScroll,
   parseInlineMarkdownText,
   renderInlineMarkdown,
-  scrollToTarget,
-  useHiddenNav,
 } from '../../logic';
-import { DEFAULT_NAV_HEIGHT } from '../../logic/sideEffects';
 import './index.scss';
 import { useLocation } from '@rspress/runtime';
+import { Link } from '../Link';
 
 const TocItem = ({
   header,
@@ -17,7 +15,7 @@ const TocItem = ({
 }: { header: Header; baseHeaderLevel: number }) => {
   return (
     <li>
-      <a
+      <Link
         href={`#${header.id}`}
         title={parseInlineMarkdownText(header.text)}
         className="aside-link transition-all duration-300 hover:text-text-1 text-text-2 block"
@@ -25,15 +23,11 @@ const TocItem = ({
           marginLeft: (header.depth - baseHeaderLevel) * 12,
           fontWeight: 'semibold',
         }}
-        onClick={e => {
-          e.preventDefault();
-          window.location.hash = header.id;
-        }}
       >
         <span className="aside-link-text block">
           {renderInlineMarkdown(header.text)}
         </span>
-      </a>
+      </Link>
     </li>
   );
 };
@@ -43,12 +37,7 @@ export function Aside(props: { headers: Header[]; outlineTitle: string }) {
   const hasOutline = headers.length > 0;
   // For outline text highlight
   const baseHeaderLevel = headers[0]?.depth || 2;
-  const hiddenNav = useHiddenNav();
-
-  const { hash: locationHash = '', pathname } = useLocation();
-  const decodedHash: string = useMemo(() => {
-    return decodeURIComponent(locationHash);
-  }, [locationHash]);
+  const { pathname } = useLocation();
 
   useEffect(() => {
     let unbinding: (() => void) | undefined;
@@ -63,19 +52,6 @@ export function Aside(props: { headers: Header[]; outlineTitle: string }) {
       }
     };
   }, [headers]);
-
-  // why window.scrollTo(0, 0)?
-  // when using history.scrollRestoration = 'auto' ref: "useUISwitch.ts", we scroll to the last page's position when navigating to nextPage
-  useEffect(() => {
-    if (decodedHash.length === 0) {
-      window.scrollTo(0, 0);
-    } else {
-      const target = document.getElementById(decodedHash.slice(1));
-      if (target) {
-        scrollToTarget(target, false, hiddenNav ? 0 : DEFAULT_NAV_HEIGHT);
-      }
-    }
-  }, [decodedHash, headers, pathname]);
 
   return (
     <div className="flex flex-col">

--- a/packages/theme-default/src/components/EditLink/index.tsx
+++ b/packages/theme-default/src/components/EditLink/index.tsx
@@ -10,6 +10,7 @@ export function EditLink() {
 
   const { text, link } = editLinkObj;
 
+  // EditLink must be an external site, so we use <a> directly instead of Link
   return (
     <a href={link} target="_blank" className={styles.editLink}>
       {text}

--- a/packages/theme-default/src/components/Link/index.module.scss
+++ b/packages/theme-default/src/components/Link/index.module.scss
@@ -1,6 +1,7 @@
 .link {
   font-weight: 500;
   transition: opacity 0.2s;
+  cursor: pointer;
 
   &:hover {
     opacity: 0.85;

--- a/packages/theme-default/src/components/Link/index.tsx
+++ b/packages/theme-default/src/components/Link/index.tsx
@@ -1,5 +1,4 @@
 import {
-  isEqualPath,
   normalizeHrefInRuntime as normalizeHref,
   pathnameToRouteService,
   useLocation,
@@ -9,8 +8,8 @@ import {
 import { isExternalUrl } from '@rspress/shared';
 import nprogress from 'nprogress';
 import type React from 'react';
-import type { ComponentProps } from 'react';
-import { scrollToTarget } from '../../logic';
+import { type ComponentProps, useMemo } from 'react';
+import { isActive } from '../../logic/getSidebarDataGroup';
 import styles from './index.module.scss';
 
 export interface LinkProps extends ComponentProps<'a'> {
@@ -24,6 +23,15 @@ export interface LinkProps extends ComponentProps<'a'> {
 
 nprogress.configure({ showSpinner: false });
 
+/**
+ * What's the difference between <Link> and <a>?
+ * Link can tell whether it's in current site or external site.
+ * 1. If external, open a new page and navigate to it.
+ * 2. If inCurrentPage, scroll to anchor.
+ * 3. If inCurrentSite, it will navigate and scroll to anchor.
+ * 4. Link is styled.
+ * TODO: if inCurrentSite, preload the asyncChunk onHover the link
+ */
 export function Link(props: LinkProps) {
   const {
     href = '/',
@@ -31,16 +39,41 @@ export function Link(props: LinkProps) {
     className = '',
     onNavigate,
     keepCurrentParams = false,
-    ...rest
+    onClick,
   } = props;
-  const isExternal = isExternalUrl(href);
-  const target = isExternal ? '_blank' : '';
-  const rel = isExternal ? 'noopener noreferrer' : undefined;
-  const withBaseUrl = isExternal ? href : withBase(normalizeHref(href));
+
   const navigate = useNavigate();
   const { pathname, search } = useLocation();
+  const withBaseUrl = useMemo(() => {
+    return withBase(normalizeHref(href));
+  }, [href]);
   const withQueryUrl = keepCurrentParams ? withBaseUrl + search : withBaseUrl;
-  const inCurrentPage = isEqualPath(pathname, withBaseUrl);
+
+  const isExternal = isExternalUrl(href);
+  const isHashOnlyLink = href.startsWith('#');
+
+  if (isExternal) {
+    return (
+      <a
+        {...props}
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`${styles.link} ${className}`}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  if (isHashOnlyLink) {
+    return (
+      <a {...props} href={href} className={`${styles.link} ${className}`}>
+        {children}
+      </a>
+    );
+  }
+
   const handleNavigate = async (
     e: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
   ) => {
@@ -58,18 +91,9 @@ export function Link(props: LinkProps) {
       return;
     }
     e.preventDefault();
-    // handle hash link in current page
-    const hash = withBaseUrl.split('#')[1];
-    if (!isExternal && inCurrentPage && hash) {
-      const el = document.getElementById(hash);
-      if (el) {
-        scrollToTarget(el, true);
-        navigate(withQueryUrl, { replace: false });
-      }
-      return;
-    }
 
     // handle normal link
+    const inCurrentPage = isActive(withBaseUrl, pathname);
     if (!process.env.__SSR__ && !inCurrentPage) {
       const matchedRoute = pathnameToRouteService(withBaseUrl);
       if (matchedRoute) {
@@ -85,31 +109,15 @@ export function Link(props: LinkProps) {
     }
   };
 
-  if (!isExternal) {
-    return (
-      <a
-        {...rest}
-        className={`${styles.link} ${className} cursor-pointer`}
-        rel={rel}
-        target={target}
-        onClick={event => {
-          rest.onClick?.(event);
-          handleNavigate(event);
-        }}
-        href={withBaseUrl}
-      >
-        {children}
-      </a>
-    );
-  }
-
   return (
     <a
-      {...rest}
+      {...props}
       href={withBaseUrl}
-      target={target}
-      rel={rel}
       className={`${styles.link} ${className}`}
+      onClick={event => {
+        onClick?.(event);
+        handleNavigate(event);
+      }}
     >
       {children}
     </a>

--- a/packages/theme-default/src/components/Toc/index.tsx
+++ b/packages/theme-default/src/components/Toc/index.tsx
@@ -2,6 +2,7 @@ import { usePageData } from '@rspress/runtime';
 import type { Header } from '@rspress/shared';
 import { renderInlineMarkdown, scrollToTarget } from '../../logic';
 import './index.css';
+import { Link } from '../Link';
 
 const TocItem = ({
   header,
@@ -11,27 +12,21 @@ const TocItem = ({
   onItemClick?: (header: Header) => void;
 }) => {
   return (
-    <li key={header.id}>
-      <a
+    <li>
+      <Link
         href={`#${header.id}`}
         className={'rspress-toc-link sm:text-normal text-sm'}
         style={{
           marginLeft: (header.depth - 2) * 12,
         }}
-        onClick={e => {
-          e.preventDefault();
-          window.location.hash = header.id;
-          const target = document.getElementById(header.id);
-          if (target) {
-            scrollToTarget(target, false);
-          }
+        onClick={() => {
           onItemClick?.(header);
         }}
       >
         <span className={'rspress-toc-link-text block'}>
           {renderInlineMarkdown(header.text)}
         </span>
-      </a>
+      </Link>
     </li>
   );
 };

--- a/packages/theme-default/src/layout/DocLayout/docComponents/a.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/a.tsx
@@ -6,11 +6,6 @@ import styles from './index.module.scss';
 export const A = (props: ComponentProps<'a'>) => {
   const { href = '', className = '' } = props;
   const { normalizeLinkHref } = usePathUtils();
-  const hasHeaderAnchor = className.includes('header-anchor');
-
-  if (hasHeaderAnchor || href.startsWith('#')) {
-    return <a {...props} className={`${styles.link} ${className}`} />;
-  }
 
   return (
     <Link

--- a/packages/theme-default/src/layout/DocLayout/docComponents/index.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/index.tsx
@@ -1,9 +1,9 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
+import { A } from './a';
 import { Code } from './code';
 import { Hr } from './hr';
 import { Img } from './img';
-import { A } from './link';
 import { Li, Ol, Ul } from './list';
 import { Blockquote, P, Strong } from './paragraph';
 import { Pre } from './pre';

--- a/packages/theme-default/src/layout/DocLayout/index.tsx
+++ b/packages/theme-default/src/layout/DocLayout/index.tsx
@@ -9,7 +9,7 @@ import { SideMenu } from '../../components/LocalSideBar';
 import { useLocaleSiteData } from '../../logic';
 import { TabDataContext } from '../../logic/TabDataContext';
 import type { UISwitchResult } from '../../logic/useUISwitch';
-import { A } from './docComponents/link';
+import { A } from './docComponents/a';
 import { H1 } from './docComponents/title';
 import styles from './index.module.scss';
 

--- a/packages/theme-default/src/logic/sideEffects.ts
+++ b/packages/theme-default/src/logic/sideEffects.ts
@@ -37,7 +37,7 @@ export function scrollToTarget(
 
 // Control the scroll behavior of the browser when user clicks on a link
 function bindingWindowScroll() {
-  const scrollToAnchor = () => {
+  const scrollToAnchor = (fallbackToScrollTop: boolean) => {
     const currentUrl = window.location;
     const { hash } = currentUrl;
     const target = document.getElementById(hash.slice(1));
@@ -48,18 +48,20 @@ function bindingWindowScroll() {
         globalHiddenNav.current ? 0 : DEFAULT_NAV_HEIGHT,
       );
     } else {
-      window.scrollTo(0, 0);
+      if (fallbackToScrollTop) {
+        window.scrollTo(0, 0);
+      }
     }
   };
 
   window.addEventListener('hashchange', e => {
     e.preventDefault();
-    scrollToAnchor();
+    scrollToAnchor(false);
   });
 
   window.addEventListener('RspressReloadContent', e => {
     e.preventDefault();
-    scrollToAnchor();
+    scrollToAnchor(true);
   });
 
   // Initial scroll position

--- a/packages/theme-default/src/logic/sideEffects.ts
+++ b/packages/theme-default/src/logic/sideEffects.ts
@@ -40,8 +40,8 @@ function bindingWindowScroll() {
   const scrollToAnchor = (fallbackToScrollTop: boolean) => {
     const currentUrl = window.location;
     const { hash } = currentUrl;
-    const target = document.getElementById(hash.slice(1));
-    if (target) {
+    const target = hash.length > 1 && document.getElementById(hash.slice(1));
+    if (hash && target) {
       scrollToTarget(
         target,
         true,

--- a/packages/theme-default/src/logic/useHiddenNav.ts
+++ b/packages/theme-default/src/logic/useHiddenNav.ts
@@ -19,12 +19,15 @@ export function useEnableNav() {
   return [enableNav, setEnableNav] as const;
 }
 
+export const globalHiddenNav = { current: false };
+
 export function useHiddenNav() {
   const {
     siteData: { themeConfig },
   } = usePageData();
   const hiddenBehavior = themeConfig.hideNavbar ?? 'never';
   const [hiddenNav, setHiddenNav] = useState(false);
+  globalHiddenNav.current = hiddenNav;
   const { pathname } = useLocation();
   const lastScrollTop = useRef(0);
 

--- a/packages/theme-default/src/logic/usePathUtils.ts
+++ b/packages/theme-default/src/logic/usePathUtils.ts
@@ -16,12 +16,15 @@ export function usePathUtils() {
   const defaultVersion = pageData.siteData.multiVersion.default;
 
   const normalizeLinkHref = (rawHref: string) => {
+    if (isExternalUrl(rawHref)) {
+      return rawHref;
+    }
+    if (rawHref.startsWith('#')) {
+      return rawHref;
+    }
+
     let href = rawHref;
-    if (
-      (defaultLang || defaultVersion) &&
-      !isExternalUrl(href) &&
-      !href.startsWith('#')
-    ) {
+    if (defaultLang || defaultVersion) {
       href = removeBase(href);
       const linkParts = href.split('/').filter(Boolean);
       let versionPart = '';

--- a/packages/theme-default/src/logic/useUISwitch.ts
+++ b/packages/theme-default/src/logic/useUISwitch.ts
@@ -1,7 +1,8 @@
 import { useLocation, usePageData } from '@rspress/runtime';
 import { inBrowser } from '@rspress/shared';
-import { useEffect, useState } from 'react';
-import { useEnableNav } from './useHiddenNav';
+import { useEffect, useMemo, useState } from 'react';
+import { DEFAULT_NAV_HEIGHT, scrollToTarget } from './sideEffects';
+import { useEnableNav, useHiddenNav } from './useHiddenNav';
 import { useLocaleSiteData } from './useLocaleSiteData';
 
 export enum QueryStatus {
@@ -94,12 +95,25 @@ export function useUISwitch(): UISwitchResult {
     };
   }, [location.search]);
 
+  const { hash: locationHash = '', pathname } = useLocation();
+  const decodedHash: string = useMemo(() => {
+    return decodeURIComponent(locationHash);
+  }, [locationHash]);
+
   // Control the scroll behavior of the browser when location hash changed
+  const { hash } = useLocation();
   useEffect(() => {
     if (inBrowser() && history.scrollRestoration) {
-      history.scrollRestoration = location.hash.length ? 'manual' : 'auto';
+      history.scrollRestoration = hash.length ? 'manual' : 'auto';
     }
-  }, [!location.hash.length]);
+  }, [!hash.length]);
+  // why window.scrollTo(0, 0)?
+  // when using history.scrollRestoration = 'auto' ref: "useUISwitch.ts", we scroll to the last page's position when navigating to nextPage
+  useEffect(() => {
+    if (decodedHash.length === 0) {
+      window.scrollTo(0, 0);
+    }
+  }, [decodedHash, pathname]);
 
   return {
     showAside,


### PR DESCRIPTION
## Summary

1. unify all the navigate and scroll behavior logic into one

2. unify all `<a />` to <Link /> component, and comment that why we need to use `<Link />` rather than `<a />`

## Features related to scroll

1. inCurrentPage: toc click

https://github.com/user-attachments/assets/4f85b57f-d42c-4769-8983-585714624cb0

2. inCurrentPage: anchor click

https://github.com/user-attachments/assets/33b4cc33-8ac7-4682-80ca-2ce34e04910b

3. inCurrentSite

https://github.com/user-attachments/assets/610f4704-5785-4b3f-af72-fb79d01da68d

4. hashChange


https://github.com/user-attachments/assets/f149ad40-d472-4f58-9cb8-2512ef3f4be7



## Related Issue

<!--- Provide link of related issues -->
https://github.com/web-infra-dev/rspress/pull/1856

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
