### PR TITLE
fix: shim `_dirname` in esm output

### DIFF
--- a/packages/plugin-client-redirects/rslib.config.ts
+++ b/packages/plugin-client-redirects/rslib.config.ts
@@ -8,6 +8,11 @@ export default defineConfig({
       },
       format: 'esm',
       syntax: 'esnext',
+      shims: {
+        esm: {
+          __dirname: true,
+        },
+      },
     },
   ],
 });

--- a/packages/plugin-playground/rslib.config.ts
+++ b/packages/plugin-playground/rslib.config.ts
@@ -19,6 +19,11 @@ export default defineConfig({
       source: {
         entry: { index: 'src/cli/index.ts' },
       },
+      shims: {
+        esm: {
+          __dirname: true,
+        },
+      },
       output: {
         distPath: {
           root: 'dist/cli/esm',


### PR DESCRIPTION
## Summary

fix rsbuild eco-ci problem:

<img width="616" alt="image" src="https://github.com/user-attachments/assets/98896969-6edc-4b65-a4fc-5c39f0ee2cad" />

https://lib.rsbuild.dev/config/lib/shims#shimsesm__dirname

## Related Issue

https://github.com/rspack-contrib/rsbuild-ecosystem-ci/actions/runs/13469849196/job/37642002320


<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
