### PR TITLE
fix(deps): update react-helmet-async 2.0.0

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -23,7 +23,13 @@ export default defineConfig({
         distPath: {
           root: './dist',
         },
-        externals: ['jsdom', 'tailwindcss'],
+        externals: [
+          'jsdom',
+          'tailwindcss',
+          {
+            'react-helmet-async': 'react-helmet-async/lib/index.esm.js',
+          },
+        ],
       },
     },
     {


### PR DESCRIPTION
## Summary

fix

<img width="400" alt="image" src="https://github.com/user-attachments/assets/8964c7c3-6bdf-464c-beb4-0ffe6767d69a" />

## Investigation

```json
{
  "name": "react-helmet-async",
  "version": "2.0.5",
  "description": "Thread-safe Helmet for React 16+ and friends",
  "sideEffects": false,
  "main": "./lib/index.js",
  "module": "./lib/index.esm.js",
  "typings": "./lib/index.d.ts",
 }
```

"./lib/index.esm.js" does not end with 'mjs' extension so that "main" field is used, there is a problem in interop process



## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
