### PR TITLE
fix: remove async fs to avoid empty global style

### DIFF
--- a/packages/core/src/node/runtimeModule/globalStyles.ts
+++ b/packages/core/src/node/runtimeModule/globalStyles.ts
@@ -1,23 +1,8 @@
-import fs from 'node:fs/promises';
 import { type FactoryContext, RuntimeModuleID } from '.';
 
 export async function globalStylesVMPlugin(context: FactoryContext) {
   const { config, pluginDriver } = context;
   const globalStylesByPlugins = pluginDriver.globalStyles();
-
-  if (config.globalStyles) {
-    // Only patch user config global styles
-    const source = config.globalStyles;
-    const styleContent = await fs.readFile(source, 'utf-8');
-
-    // Patch --modern-abc, .modern-abc global name
-    const patchedStyleContent = styleContent
-      .replace(/--modern-/g, '--rp-')
-      .replace(/\.modern-doc/g, '.rspress')
-      .replace(/\.modern-/g, '.rspress-');
-
-    await fs.writeFile(source, patchedStyleContent, 'utf-8');
-  }
 
   const moduleContent = (
     await Promise.all(


### PR DESCRIPTION
## Summary

Occasionally rspack website does not bundle the global-style file during deployment.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/18178fe3-9cfe-49b2-8a86-be26e74676bd" />


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
