### PR TITLE
chore(deps): bump Rslib v0.5.2 and modify some build configurations

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.49.2",
-    "@rslib/core": "0.4.1",
+    "@rslib/core": "0.5.2",
     "@types/jest": "~29.5.14",
     "@types/node": "^18.11.17",
     "@types/react": "^18.3.18",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -88,7 +88,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.49.2",
-    "@rslib/core": "0.4.1",
+    "@rslib/core": "0.5.2",
     "@rspress-dev/plugin-preview": "link:../plugin-preview",
     "@rspress/config": "workspace:*",
     "@types/hast": "^2.3.10",

--- a/packages/create-rspress/package.json
+++ b/packages/create-rspress/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.49.2",
-    "@rslib/core": "0.4.1",
+    "@rslib/core": "0.5.2",
     "@types/node": "^18.11.17",
     "typescript": "^5.5.3"
   },

--- a/packages/modern-plugin-rspress/package.json
+++ b/packages/modern-plugin-rspress/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.49.2",
     "@modern-js/module-tools": "2.64.0",
-    "@rslib/core": "0.4.1",
+    "@rslib/core": "0.5.2",
     "@types/lodash": "^4.17.15",
     "@types/node": "^18.11.17",
     "@types/react": "^18.3.18",

--- a/packages/plugin-api-docgen/package.json
+++ b/packages/plugin-api-docgen/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.49.2",
-    "@rslib/core": "0.4.1",
+    "@rslib/core": "0.5.2",
     "@types/mdast": "^3.0.15",
     "@types/node": "^18.11.17",
     "@types/react": "^18.3.18",

--- a/packages/plugin-auto-nav-sidebar/package.json
+++ b/packages/plugin-auto-nav-sidebar/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.49.2",
-    "@rslib/core": "0.4.1",
+    "@rslib/core": "0.5.2",
     "@rspress/config": "workspace:*",
     "@types/node": "^18.11.17",
     "@types/react": "^18.3.18",

--- a/packages/plugin-client-redirects/package.json
+++ b/packages/plugin-client-redirects/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.49.2",
-    "@rslib/core": "0.4.1",
+    "@rslib/core": "0.5.2",
     "@rspress/config": "workspace:*",
     "@types/node": "^18.11.17",
     "@types/react": "^18.3.18",

--- a/packages/plugin-container-syntax/package.json
+++ b/packages/plugin-container-syntax/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.49.2",
-    "@rslib/core": "0.4.1",
+    "@rslib/core": "0.5.2",
     "@types/mdast": "^3.0.15",
     "mdast-util-mdx-expression": "^1.3.2",
     "mdast-util-mdx-jsx": "^2.1.4",

--- a/packages/plugin-last-updated/package.json
+++ b/packages/plugin-last-updated/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.49.2",
-    "@rslib/core": "0.4.1",
+    "@rslib/core": "0.5.2",
     "@rspress/config": "workspace:*",
     "@types/node": "^18.11.17",
     "@types/react": "^18.3.18",

--- a/packages/plugin-medium-zoom/package.json
+++ b/packages/plugin-medium-zoom/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.49.2",
-    "@rslib/core": "0.4.1",
+    "@rslib/core": "0.5.2",
     "@rspress/config": "workspace:*",
     "@rspress/shared": "workspace:*",
     "@types/node": "^18.11.17",

--- a/packages/plugin-playground/package.json
+++ b/packages/plugin-playground/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@babel/types": "^7.26.7",
     "@rsbuild/plugin-react": "~1.1.0",
-    "@rslib/core": "0.4.1",
+    "@rslib/core": "0.5.2",
     "@types/babel__core": "^7.20.5",
     "@types/babel__standalone": "^7.1.9",
     "@types/babel__traverse": "^7.20.6",

--- a/packages/plugin-preview/package.json
+++ b/packages/plugin-preview/package.json
@@ -34,7 +34,7 @@
     "qrcode.react": "^3.2.0"
   },
   "devDependencies": {
-    "@rslib/core": "0.4.1",
+    "@rslib/core": "0.5.2",
     "@types/lodash": "^4.17.15",
     "@types/mdast": "^3.0.15",
     "@types/node": "^18.11.17",

--- a/packages/plugin-preview/rslib.config.ts
+++ b/packages/plugin-preview/rslib.config.ts
@@ -5,17 +5,10 @@ export default defineConfig({
     {
       format: 'cjs',
       source: {
-        entry: { index: 'src/index.ts' },
-      },
-      syntax: 'es2020',
-      dts: {
-        bundle: true,
-      },
-    },
-    {
-      format: 'cjs',
-      source: {
-        entry: { utils: 'src/utils.ts' },
+        entry: {
+          index: 'src/index.ts',
+          utils: 'src/utils.ts',
+        },
       },
       syntax: 'es2020',
       dts: {

--- a/packages/plugin-rss/package.json
+++ b/packages/plugin-rss/package.json
@@ -34,7 +34,7 @@
     "feed": "^4.2.2"
   },
   "devDependencies": {
-    "@rslib/core": "0.4.1",
+    "@rslib/core": "0.5.2",
     "@rspress/runtime": "workspace:*",
     "@types/node": "^18.11.17",
     "@types/react": "^18.3.18",

--- a/packages/plugin-shiki/package.json
+++ b/packages/plugin-shiki/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.49.2",
-    "@rslib/core": "0.4.1",
+    "@rslib/core": "0.5.2",
     "@rspress/config": "workspace:*",
     "@types/hast": "^2.3.10",
     "@types/node": "^18.11.17",

--- a/packages/plugin-typedoc/package.json
+++ b/packages/plugin-typedoc/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.49.2",
-    "@rslib/core": "0.4.1",
+    "@rslib/core": "0.5.2",
     "@rspress/config": "workspace:*",
     "@types/node": "^18.11.17",
     "@types/react": "^18.3.18",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@rsbuild/plugin-react": "~1.1.0",
-    "@rslib/core": "0.4.1",
+    "@rslib/core": "0.5.2",
     "@rspress/config": "workspace:*",
     "@types/jest": "~29.5.14",
     "@types/react": "^18.3.18",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -47,7 +47,7 @@
     "unified": "^10.1.2"
   },
   "devDependencies": {
-    "@rslib/core": "0.4.1",
+    "@rslib/core": "0.5.2",
     "@types/fs-extra": "11.0.4",
     "@types/jest": "~29.5.14",
     "@types/lodash-es": "^4.17.12",

--- a/packages/shared/rslib.config.ts
+++ b/packages/shared/rslib.config.ts
@@ -1,47 +1,28 @@
-import { type LibConfig, defineConfig } from '@rslib/core';
-
-const entries = {
-  index: 'src/index.ts',
-  logger: 'src/logger.ts',
-  'node-utils': 'src/node-utils.ts',
-  constants: 'src/constants.ts',
-};
-
-const COMMON_EXTERNALS = ['mdast-util-mdx-jsx'];
-
-// TODO: Rslib only supports bundle one single entry point when multiple entry points are provided.
-// https://github.com/web-infra-dev/rslib/blob/befb09a8b0a7dfd7f5c96aa53dd10255c315dc7e/packages/plugin-dts/src/index.ts#L76
-// Using multiple libs as a workaround as of now.
-const cjsLibs = Object.entries(entries).map<LibConfig>(([name, entry]) => {
-  return {
-    dts: {
-      bundle: true,
-    },
-    format: 'cjs',
-    syntax: 'esnext',
-    source: {
-      entry: {
-        [name]: entry,
-      },
-    },
-    output: {
-      externals: COMMON_EXTERNALS,
-    },
-  };
-});
+import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
-    ...cjsLibs,
+    {
+      dts: {
+        bundle: true,
+      },
+      format: 'cjs',
+      syntax: 'esnext',
+    },
     {
       format: 'esm',
       syntax: 'esnext',
-      source: {
-        entry: entries,
-      },
-      output: {
-        externals: COMMON_EXTERNALS,
-      },
     },
   ],
+  source: {
+    entry: {
+      index: 'src/index.ts',
+      logger: 'src/logger.ts',
+      'node-utils': 'src/node-utils.ts',
+      constants: 'src/constants.ts',
+    },
+  },
+  output: {
+    externals: ['mdast-util-mdx-jsx'],
+  },
 });

--- a/packages/theme-default/package.json
+++ b/packages/theme-default/package.json
@@ -64,7 +64,7 @@
     "@rsbuild/plugin-react": "~1.1.0",
     "@rsbuild/plugin-sass": "~1.2.0",
     "@rsbuild/plugin-svgr": "^1.0.6",
-    "@rslib/core": "0.4.1",
+    "@rslib/core": "0.5.2",
     "@types/body-scroll-lock": "^3.1.2",
     "@types/hast": "^2.3.10",
     "@types/jest": "~29.5.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -698,8 +698,8 @@ importers:
         specifier: ^7.49.2
         version: 7.49.2(@types/node@18.11.17)
       '@rslib/core':
-        specifier: 0.4.1
-        version: 0.4.1(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
+        specifier: 0.5.2
+        version: 0.5.2(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
       '@types/jest':
         specifier: ~29.5.14
         version: 29.5.14
@@ -837,8 +837,8 @@ importers:
         specifier: ^7.49.2
         version: 7.49.2(@types/node@18.11.17)
       '@rslib/core':
-        specifier: 0.4.1
-        version: 0.4.1(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
+        specifier: 0.5.2
+        version: 0.5.2(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
       '@rspress-dev/plugin-preview':
         specifier: link:../plugin-preview
         version: link:../plugin-preview
@@ -901,8 +901,8 @@ importers:
         specifier: ^7.49.2
         version: 7.49.2(@types/node@18.11.17)
       '@rslib/core':
-        specifier: 0.4.1
-        version: 0.4.1(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
+        specifier: 0.5.2
+        version: 0.5.2(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
       '@types/node':
         specifier: ^18.11.17
         version: 18.11.17
@@ -923,10 +923,10 @@ importers:
         version: 12.0.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       rsbuild-plugin-google-analytics:
         specifier: ^1.0.3
-        version: 1.0.3(@rsbuild/core@1.2.5)
+        version: 1.0.3(@rsbuild/core@1.2.11)
       rsbuild-plugin-open-graph:
         specifier: ^1.0.2
-        version: 1.0.2(@rsbuild/core@1.2.5)
+        version: 1.0.2(@rsbuild/core@1.2.11)
       rspress:
         specifier: workspace:*
         version: link:../cli
@@ -965,8 +965,8 @@ importers:
         specifier: 2.64.0
         version: 2.64.0(typescript@5.5.3)
       '@rslib/core':
-        specifier: 0.4.1
-        version: 0.4.1(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
+        specifier: 0.5.2
+        version: 0.5.2(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
       '@types/lodash':
         specifier: ^4.17.15
         version: 4.17.15
@@ -1014,8 +1014,8 @@ importers:
         specifier: ^7.49.2
         version: 7.49.2(@types/node@18.11.17)
       '@rslib/core':
-        specifier: 0.4.1
-        version: 0.4.1(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
+        specifier: 0.5.2
+        version: 0.5.2(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
       '@types/mdast':
         specifier: ^3.0.15
         version: 3.0.15
@@ -1057,8 +1057,8 @@ importers:
         specifier: ^7.49.2
         version: 7.49.2(@types/node@18.11.17)
       '@rslib/core':
-        specifier: 0.4.1
-        version: 0.4.1(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
+        specifier: 0.5.2
+        version: 0.5.2(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
       '@rspress/config':
         specifier: workspace:*
         version: link:../../scripts/config
@@ -1091,8 +1091,8 @@ importers:
         specifier: ^7.49.2
         version: 7.49.2(@types/node@18.11.17)
       '@rslib/core':
-        specifier: 0.4.1
-        version: 0.4.1(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
+        specifier: 0.5.2
+        version: 0.5.2(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
       '@rspress/config':
         specifier: workspace:*
         version: link:../../scripts/config
@@ -1122,8 +1122,8 @@ importers:
         specifier: ^7.49.2
         version: 7.49.2(@types/node@22.10.2)
       '@rslib/core':
-        specifier: 0.4.1
-        version: 0.4.1(@microsoft/api-extractor@7.49.2(@types/node@22.10.2))(typescript@5.7.2)
+        specifier: 0.5.2
+        version: 0.5.2(@microsoft/api-extractor@7.49.2(@types/node@22.10.2))(typescript@5.7.2)
       '@types/mdast':
         specifier: ^3.0.15
         version: 3.0.15
@@ -1162,8 +1162,8 @@ importers:
         specifier: ^7.49.2
         version: 7.49.2(@types/node@18.11.17)
       '@rslib/core':
-        specifier: 0.4.1
-        version: 0.4.1(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
+        specifier: 0.5.2
+        version: 0.5.2(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
       '@rspress/config':
         specifier: workspace:*
         version: link:../../scripts/config
@@ -1199,8 +1199,8 @@ importers:
         specifier: ^7.49.2
         version: 7.49.2(@types/node@18.11.17)
       '@rslib/core':
-        specifier: 0.4.1
-        version: 0.4.1(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
+        specifier: 0.5.2
+        version: 0.5.2(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
       '@rspress/config':
         specifier: workspace:*
         version: link:../../scripts/config
@@ -1252,10 +1252,10 @@ importers:
         version: 7.26.7
       '@rsbuild/plugin-react':
         specifier: ~1.1.0
-        version: 1.1.0(@rsbuild/core@1.2.5)
+        version: 1.1.0(@rsbuild/core@1.2.11)
       '@rslib/core':
-        specifier: 0.4.1
-        version: 0.4.1(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
+        specifier: 0.5.2
+        version: 0.5.2(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5
@@ -1336,8 +1336,8 @@ importers:
         version: 3.2.0(react@18.3.1)
     devDependencies:
       '@rslib/core':
-        specifier: 0.4.1
-        version: 0.4.1(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
+        specifier: 0.5.2
+        version: 0.5.2(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
       '@types/lodash':
         specifier: ^4.17.15
         version: 4.17.15
@@ -1391,8 +1391,8 @@ importers:
         version: link:../cli
     devDependencies:
       '@rslib/core':
-        specifier: 0.4.1
-        version: 0.4.1(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
+        specifier: 0.5.2
+        version: 0.5.2(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
       '@rspress/runtime':
         specifier: workspace:*
         version: link:../runtime
@@ -1428,8 +1428,8 @@ importers:
         specifier: ^7.49.2
         version: 7.49.2(@types/node@18.11.17)
       '@rslib/core':
-        specifier: 0.4.1
-        version: 0.4.1(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
+        specifier: 0.5.2
+        version: 0.5.2(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
       '@rspress/config':
         specifier: workspace:*
         version: link:../../scripts/config
@@ -1474,8 +1474,8 @@ importers:
         specifier: ^7.49.2
         version: 7.49.2(@types/node@18.11.17)
       '@rslib/core':
-        specifier: 0.4.1
-        version: 0.4.1(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
+        specifier: 0.5.2
+        version: 0.5.2(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
       '@rspress/config':
         specifier: workspace:*
         version: link:../../scripts/config
@@ -1515,10 +1515,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ~1.1.0
-        version: 1.1.0(@rsbuild/core@1.2.5)
+        version: 1.1.0(@rsbuild/core@1.2.11)
       '@rslib/core':
-        specifier: 0.4.1
-        version: 0.4.1(@microsoft/api-extractor@7.49.2(@types/node@22.10.2))(typescript@5.5.3)
+        specifier: 0.5.2
+        version: 0.5.2(@microsoft/api-extractor@7.49.2(@types/node@22.10.2))(typescript@5.5.3)
       '@rspress/config':
         specifier: workspace:*
         version: link:../../scripts/config
@@ -1551,8 +1551,8 @@ importers:
         version: 10.1.2
     devDependencies:
       '@rslib/core':
-        specifier: 0.4.1
-        version: 0.4.1(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
+        specifier: 0.5.2
+        version: 0.5.2(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)
       '@types/fs-extra':
         specifier: 11.0.4
         version: 11.0.4
@@ -1634,16 +1634,16 @@ importers:
         version: 2.64.0
       '@rsbuild/plugin-react':
         specifier: ~1.1.0
-        version: 1.1.0(@rsbuild/core@1.2.5)
+        version: 1.1.0(@rsbuild/core@1.2.11)
       '@rsbuild/plugin-sass':
         specifier: ~1.2.0
-        version: 1.2.0(@rsbuild/core@1.2.5)
+        version: 1.2.0(@rsbuild/core@1.2.11)
       '@rsbuild/plugin-svgr':
         specifier: ^1.0.6
-        version: 1.0.6(@rsbuild/core@1.2.5)(typescript@5.5.3)
+        version: 1.0.6(@rsbuild/core@1.2.11)(typescript@5.5.3)
       '@rslib/core':
-        specifier: 0.4.1
-        version: 0.4.1(@microsoft/api-extractor@7.49.2(@types/node@22.10.2))(typescript@5.5.3)
+        specifier: 0.5.2
+        version: 0.5.2(@microsoft/api-extractor@7.49.2(@types/node@22.10.2))(typescript@5.5.3)
       '@types/body-scroll-lock':
         specifier: ^3.1.2
         version: 3.1.2
@@ -1715,8 +1715,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@ast-grep/napi-darwin-arm64@0.35.0':
+    resolution: {integrity: sha512-T+MN4Oinc+sXjXCIHzfxDDWY7r2pKgPxM6zVeVlkMTrJV2mJtyKYBIS+CABhRM6kflps2T2I6l4DGaKV/8Ym9w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@ast-grep/napi-darwin-x64@0.33.1':
     resolution: {integrity: sha512-Gu3dd+7RZcLyte/xwBX4ErT12GYgGeQGQh6743NffChyVnpwZpj2aWmdkD8gHRKswXz2dp5R01QMCV0G5o8rDQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@ast-grep/napi-darwin-x64@0.35.0':
+    resolution: {integrity: sha512-pEYiN6JI1HY2uWhMYJ9+3yIMyVYKuYdFzeD+dL7odA3qzK0o9N9AM3/NOt4ynU2EhufaWCJr0P5NoQ636qN6MQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -1727,8 +1739,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@ast-grep/napi-linux-arm64-gnu@0.35.0':
+    resolution: {integrity: sha512-NBuzQngABGKz7lhG08IQb+7nPqUx81Ol37xmS3ZhVSdSgM0mtp93rCbgFTkJcAFE8IMfCHQSg7G4g0Iotz4ABQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
   '@ast-grep/napi-linux-arm64-musl@0.33.1':
     resolution: {integrity: sha512-+vTHYYP8iRG9lZHhcpQRxAuD8CBYXJHFXgsevmnurS/R53r0YjNtrtj6W33e7RYXY5hehmey2Cz/5h6OhdLcJw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@ast-grep/napi-linux-arm64-musl@0.35.0':
+    resolution: {integrity: sha512-1EcvHPwyWpCL/96LuItBYGfeI5FaMTRvL+dHbO/hL5q1npqbb5qn+ppJwtNOjTPz8tayvgggxVk9T4C2O7taYA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -1739,8 +1763,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@ast-grep/napi-linux-x64-gnu@0.35.0':
+    resolution: {integrity: sha512-FDzNdlqmQnsiWXhnLxusw5AOfEcEM+5xtmrnAf3SBRFr86JyWD9qsynnFYC2pnP9hlMfifNH2TTmMpyGJW49Xw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
   '@ast-grep/napi-linux-x64-musl@0.33.1':
     resolution: {integrity: sha512-+ye9d8nwgi+f9yhA0NEv5lDcpfIF7xhCcF9FerIKpksX57oI68QWNz1bOWHOuebaf9Wc0hgEtfai7lzcDWcsnA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@ast-grep/napi-linux-x64-musl@0.35.0':
+    resolution: {integrity: sha512-wlmndjfBafT8u5p4DBnoRQyoCSGNuVSz7rT3TqhvlHcPzUouRWMn95epU9B1LNLyjXvr9xHeRjSktyCN28w57Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -1751,8 +1787,20 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@ast-grep/napi-win32-arm64-msvc@0.35.0':
+    resolution: {integrity: sha512-gkhJeYc4rrZLX2icLxalPikTLMR57DuIYLwLr9g+StHYXIsGHrbfrE6Nnbdd8Izfs34ArFCrcwdaMrGlvOPSeg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
   '@ast-grep/napi-win32-ia32-msvc@0.33.1':
     resolution: {integrity: sha512-rM6kK19Z9mknXQLZYvIGW1vR472n0dzhexWRM4O8BAL33B4NXA0qa7lX7I3ioHBTOUx0dGW10oNRm3yindUohg==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@ast-grep/napi-win32-ia32-msvc@0.35.0':
+    resolution: {integrity: sha512-OdUuRa3chHCZ65y+qALfkUjz0W0Eg21YZ9TyPquV5why07M6HAK38mmYGzLxFH6294SvRQhs+FA/rAfbKeH0jA==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
@@ -1763,8 +1811,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@ast-grep/napi-win32-x64-msvc@0.35.0':
+    resolution: {integrity: sha512-pcQRUHqbroTN1oQ56V982a7IZTUUySQYWa2KEyksiifHGuBuitlzcyzFGjT96ThcqD9XW0UVJMvpoF2Qjh006Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
   '@ast-grep/napi@0.33.1':
     resolution: {integrity: sha512-AfUsqmEa8NoYq1QhY2LWKCgKRBrCW89WB2D7t4hhTwXcfBB+CWRtY11vUughpfGLrdyziPst7kpdFzI9TC9Efw==}
+    engines: {node: '>= 10'}
+
+  '@ast-grep/napi@0.35.0':
+    resolution: {integrity: sha512-3ucaaSxV6fxXoqHrE/rxAvP1THnDdY5jNzGlnvx+JvnY9C/dSRKc0jlRMRz59N3El572+/yNRUUpAV1T9aBJug==}
     engines: {node: '>= 10'}
 
   '@babel/code-frame@7.25.7':
@@ -2913,13 +2971,13 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rsbuild/core@1.2.3':
-    resolution: {integrity: sha512-lUCt8gQe9E2PI3srcEJ1Na3GQYmsYuvAqK0f/k00HM0pEjrbOFC9Xq2kR85UoXHFqlTCIw/fLLDe91PKRCbKAw==}
+  '@rsbuild/core@1.2.11':
+    resolution: {integrity: sha512-bsTtXlqJKoqnHwOZ05NePGpBf/neuwHTzJtQegQ9GA8YLyjow1wn8vPXFiRtYL0UqASEDtFtAm2bcaieg7r/TQ==}
     engines: {node: '>=16.7.0'}
     hasBin: true
 
-  '@rsbuild/core@1.2.5':
-    resolution: {integrity: sha512-k9JFE613b0X0WUaqfp6CIh2sS+jpzx30cCqe8wPIaQ/tVfUc1kr7gfR3dwcdiE68+WVnFHGm1JqMdeOZogjsJQ==}
+  '@rsbuild/core@1.2.3':
+    resolution: {integrity: sha512-lUCt8gQe9E2PI3srcEJ1Na3GQYmsYuvAqK0f/k00HM0pEjrbOFC9Xq2kR85UoXHFqlTCIw/fLLDe91PKRCbKAw==}
     engines: {node: '>=16.7.0'}
     hasBin: true
 
@@ -2953,9 +3011,9 @@ packages:
     peerDependencies:
       '@rsbuild/core': 1.x
 
-  '@rslib/core@0.4.1':
-    resolution: {integrity: sha512-qYzXqmyJsYhrorxUnXz1UNaLlkun/4HPXfDmvkrvFJ/vbQTLZom66a9uMQfkluRish3kJNumYNwtgfxBzn6ZBQ==}
-    engines: {node: '>=16.0.0'}
+  '@rslib/core@0.5.2':
+    resolution: {integrity: sha512-cOeks7bS+v6VOGeGt+cWtkxD6WyCJuqPHjB+/LI1F6fGR+y6bA0py1jCpXu7yFrAOqH2+qArcBvQKcAfepyhGg==}
+    engines: {node: '>=16.7.0'}
     hasBin: true
     peerDependencies:
       '@microsoft/api-extractor': ^7
@@ -2971,8 +3029,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@1.2.3':
+    resolution: {integrity: sha512-xuwYzhPgNCr4BtKXCU3xe4249TFsXAZglIlbxv8Qs3PeIarrZMRddcqH2zUXi+nJavNw3yN12sCYEzk1f+O4FQ==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@1.2.2':
     resolution: {integrity: sha512-vG5s7FkEvwrGLfksyDRHwKAHUkhZt1zHZZXJQn4gZKjTBonje8ezdc7IFlDiWpC4S+oBYp73nDWkUzkGRbSdcQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@1.2.3':
+    resolution: {integrity: sha512-afiIN8elcrO2EtO27UN0qyZqu5FXGUdclud56DrhvEfnWS3GGxJEdjA8XUYVXkfCYakdXHucIJKlkkgaAjEvHg==}
     cpu: [x64]
     os: [darwin]
 
@@ -2981,8 +3049,18 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rspack/binding-linux-arm64-gnu@1.2.3':
+    resolution: {integrity: sha512-K2u/fPUmKujlKSWL3q2zaUu8/6ZK/bOGKcqJSib8jdanQQ/GFKwKtPAFOOa/vvqbzhDocqKOobFR10FhgJqCHg==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rspack/binding-linux-arm64-musl@1.2.2':
     resolution: {integrity: sha512-Z5vAC4wGfXi8XXZ6hs8Q06TYjr3zHf819HB4DI5i4C1eQTeKdZSyoFD0NHFG23bP4NWJffp8KhmoObcy9jBT5Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rspack/binding-linux-arm64-musl@1.2.3':
+    resolution: {integrity: sha512-mgovdzGb6cH9hQsjTyzDbfZWCPhTcoHcLro1P7UbiqcLPMDJp/k3Io9xV2/EJhaDA1aynIdq7XfY0fuk4+6Irw==}
     cpu: [arm64]
     os: [linux]
 
@@ -2991,8 +3069,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rspack/binding-linux-x64-gnu@1.2.3':
+    resolution: {integrity: sha512-542lwJzB1RMGuVdBdA3cOWTlmL9okpOppHUBWcNCjmJM+9zTI+0jwjVe8HaqOqtuR8XzNsoCwT9QonU/GLcuhg==}
+    cpu: [x64]
+    os: [linux]
+
   '@rspack/binding-linux-x64-musl@1.2.2':
     resolution: {integrity: sha512-RE3e0xe4DdchHssttKzryDwjLkbrNk/4H59TkkWeGYJcLw41tmcOZVFQUOwKLUvXWVyif/vjvV/w1SMlqB4wQg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rspack/binding-linux-x64-musl@1.2.3':
+    resolution: {integrity: sha512-dJromiREDcTWqzfCOI5y1IVoYmUnCv7vCp63AEq0+13fJJdk7+pcNN3VV2jOKpk9VECSvjg1c01wl+UzXAXFMw==}
     cpu: [x64]
     os: [linux]
 
@@ -3001,8 +3089,18 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@rspack/binding-win32-arm64-msvc@1.2.3':
+    resolution: {integrity: sha512-S8ZKddMMQDGy8jx/R0i2m1XrmfY2CpI+t6lIEpsuZuKUR4MbOGKN2DuL4MDnT3m8JaYvC8ihsvQjBXQCy3SNxQ==}
+    cpu: [arm64]
+    os: [win32]
+
   '@rspack/binding-win32-ia32-msvc@1.2.2':
     resolution: {integrity: sha512-dBqz3sRAGZ2f31FgzKLDvIRfq2haRP3X3XVCT0PsiMcvt7QJng+26aYYMy2THatd/nM8IwExYeitHWeiMBoruw==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rspack/binding-win32-ia32-msvc@1.2.3':
+    resolution: {integrity: sha512-74lqSMKQJcJcgfFaxm+G9YVJSl2KK9/v4fRoMsWApztNy2qNgee+UguNBCOU6JLa3rVSj8Z5OVVDtJkGFrSvVg==}
     cpu: [ia32]
     os: [win32]
 
@@ -3011,11 +3109,31 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rspack/binding-win32-x64-msvc@1.2.3':
+    resolution: {integrity: sha512-fcU532PgFdd5Bil8jwQW0Dcb/80oM6V0qSstGIxZ4M77t4t8e/PcukXfORTL71FfNQ64Rd4Dp6XRl1NHNJVxeg==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding@1.2.2':
     resolution: {integrity: sha512-GCZwpGFYlLTdJ2soPLwjw9z4LSZ+GdpbHNfBt3Cm/f/bAF8n6mZc7dHUqN893RFh7MPU17HNEL3fMw7XR+6pHg==}
 
+  '@rspack/binding@1.2.3':
+    resolution: {integrity: sha512-enpOXZPQOJO800wdWcR7H5Dx5UZfwkaT0D0xsHD53WbpI09Z2KJbLX7I/i1FLLy3K1KQTB+2FIHLVdRikasXZA==}
+
   '@rspack/core@1.2.2':
     resolution: {integrity: sha512-EeHAmY65Uj62hSbUKesbrcWGE7jfUI887RD03G++Gj8jS4WPHEu1TFODXNOXg6pa7zyIvs2BK0Bm16Kwz8AEaQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@rspack/tracing': ^1.x
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@rspack/tracing':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@1.2.3':
+    resolution: {integrity: sha512-BFgdUYf05/hjjY9Nlwq8DpWaRJN5w2kTl8ZJi20SRL60oAx+ZD2ABT+fsPhBiFSmfTZDdvGGIq5e3vfRzoIuqg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@rspack/tracing': ^1.x
@@ -4240,6 +4358,14 @@ packages:
 
   fdir@6.4.2:
     resolution: {integrity: sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fdir@6.4.3:
+    resolution: {integrity: sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -5851,9 +5977,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rsbuild-plugin-dts@0.4.1:
-    resolution: {integrity: sha512-9/GJ/U8vt7pvRJts8l/FX6f5HzT2/0LUlwCrCz4mvqHh7EF4DI/b1TWXehvR7OH5ORE3hQxmPAhW01eaHBT8IQ==}
-    engines: {node: '>=16.0.0'}
+  rsbuild-plugin-dts@0.5.2:
+    resolution: {integrity: sha512-DGYjgQ2bgbVedZLOeETvPa1QyNeWJaLIQtTp2lOxZs3SXG+fj4BpeOeKohwQNOa+YyfRRmu4z4T9xrfRucr4OA==}
+    engines: {node: '>=16.7.0'}
     peerDependencies:
       '@microsoft/api-extractor': ^7
       '@rsbuild/core': 1.x
@@ -6399,6 +6525,10 @@ packages:
     resolution: {integrity: sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.12:
+    resolution: {integrity: sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@1.0.1:
     resolution: {integrity: sha512-URZYihUbRPcGv95En+sz6MfghfIc2OJ1sv/RmhWZLouPY0/8Vo80viwPvg3dlaS9fuq7fQMEfgRRK7BBZThBEA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -6874,28 +7004,55 @@ snapshots:
   '@ast-grep/napi-darwin-arm64@0.33.1':
     optional: true
 
+  '@ast-grep/napi-darwin-arm64@0.35.0':
+    optional: true
+
   '@ast-grep/napi-darwin-x64@0.33.1':
+    optional: true
+
+  '@ast-grep/napi-darwin-x64@0.35.0':
     optional: true
 
   '@ast-grep/napi-linux-arm64-gnu@0.33.1':
     optional: true
 
+  '@ast-grep/napi-linux-arm64-gnu@0.35.0':
+    optional: true
+
   '@ast-grep/napi-linux-arm64-musl@0.33.1':
+    optional: true
+
+  '@ast-grep/napi-linux-arm64-musl@0.35.0':
     optional: true
 
   '@ast-grep/napi-linux-x64-gnu@0.33.1':
     optional: true
 
+  '@ast-grep/napi-linux-x64-gnu@0.35.0':
+    optional: true
+
   '@ast-grep/napi-linux-x64-musl@0.33.1':
+    optional: true
+
+  '@ast-grep/napi-linux-x64-musl@0.35.0':
     optional: true
 
   '@ast-grep/napi-win32-arm64-msvc@0.33.1':
     optional: true
 
+  '@ast-grep/napi-win32-arm64-msvc@0.35.0':
+    optional: true
+
   '@ast-grep/napi-win32-ia32-msvc@0.33.1':
     optional: true
 
+  '@ast-grep/napi-win32-ia32-msvc@0.35.0':
+    optional: true
+
   '@ast-grep/napi-win32-x64-msvc@0.33.1':
+    optional: true
+
+  '@ast-grep/napi-win32-x64-msvc@0.35.0':
     optional: true
 
   '@ast-grep/napi@0.33.1':
@@ -6909,6 +7066,18 @@ snapshots:
       '@ast-grep/napi-win32-arm64-msvc': 0.33.1
       '@ast-grep/napi-win32-ia32-msvc': 0.33.1
       '@ast-grep/napi-win32-x64-msvc': 0.33.1
+
+  '@ast-grep/napi@0.35.0':
+    optionalDependencies:
+      '@ast-grep/napi-darwin-arm64': 0.35.0
+      '@ast-grep/napi-darwin-x64': 0.35.0
+      '@ast-grep/napi-linux-arm64-gnu': 0.35.0
+      '@ast-grep/napi-linux-arm64-musl': 0.35.0
+      '@ast-grep/napi-linux-x64-gnu': 0.35.0
+      '@ast-grep/napi-linux-x64-musl': 0.35.0
+      '@ast-grep/napi-win32-arm64-msvc': 0.35.0
+      '@ast-grep/napi-win32-ia32-msvc': 0.35.0
+      '@ast-grep/napi-win32-x64-msvc': 0.35.0
 
   '@babel/code-frame@7.25.7':
     dependencies:
@@ -8095,16 +8264,16 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.20.0':
     optional: true
 
-  '@rsbuild/core@1.2.3':
+  '@rsbuild/core@1.2.11':
     dependencies:
-      '@rspack/core': 1.2.2(@swc/helpers@0.5.15)
+      '@rspack/core': 1.2.3(@swc/helpers@0.5.15)
       '@rspack/lite-tapable': 1.0.1
       '@swc/helpers': 0.5.15
       core-js: 3.40.0
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rsbuild/core@1.2.5':
+  '@rsbuild/core@1.2.3':
     dependencies:
       '@rspack/core': 1.2.2(@swc/helpers@0.5.15)
       '@rspack/lite-tapable': 1.0.1
@@ -8133,30 +8302,30 @@ snapshots:
       deepmerge: 4.3.1
       reduce-configs: 1.0.0
 
+  '@rsbuild/plugin-react@1.1.0(@rsbuild/core@1.2.11)':
+    dependencies:
+      '@rsbuild/core': 1.2.11
+      '@rspack/plugin-react-refresh': 1.0.0(react-refresh@0.16.0)
+      react-refresh: 0.16.0
+
   '@rsbuild/plugin-react@1.1.0(@rsbuild/core@1.2.3)':
     dependencies:
       '@rsbuild/core': 1.2.3
       '@rspack/plugin-react-refresh': 1.0.0(react-refresh@0.16.0)
       react-refresh: 0.16.0
 
-  '@rsbuild/plugin-react@1.1.0(@rsbuild/core@1.2.5)':
+  '@rsbuild/plugin-sass@1.2.0(@rsbuild/core@1.2.11)':
     dependencies:
-      '@rsbuild/core': 1.2.5
-      '@rspack/plugin-react-refresh': 1.0.0(react-refresh@0.16.0)
-      react-refresh: 0.16.0
-
-  '@rsbuild/plugin-sass@1.2.0(@rsbuild/core@1.2.3)':
-    dependencies:
-      '@rsbuild/core': 1.2.3
+      '@rsbuild/core': 1.2.11
       deepmerge: 4.3.1
       loader-utils: 2.0.4
       postcss: 8.5.1
       reduce-configs: 1.1.0
       sass-embedded: 1.83.4
 
-  '@rsbuild/plugin-sass@1.2.0(@rsbuild/core@1.2.5)':
+  '@rsbuild/plugin-sass@1.2.0(@rsbuild/core@1.2.3)':
     dependencies:
-      '@rsbuild/core': 1.2.5
+      '@rsbuild/core': 1.2.3
       deepmerge: 4.3.1
       loader-utils: 2.0.4
       postcss: 8.5.1
@@ -8174,10 +8343,10 @@ snapshots:
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-svgr@1.0.6(@rsbuild/core@1.2.5)(typescript@5.5.3)':
+  '@rsbuild/plugin-svgr@1.0.6(@rsbuild/core@1.2.11)(typescript@5.5.3)':
     dependencies:
-      '@rsbuild/core': 1.2.5
-      '@rsbuild/plugin-react': 1.1.0(@rsbuild/core@1.2.5)
+      '@rsbuild/core': 1.2.11
+      '@rsbuild/plugin-react': 1.1.0(@rsbuild/core@1.2.11)
       '@svgr/core': 8.1.0(typescript@5.5.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.5.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.5.3))(typescript@5.5.3)
@@ -8187,33 +8356,33 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rslib/core@0.4.1(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)':
+  '@rslib/core@0.5.2(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.5.3)':
     dependencies:
-      '@rsbuild/core': 1.2.5
-      rsbuild-plugin-dts: 0.4.1(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(@rsbuild/core@1.2.5)(typescript@5.5.3)
-      tinyglobby: 0.2.10
+      '@rsbuild/core': 1.2.11
+      rsbuild-plugin-dts: 0.5.2(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(@rsbuild/core@1.2.11)(typescript@5.5.3)
+      tinyglobby: 0.2.12
     optionalDependencies:
       '@microsoft/api-extractor': 7.49.2(@types/node@18.11.17)
       typescript: 5.5.3
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rslib/core@0.4.1(@microsoft/api-extractor@7.49.2(@types/node@22.10.2))(typescript@5.5.3)':
+  '@rslib/core@0.5.2(@microsoft/api-extractor@7.49.2(@types/node@22.10.2))(typescript@5.5.3)':
     dependencies:
-      '@rsbuild/core': 1.2.5
-      rsbuild-plugin-dts: 0.4.1(@microsoft/api-extractor@7.49.2(@types/node@22.10.2))(@rsbuild/core@1.2.5)(typescript@5.5.3)
-      tinyglobby: 0.2.10
+      '@rsbuild/core': 1.2.11
+      rsbuild-plugin-dts: 0.5.2(@microsoft/api-extractor@7.49.2(@types/node@22.10.2))(@rsbuild/core@1.2.11)(typescript@5.5.3)
+      tinyglobby: 0.2.12
     optionalDependencies:
       '@microsoft/api-extractor': 7.49.2(@types/node@22.10.2)
       typescript: 5.5.3
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rslib/core@0.4.1(@microsoft/api-extractor@7.49.2(@types/node@22.10.2))(typescript@5.7.2)':
+  '@rslib/core@0.5.2(@microsoft/api-extractor@7.49.2(@types/node@22.10.2))(typescript@5.7.2)':
     dependencies:
-      '@rsbuild/core': 1.2.5
-      rsbuild-plugin-dts: 0.4.1(@microsoft/api-extractor@7.49.2(@types/node@22.10.2))(@rsbuild/core@1.2.5)(typescript@5.7.2)
-      tinyglobby: 0.2.10
+      '@rsbuild/core': 1.2.11
+      rsbuild-plugin-dts: 0.5.2(@microsoft/api-extractor@7.49.2(@types/node@22.10.2))(@rsbuild/core@1.2.11)(typescript@5.7.2)
+      tinyglobby: 0.2.12
     optionalDependencies:
       '@microsoft/api-extractor': 7.49.2(@types/node@22.10.2)
       typescript: 5.7.2
@@ -8223,28 +8392,55 @@ snapshots:
   '@rspack/binding-darwin-arm64@1.2.2':
     optional: true
 
+  '@rspack/binding-darwin-arm64@1.2.3':
+    optional: true
+
   '@rspack/binding-darwin-x64@1.2.2':
+    optional: true
+
+  '@rspack/binding-darwin-x64@1.2.3':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@1.2.2':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@1.2.3':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@1.2.2':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@1.2.3':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@1.2.2':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@1.2.3':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@1.2.2':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@1.2.3':
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@1.2.2':
     optional: true
 
+  '@rspack/binding-win32-arm64-msvc@1.2.3':
+    optional: true
+
   '@rspack/binding-win32-ia32-msvc@1.2.2':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@1.2.3':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@1.2.2':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@1.2.3':
     optional: true
 
   '@rspack/binding@1.2.2':
@@ -8259,10 +8455,31 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.2.2
       '@rspack/binding-win32-x64-msvc': 1.2.2
 
+  '@rspack/binding@1.2.3':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 1.2.3
+      '@rspack/binding-darwin-x64': 1.2.3
+      '@rspack/binding-linux-arm64-gnu': 1.2.3
+      '@rspack/binding-linux-arm64-musl': 1.2.3
+      '@rspack/binding-linux-x64-gnu': 1.2.3
+      '@rspack/binding-linux-x64-musl': 1.2.3
+      '@rspack/binding-win32-arm64-msvc': 1.2.3
+      '@rspack/binding-win32-ia32-msvc': 1.2.3
+      '@rspack/binding-win32-x64-msvc': 1.2.3
+
   '@rspack/core@1.2.2(@swc/helpers@0.5.15)':
     dependencies:
       '@module-federation/runtime-tools': 0.8.4
       '@rspack/binding': 1.2.2
+      '@rspack/lite-tapable': 1.0.1
+      caniuse-lite: 1.0.30001668
+    optionalDependencies:
+      '@swc/helpers': 0.5.15
+
+  '@rspack/core@1.2.3(@swc/helpers@0.5.15)':
+    dependencies:
+      '@module-federation/runtime-tools': 0.8.4
+      '@rspack/binding': 1.2.3
       '@rspack/lite-tapable': 1.0.1
       caniuse-lite: 1.0.30001668
     optionalDependencies:
@@ -9654,6 +9871,10 @@ snapshots:
       format: 0.2.2
 
   fdir@6.4.2(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
+
+  fdir@6.4.3(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
 
@@ -11699,43 +11920,49 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.20.0
       fsevents: 2.3.3
 
-  rsbuild-plugin-dts@0.4.1(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(@rsbuild/core@1.2.5)(typescript@5.5.3):
+  rsbuild-plugin-dts@0.5.2(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(@rsbuild/core@1.2.11)(typescript@5.5.3):
     dependencies:
-      '@rsbuild/core': 1.2.5
+      '@ast-grep/napi': 0.35.0
+      '@rsbuild/core': 1.2.11
       magic-string: 0.30.17
       picocolors: 1.1.1
-      tinyglobby: 0.2.10
+      tinyglobby: 0.2.12
+      tsconfig-paths: 4.2.0
     optionalDependencies:
       '@microsoft/api-extractor': 7.49.2(@types/node@18.11.17)
       typescript: 5.5.3
 
-  rsbuild-plugin-dts@0.4.1(@microsoft/api-extractor@7.49.2(@types/node@22.10.2))(@rsbuild/core@1.2.5)(typescript@5.5.3):
+  rsbuild-plugin-dts@0.5.2(@microsoft/api-extractor@7.49.2(@types/node@22.10.2))(@rsbuild/core@1.2.11)(typescript@5.5.3):
     dependencies:
-      '@rsbuild/core': 1.2.5
+      '@ast-grep/napi': 0.35.0
+      '@rsbuild/core': 1.2.11
       magic-string: 0.30.17
       picocolors: 1.1.1
-      tinyglobby: 0.2.10
+      tinyglobby: 0.2.12
+      tsconfig-paths: 4.2.0
     optionalDependencies:
       '@microsoft/api-extractor': 7.49.2(@types/node@22.10.2)
       typescript: 5.5.3
 
-  rsbuild-plugin-dts@0.4.1(@microsoft/api-extractor@7.49.2(@types/node@22.10.2))(@rsbuild/core@1.2.5)(typescript@5.7.2):
+  rsbuild-plugin-dts@0.5.2(@microsoft/api-extractor@7.49.2(@types/node@22.10.2))(@rsbuild/core@1.2.11)(typescript@5.7.2):
     dependencies:
-      '@rsbuild/core': 1.2.5
+      '@ast-grep/napi': 0.35.0
+      '@rsbuild/core': 1.2.11
       magic-string: 0.30.17
       picocolors: 1.1.1
-      tinyglobby: 0.2.10
+      tinyglobby: 0.2.12
+      tsconfig-paths: 4.2.0
     optionalDependencies:
       '@microsoft/api-extractor': 7.49.2(@types/node@22.10.2)
       typescript: 5.7.2
 
-  rsbuild-plugin-google-analytics@1.0.3(@rsbuild/core@1.2.5):
+  rsbuild-plugin-google-analytics@1.0.3(@rsbuild/core@1.2.11):
     optionalDependencies:
-      '@rsbuild/core': 1.2.5
+      '@rsbuild/core': 1.2.11
 
-  rsbuild-plugin-open-graph@1.0.2(@rsbuild/core@1.2.5):
+  rsbuild-plugin-open-graph@1.0.2(@rsbuild/core@1.2.11):
     optionalDependencies:
-      '@rsbuild/core': 1.2.5
+      '@rsbuild/core': 1.2.11
 
   rslog@1.1.0: {}
 
@@ -12268,6 +12495,11 @@ snapshots:
   tinyglobby@0.2.10:
     dependencies:
       fdir: 6.4.2(picomatch@4.0.2)
+      picomatch: 4.0.2
+
+  tinyglobby@0.2.12:
+    dependencies:
+      fdir: 6.4.3(picomatch@4.0.2)
       picomatch: 4.0.2
 
   tinypool@1.0.1: {}


### PR DESCRIPTION
## Summary

Rslib v0.5.2 support bundle DTS of multiple entries

## Related Issue

https://github.com/web-infra-dev/rslib/releases/tag/v0.5.2

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
