### PR TITLE
fix: remove outdated hero default values

### DIFF
--- a/packages/theme-default/src/components/HomeHero/index.tsx
+++ b/packages/theme-default/src/components/HomeHero/index.tsx
@@ -7,9 +7,9 @@ import { renderHtmlOrText } from '../../logic/utils';
 import styles from './index.module.scss';
 
 const DEFAULT_HERO = {
-  name: 'modern',
-  text: 'modern ssg',
-  tagline: 'modern ssg',
+  name: '',
+  text: '',
+  tagline: '',
   actions: [],
   image: undefined,
 } satisfies FrontMatterMeta['hero'];
@@ -65,7 +65,7 @@ export function HomeHero({
           >
             {renderHtmlOrText(hero.tagline)}
           </p>
-          {hero.actions?.length && (
+          {hero.actions?.length ? (
             <div className="grid md:flex md:flex-wrap md:justify-center gap-3 m--1.5 pt-6 sm:pt-8 z-10">
               {hero.actions.map(action => {
                 const link = isExternalUrl(action.link)
@@ -84,7 +84,7 @@ export function HomeHero({
                 );
               })}
             </div>
-          )}
+          ) : null}
         </div>
 
         {hasImage ? (


### PR DESCRIPTION
## Summary

Remove outdated hero default values. If the title or tagline in the hero is empty, the corresponding elements should not be rendered.

Fix:

<img width="840" alt="Screenshot 2025-03-09 at 22 17 26" src="https://github.com/user-attachments/assets/3b77c8bf-602b-4e3c-9b16-93b4969ce030" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
