### PR TITLE
docs: update i18n messages

### DIFF
--- a/packages/document/i18n.json
+++ b/packages/document/i18n.json
@@ -55,24 +55,12 @@
     "zh": "社区插件",
     "en": "Community Plugins"
   },
-  "start": {
-    "zh": "冷启动(Start)",
-    "en": "Code Start"
-  },
-  "hmr": {
-    "zh": "热更新",
-    "en": "HMR"
-  },
-  "build": {
-    "zh": "冷构建(Build)",
-    "en": "Code Build"
-  },
   "toolStackTitle": {
-    "zh": "工具栈",
-    "en": "Tool Stack"
+    "zh": "Rstack",
+    "en": "Rstack"
   },
   "toolStackDesc": {
-    "zh": "围绕 Rspack 打造的高性能工具栈，助力现代 Web 开发",
-    "en": "High-performance tool stack built around Rspack to boost modern web development"
+    "zh": "围绕 Rspack 打造的高性能工具链，助力现代 Web 开发",
+    "en": "High-performance toolchain built around Rspack to boost modern web development"
   }
 }

--- a/packages/document/rspress.config.ts
+++ b/packages/document/rspress.config.ts
@@ -57,7 +57,6 @@ export default defineConfig({
     exclude: ['**/fragments/**'],
   },
   themeConfig: {
-    enableContentAnimation: true,
     enableAppearanceAnimation: false,
     footer: {
       message: '© 2024 Bytedance Inc. All Rights Reserved.',


### PR DESCRIPTION
## Summary

- Update i18n messages to use `Rstack` instead of `Tool Stack`
- Remove `enableContentAnimation: true` config as switching from the API overview page to other pages will cause a horizontal shift effect.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
