### PR TITLE
fix(search): should use `index.searchAsync`

### DIFF
--- a/packages/theme-default/src/components/Search/logic/providers/LocalProvider.ts
+++ b/packages/theme-default/src/components/Search/logic/providers/LocalProvider.ts
@@ -135,9 +135,9 @@ export class LocalProvider implements Provider {
     };
 
     const searchResult = await Promise.all([
-      this.#index?.search<true>(keyword, limit, options),
-      this.#cjkIndex?.search<true>(keyword, limit, options),
-      this.#cyrillicIndex?.search<true>(keyword, limit, options),
+      this.#index?.searchAsync<true>(keyword, options),
+      this.#cjkIndex?.searchAsync<true>(keyword, options),
+      this.#cyrillicIndex?.searchAsync<true>(keyword, options),
     ]);
 
     const combinedSearchResult: PageIndexInfo[] = [];


### PR DESCRIPTION
## Summary

We should use `index.searchAsync` as it doesn't make sense to use `Promise.all` to run sync methods.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
