### PR TITLE
feat: enable `search.codeBlocks` by default

### DIFF
--- a/e2e/fixtures/search-code-blocks/rspress.config.ts
+++ b/e2e/fixtures/search-code-blocks/rspress.config.ts
@@ -3,7 +3,4 @@ import { defineConfig } from 'rspress/config';
 
 export default defineConfig({
   root: path.join(__dirname, 'doc'),
-  search: {
-    codeBlocks: true,
-  },
 });

--- a/packages/core/src/node/runtimeModule/siteData/index.ts
+++ b/packages/core/src/node/runtimeModule/siteData/index.ts
@@ -51,7 +51,7 @@ export async function siteDataVMPlugin(context: FactoryContext) {
     searchConfig?.mode === 'remote' ? (searchConfig.domain ?? '') : '';
 
   const searchCodeBlocks =
-    'codeBlocks' in searchConfig ? Boolean(searchConfig.codeBlocks) : false;
+    'codeBlocks' in searchConfig ? Boolean(searchConfig.codeBlocks) : true;
 
   const pages = await extractPageData(
     replaceRules,

--- a/packages/document/docs/en/api/config/config-basic.mdx
+++ b/packages/document/docs/en/api/config/config-basic.mdx
@@ -312,16 +312,16 @@ export default defineConfig({
 ### codeBlocks
 
 - Type: `boolean`
-- Default: `false`
+- Default: `true`
 
-If enabled, the search index will include code block content, which allows users to search code blocks.
+Whether to include code block content in the search index, which allows users to search code blocks.
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';
 
 export default defineConfig({
   search: {
-    codeBlocks: true,
+    codeBlocks: false,
   },
 });
 ```

--- a/packages/document/docs/zh/api/config/config-basic.mdx
+++ b/packages/document/docs/zh/api/config/config-basic.mdx
@@ -311,16 +311,16 @@ export default defineConfig({
 ### codeBlocks
 
 - Type: `boolean`
-- Default: `false`
+- Default: `true`
 
-开启后，搜索的索引将包含代码块的内容，从而允许用户搜索代码块。
+是否在搜索的索引中包含代码块的内容，这可以让用户搜索代码块。
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';
 
 export default defineConfig({
   search: {
-    codeBlocks: true,
+    codeBlocks: false,
   },
 });
 ```


### PR DESCRIPTION
## Summary

We added `search.codeBlocks` option in https://github.com/web-infra-dev/rspress/pull/1797.

After a period of trial, this feature has been proven to be stable and has brought better search results. So this PR enables `search.codeBlocks` by default.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
