### PR TITLE
perf(search): remove group calculation

### DIFF
--- a/packages/theme-default/src/components/Search/SearchPanel.tsx
+++ b/packages/theme-default/src/components/Search/SearchPanel.tsx
@@ -11,7 +11,6 @@ import { debounce } from 'lodash-es';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import * as userSearchHooks from 'virtual-search-hooks';
-import { getSidebarDataGroup } from '../../logic/getSidebarDataGroup';
 import { useLocaleSiteData } from '../../logic/useLocaleSiteData';
 import { SvgWrapper } from '../SvgWrapper';
 import { Tab, Tabs } from '../Tabs';
@@ -115,8 +114,7 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
     siteData,
     page: { lang, version },
   } = usePageData();
-  const { sidebar, searchPlaceholderText = 'Search Docs' } =
-    useLocaleSiteData();
+  const { searchPlaceholderText = 'Search Docs' } = useLocaleSiteData();
   const { search, title: siteTitle } = siteData;
   const versionedSearch =
     search && search.mode !== 'remote' && search.versioned;

--- a/packages/theme-default/src/components/Search/SearchPanel.tsx
+++ b/packages/theme-default/src/components/Search/SearchPanel.tsx
@@ -128,10 +128,6 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
   const currentRenderType =
     searchResult[resultTabIndex]?.renderType ?? RenderType.Default;
 
-  // We need to extract the group name by the link so that we can divide the search result into different groups.
-  const extractGroupName = (link: string) =>
-    getSidebarDataGroup(sidebar, link).group;
-
   async function initPageSearcher() {
     if (search === false) {
       return;
@@ -139,7 +135,6 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
     const pageSearcherConfig = {
       currentLang: lang,
       currentVersion: version,
-      extractGroupName,
     };
     const pageSearcher = new PageSearcher({
       indexName: siteTitle,
@@ -353,7 +348,7 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
   ): Record<string, DefaultMatchResultItem[]> => {
     return suggestions.reduce(
       (groups, item) => {
-        const group = item.group;
+        const group = item.title;
         if (!groups[group]) {
           groups[group] = [];
         }

--- a/packages/theme-default/src/components/Search/logic/search.ts
+++ b/packages/theme-default/src/components/Search/logic/search.ts
@@ -120,7 +120,6 @@ export class PageSearcher {
             length: getStrByteLength(query),
           },
         ],
-        group: this.#options.extractGroupName(item.routePath),
       });
       return true;
     }
@@ -160,7 +159,6 @@ export class PageSearcher {
           ],
           link: `${domain}${normalizeHref(item.routePath)}#${header.id}`,
           query,
-          group: this.#options.extractGroupName(item.routePath),
         });
         matchHeaderSet.add(header);
       }
@@ -248,7 +246,6 @@ export class PageSearcher {
         }`,
         query,
         highlightInfoList,
-        group: this.#options.extractGroupName(item.routePath),
         statement: `...${statement}...`,
       });
       return;
@@ -284,7 +281,6 @@ export class PageSearcher {
             currentHeader ? `#${currentHeader.id}` : ''
           }`,
           query,
-          group: this.#options.extractGroupName(item.routePath),
         });
         // 同一区块只匹配一次
         currentHeader && matchHeaderSet?.add(currentHeader);

--- a/packages/theme-default/src/components/Search/logic/types.ts
+++ b/packages/theme-default/src/components/Search/logic/types.ts
@@ -16,7 +16,6 @@ interface CommonMatchResult {
   link: string;
   query: string;
   highlightInfoList: HighlightInfo[];
-  group: string;
 }
 
 interface TitleMatch extends CommonMatchResult {
@@ -54,7 +53,6 @@ export type MatchResult = (DefaultMatchResult | CustomMatchResult)[];
 export type PageSearcherConfig = {
   currentLang: string;
   currentVersion: string;
-  extractGroupName: (path: string) => string;
 };
 
 export type SearchOptions = (LocalSearchOptions | RemoteSearchOptions) &

--- a/packages/theme-default/src/components/Search/logic/util.ts
+++ b/packages/theme-default/src/components/Search/logic/util.ts
@@ -40,12 +40,13 @@ export function formatText(text: string) {
 
 export function normalizeTextCase(text: string | number) {
   const textNormalized = text.toString().toLowerCase().normalize('NFD');
-  const resultWithAccents = textNormalized;
+
+  if (cyrillicRegex.test(String(text))) {
+    return textNormalized.normalize('NFC');
+  }
+
   // biome-ignore lint/suspicious/noMisleadingCharacterClass: temporarily ignore
   const resultWithoutAccents = textNormalized.replace(/[\u0300-\u036f]/g, '');
-  if (cyrillicRegex.test(String(text))) {
-    return resultWithAccents.normalize('NFC');
-  }
   if (kRegex.test(String(text))) {
     return resultWithoutAccents.normalize('NFC');
   }

--- a/packages/theme-default/src/logic/useFullTextSearch.ts
+++ b/packages/theme-default/src/logic/useFullTextSearch.ts
@@ -2,8 +2,6 @@ import { usePageData } from '@rspress/runtime';
 import { useEffect, useRef, useState } from 'react';
 import type { MatchResult } from '..';
 import { PageSearcher } from '../components/Search/logic/search';
-import { getSidebarDataGroup } from './getSidebarDataGroup';
-import { useLocaleSiteData } from './useLocaleSiteData';
 
 export function useFullTextSearch(): {
   initialized: boolean;
@@ -11,9 +9,6 @@ export function useFullTextSearch(): {
 } {
   const { siteData, page } = usePageData();
   const [initialized, setInitialized] = useState(false);
-  const { sidebar } = useLocaleSiteData();
-  const extractGroupName = (link: string) =>
-    getSidebarDataGroup(sidebar, link).group;
   const searchRef = useRef<PageSearcher | null>(null);
 
   useEffect(() => {
@@ -24,7 +19,6 @@ export function useFullTextSearch(): {
           mode: 'local',
           currentLang: page.lang,
           currentVersion: page.version,
-          extractGroupName,
         });
         searchRef.current = searcher;
         await searcher.init();


### PR DESCRIPTION
## Summary

The `getSidebarDataGroup` can be very slow when there are thousands of routes.

![20250302-132252](https://github.com/user-attachments/assets/cf20bb06-72fa-4a2b-a466-fcfa644ad7c3)

This PR removed the group calculation and use `item.title` to group the search results.

In the future, the sorting of search results should be better implemented (for example, according to some weight indicators we agree on, such as title > content > code).

## Related PR

Performance regression since https://github.com/web-infra-dev/rspress/pull/1863

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
