### PR TITLE
chore(plugin-algolia): correct peer dependency version

### DIFF
--- a/packages/modern-plugin-rspress/package.json
+++ b/packages/modern-plugin-rspress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/modern-js-plugin",
-  "version": "1.42.1",
+  "version": "2.0.0-alpha.0",
   "description": "A Modern.js plugin to integrate rspress",
   "keywords": [
     "react",

--- a/packages/plugin-algolia/package.json
+++ b/packages/plugin-algolia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/plugin-algolia",
-  "version": "1.42.1",
+  "version": "2.0.0-alpha.0",
   "description": "A plugin for rspress to search with algolia in docs.",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {
@@ -40,7 +40,7 @@
     "typescript": "^5.5.3"
   },
   "peerDependencies": {
-    "@rspress/runtime": "workspace:^1.42.1"
+    "@rspress/runtime": "workspace:^2.0.0-alpha.0"
   },
   "engines": {
     "node": ">=14.17.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -992,7 +992,7 @@ importers:
   packages/plugin-algolia:
     dependencies:
       '@rspress/runtime':
-        specifier: workspace:^1.42.1
+        specifier: workspace:^2.0.0-alpha.0
         version: link:../runtime
     devDependencies:
       '@microsoft/api-extractor':


### PR DESCRIPTION
## Summary

Correct the peer dependency version of `plugin-algolia`.

Fix rsbuild-ecosystem-ci: https://github.com/rspack-contrib/rsbuild-ecosystem-ci/actions/runs/13745538869/job/38439970095

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
