### PR TITLE
perf(search): add index async to avoid blocking the main thread

### DIFF
--- a/packages/theme-default/src/components/Search/logic/providers/LocalProvider.ts
+++ b/packages/theme-default/src/components/Search/logic/providers/LocalProvider.ts
@@ -119,9 +119,9 @@ export class LocalProvider implements Provider {
     });
     for (const item of pagesForSearch) {
       // Add search index async to avoid blocking the main thread
-      this.#index!.addAsync(item);
-      this.#cjkIndex!.addAsync(item);
-      this.#cyrillicIndex!.addAsync(item);
+      this.#index!.addAsync(item.id, item);
+      this.#cjkIndex!.addAsync(item.id, item);
+      this.#cyrillicIndex!.addAsync(item.id, item);
     }
   }
 

--- a/packages/theme-default/src/components/Search/logic/providers/LocalProvider.ts
+++ b/packages/theme-default/src/components/Search/logic/providers/LocalProvider.ts
@@ -118,9 +118,10 @@ export class LocalProvider implements Provider {
       tokenize: (str: string) => tokenize(str, cyrillicRegex),
     });
     for (const item of pagesForSearch) {
-      this.#index!.add(item);
-      this.#cjkIndex!.add(item);
-      this.#cyrillicIndex!.add(item);
+      // Add search index async to avoid blocking the main thread
+      this.#index!.addAsync(item);
+      this.#cjkIndex!.addAsync(item);
+      this.#cyrillicIndex!.addAsync(item);
     }
   }
 


### PR DESCRIPTION
## Summary

Currently the `searchIndex.add` is quite slow and will block the main thread.

This PR uses `addAsync` to replace `add` to avoid blocking the main thread.

- before:

<img width="268" alt="Screenshot 2025-03-02 at 09 38 52" src="https://github.com/user-attachments/assets/faa2680b-296f-4e0a-8b61-f108cd183364" />

- after:

<img width="267" alt="Screenshot 2025-03-02 at 09 38 43" src="https://github.com/user-attachments/assets/590495fd-80fa-4f21-abb8-2efeb9d5d60d" />


## Related Issue

- https://github.com/nextapps-de/flexsearch?tab=readme-ov-file#api-overview
- https://github.com/nextapps-de/flexsearch/blob/5bcbc72dac5118c049aac040a7621d5677c7e0d6/index.d.ts#L388

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
