### PR TITLE
fix(cli): should catch build errors

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -110,11 +110,16 @@ cli.command('build [root]').action(async (root, options) => {
   config.root = resolveDocRoot(cwd, root, config.root);
   const docDirectory = config.root;
 
-  await build({
-    appDirectory: cwd,
-    docDirectory,
-    config,
-  });
+  try {
+    await build({
+      appDirectory: cwd,
+      docDirectory,
+      config,
+    });
+  } catch (err) {
+    logger.error(err);
+    process.exit(1);
+  }
 });
 
 cli


### PR DESCRIPTION
## Summary

Should catch build errors when running the `build()` method.

### before

<img width="1246" alt="Screenshot 2025-03-11 at 13 32 32" src="https://github.com/user-attachments/assets/5ce6d096-48d6-40d6-893a-108cf51f3c18" />

### after

<img width="1250" alt="Screenshot 2025-03-11 at 13 40 15" src="https://github.com/user-attachments/assets/c40d53b7-94f6-4142-a4c7-f3c73b63a468" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
