### PR TITLE
perf(search): improve initialization and prefetching logic

### DIFF
--- a/packages/theme-default/src/components/Search/SearchPanel.tsx
+++ b/packages/theme-default/src/components/Search/SearchPanel.tsx
@@ -159,7 +159,7 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
    * Call `searcher.init` to initialize the search index
    */
   async function initSearch() {
-    if (initStatus === 'inited' || initStatus === 'initing') {
+    if (initStatus !== 'initial') {
       return;
     }
 

--- a/packages/theme-default/src/components/Search/SearchPanel.tsx
+++ b/packages/theme-default/src/components/Search/SearchPanel.tsx
@@ -296,6 +296,10 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
 
   // init pageSearcher again when lang or version changed
   useEffect(() => {
+    if (initStatus === 'initial') {
+      return;
+    }
+
     const { currentLang, currentVersion } = pageSearcherConfigRef.current ?? {};
     const isLangChanged = lang !== currentLang;
     const isVersionChanged = versionedSearch && version !== currentVersion;

--- a/packages/theme-default/src/components/Search/logic/Provider.ts
+++ b/packages/theme-default/src/components/Search/logic/Provider.ts
@@ -27,6 +27,13 @@ export abstract class Provider {
   }
 
   /**
+   * Fetch the search index
+   */
+  async fetchSearchIndex(_options: SearchOptions): Promise<PageIndexInfo[]> {
+    throw new Error('Not implemented');
+  }
+
+  /**
    * Search the pages according to the query
    */
   search(_query: SearchQuery): Promise<NormalizedSearchResult> {

--- a/packages/theme-default/src/components/Search/logic/providers/RemoteProvider.ts
+++ b/packages/theme-default/src/components/Search/logic/providers/RemoteProvider.ts
@@ -15,6 +15,10 @@ export class RemoteProvider implements Provider {
     this.#options = options;
   }
 
+  async fetchSearchIndex(_options: SearchOptions) {
+    return [];
+  }
+
   async search(query: SearchQuery) {
     const { apiUrl, searchIndexes } = this.#options as RemoteSearchOptions;
     const { keyword, limit } = query;

--- a/packages/theme-default/src/components/Search/logic/search.ts
+++ b/packages/theme-default/src/components/Search/logic/search.ts
@@ -46,6 +46,10 @@ export class PageSearcher {
     await this.#provider?.init(this.#options);
   }
 
+  async fetchSearchIndex() {
+    return this.#provider?.fetchSearchIndex(this.#options);
+  }
+
   async match(keyword: string, limit = 7) {
     const searchResult = await this.#provider?.search({ keyword, limit });
     const normalizedKeyWord = normalizeTextCase(keyword);

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -52,6 +52,7 @@ idents
 iife
 imagex
 initing
+inited
 jfif
 jiti
 jscpuprofile


### PR DESCRIPTION
## Summary

For large sites, initializing the search while the page is idle may cause the page to render slowly.

To address this issue, this PR splits search init into two steps: prefetch and init:

- prefetch the search index when the page is idle
- init the search when the search bar is focused.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
