### PR TITLE
fix(theme): unset overflow style when sidebar destroy

### DIFF
--- a/packages/theme-default/src/components/Sidebar/index.tsx
+++ b/packages/theme-default/src/components/Sidebar/index.tsx
@@ -88,6 +88,11 @@ export function Sidebar(props: Props) {
         document.body.style.overflow = bodyStyleOverflow || '';
       }
     }
+    return () => {
+      if (inBrowser()) {
+        document.body.style.overflow = bodyStyleOverflow || '';
+      }
+    };
   }, [isSidebarOpen]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

unset overflow style when sidebar destroy

## Related Issue

close https://github.com/web-infra-dev/rspress/issues/1828

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
