### PR TITLE
fix(style): unset the navItem bg color

### DIFF
--- a/packages/plugin-algolia/src/runtime/Search.css
+++ b/packages/plugin-algolia/src/runtime/Search.css
@@ -3,6 +3,12 @@
   --docsearch-searchbox-background: var(--rp-c-bg-mute);
 }
 
+@media (max-width: 768px) {
+  .DocSearch {
+    --docsearch-searchbox-background: transparent;
+  }
+}
+
 .DocSearch-Button-Container > .DocSearch-Button-Placeholder {
   font-size: 0.825rem;
 }

--- a/packages/theme-default/src/components/Nav/NavMenuSingleItem.tsx
+++ b/packages/theme-default/src/components/Nav/NavMenuSingleItem.tsx
@@ -12,7 +12,6 @@ interface Props {
   langs?: string[];
   base: string;
   rightIcon?: React.ReactNode;
-  compact?: boolean;
   onClick?: () => void;
 }
 
@@ -30,7 +29,7 @@ export function NavMenuSingleItem(
         key={item.text}
         className={`rspress-nav-menu-item ${styles.singleItem} ${
           isActive ? styles.activeItem : ''
-        } text-sm font-medium ${item.compact ? 'mx-0.5' : 'mx-1.5'} px-3 py-2 flex items-center`}
+        } text-sm font-medium mx-0.5 px-3 py-2 flex items-center`}
       >
         <Tag tag={item.tag} />
         {item.text}

--- a/packages/theme-default/src/components/Nav/index.module.scss
+++ b/packages/theme-default/src/components/Nav/index.module.scss
@@ -52,7 +52,6 @@
 
 .activeItem,
 .singleItem:hover {
-  background-color: var(--rp-c-bg-mute);
   cursor: pointer;
   color: var(--rp-c-link);
   border-radius: var(--rp-radius);

--- a/packages/theme-default/src/components/Nav/index.tsx
+++ b/packages/theme-default/src/components/Nav/index.tsx
@@ -72,7 +72,6 @@ export function Nav(props: NavProps) {
               langs={langs}
               base={base}
               key={item.link}
-              compact={menuItems.length > 5}
               {...item}
             />
           );


### PR DESCRIPTION
## Summary

### Before

<img width="1577" alt="image" src="https://github.com/user-attachments/assets/55a7c147-9ceb-4133-ae33-da365cafb1bb" />

### After

<img width="1554" alt="image" src="https://github.com/user-attachments/assets/ced742c5-d15e-45a3-896d-976330affe38" />

remove compact

<img width="1405" alt="image" src="https://github.com/user-attachments/assets/0625c6bd-2c16-4a0d-a0f2-29ab1e9e2e94" />




## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
