### PR TITLE
refactor(theme): use namedExport of cssModules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ playwright-report/
 # plugin-typedoc auto-generated files
 e2e/fixtures/plugin-typedoc/single/doc/api
 e2e/fixtures/plugin-typedoc/multi/doc/api
+
+# ignore typed css module
+*.scss.d.ts

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "rspress-monorepo",
   "private": true,
   "scripts": {
-    "build": "cross-env NX_DAEMON=false NX_REJECT_UNKNOWN_LOCAL_CACHE=0 nx run-many -t build --exclude @rspress-fixture/* --exclude @rspress/docs",
-    "build:website": "cross-env NX_DAEMON=false NX_REJECT_UNKNOWN_LOCAL_CACHE=0 nx run @rspress/docs:build",
+    "build": "cross-env NX_DAEMON=false nx run-many -t build --exclude @rspress-fixture/* --exclude @rspress/docs",
+    "build:website": "cross-env NX_DAEMON=false nx run @rspress/docs:build",
     "change": "changeset",
     "changeset": "changeset",
     "check-dependency-version": "check-dependency-version-consistency . --dep-type devDependencies",

--- a/packages/theme-default/package.json
+++ b/packages/theme-default/package.json
@@ -64,6 +64,7 @@
     "@rsbuild/plugin-react": "~1.1.1",
     "@rsbuild/plugin-sass": "~1.2.2",
     "@rsbuild/plugin-svgr": "^1.0.7",
+    "@rsbuild/plugin-typed-css-modules": "~1.0.2",
     "@rslib/core": "0.5.4",
     "@types/body-scroll-lock": "^3.1.2",
     "@types/hast": "^2.3.10",

--- a/packages/theme-default/rslib.config.ts
+++ b/packages/theme-default/rslib.config.ts
@@ -1,6 +1,7 @@
 import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginSass } from '@rsbuild/plugin-sass';
 import { pluginSvgr } from '@rsbuild/plugin-svgr';
+import { pluginTypedCSSModules } from '@rsbuild/plugin-typed-css-modules';
 import { defineConfig } from '@rslib/core';
 
 const COMMON_EXTERNALS = [
@@ -25,7 +26,12 @@ export default defineConfig({
     {
       format: 'esm',
       dts: { bundle: true },
-      plugins: [pluginReact(), pluginSvgr(), pluginSass()],
+      plugins: [
+        pluginReact(),
+        pluginSvgr(),
+        pluginSass(),
+        pluginTypedCSSModules(),
+      ],
       source: {
         define: {
           __WEBPACK_PUBLIC_PATH__: '__webpack_public_path__',
@@ -49,6 +55,8 @@ export default defineConfig({
         externals: COMMON_EXTERNALS,
         cssModules: {
           localIdentName: '[local]_[hash:hex:5]',
+          namedExport: true,
+          exportLocalsConvention: 'camelCaseOnly',
         },
         copy: {
           patterns: [

--- a/packages/theme-default/src/components/Badge/index.tsx
+++ b/packages/theme-default/src/components/Badge/index.tsx
@@ -1,4 +1,4 @@
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 interface BadgeProps {
   /**

--- a/packages/theme-default/src/components/Button/index.tsx
+++ b/packages/theme-default/src/components/Button/index.tsx
@@ -1,6 +1,6 @@
 import { Link } from '@theme';
 import React from 'react';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 interface ButtonProps {
   type?: string;

--- a/packages/theme-default/src/components/DocFooter/index.tsx
+++ b/packages/theme-default/src/components/DocFooter/index.tsx
@@ -5,7 +5,7 @@ import {
 import { EditLink, LastUpdated, PrevNextPage } from '@theme';
 import { useLocaleSiteData } from '../../logic/useLocaleSiteData';
 import { usePrevNextPage } from '../../logic/usePrevNextPage';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 export function DocFooter() {
   const { prevPage, nextPage } = usePrevNextPage();

--- a/packages/theme-default/src/components/EditLink/index.tsx
+++ b/packages/theme-default/src/components/EditLink/index.tsx
@@ -1,5 +1,5 @@
 import { useEditLink } from '../../logic/useEditLink';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 export function EditLink() {
   const editLinkObj = useEditLink();

--- a/packages/theme-default/src/components/HomeFeature/index.tsx
+++ b/packages/theme-default/src/components/HomeFeature/index.tsx
@@ -3,13 +3,24 @@ import { isExternalUrl, withBase } from '@rspress/shared';
 import type { Feature, FrontMatterMeta } from '@rspress/shared';
 
 import { renderHtmlOrText } from '../../logic/utils';
-import styles from './index.module.scss';
-
-const GRID_PREFIX = 'grid-';
+import * as styles from './index.module.scss';
 
 const getGridClass = (feature: Feature): string => {
   const { span } = feature;
-  return `${GRID_PREFIX}${span || 4}`;
+  switch (span) {
+    case 2:
+      return styles.grid2;
+    case 3:
+      return styles.grid3;
+    case 4:
+      return styles.grid4;
+    case 6:
+      return styles.grid6;
+    case undefined:
+      return styles.grid4;
+    default:
+      return '';
+  }
 };
 
 export function HomeFeature({
@@ -36,9 +47,9 @@ export function HomeFeature({
         return (
           <div
             key={title}
-            className={`${
-              styles[getGridClass(feature)]
-            } rounded hover:var(--rp-c-brand)`}
+            className={`${getGridClass(
+              feature,
+            )} rounded hover:var(--rp-c-brand)`}
           >
             <div className="h-full p-2">
               <article

--- a/packages/theme-default/src/components/HomeHero/index.tsx
+++ b/packages/theme-default/src/components/HomeHero/index.tsx
@@ -4,7 +4,7 @@ import type { FrontMatterMeta } from '@rspress/shared';
 import { Button } from '@theme';
 
 import { renderHtmlOrText } from '../../logic/utils';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 const DEFAULT_HERO = {
   name: '',

--- a/packages/theme-default/src/components/Link/index.tsx
+++ b/packages/theme-default/src/components/Link/index.tsx
@@ -11,7 +11,7 @@ import nprogress from 'nprogress';
 import type React from 'react';
 import type { ComponentProps } from 'react';
 import { scrollToTarget } from '../../logic/sideEffects';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 export interface LinkProps extends ComponentProps<'a'> {
   href?: string;

--- a/packages/theme-default/src/components/LinkCard/index.tsx
+++ b/packages/theme-default/src/components/LinkCard/index.tsx
@@ -1,5 +1,5 @@
 import ArrowRight from '@theme-assets/arrow-right';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 interface LinkCardProps {
   /**

--- a/packages/theme-default/src/components/Nav/NavBarTitle.tsx
+++ b/packages/theme-default/src/components/Nav/NavBarTitle.tsx
@@ -2,7 +2,7 @@ import { normalizeImagePath, usePageData } from '@rspress/runtime';
 import { Link } from '@theme';
 import { useMemo } from 'react';
 import { useLocaleSiteData } from '../../logic/useLocaleSiteData';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 export const NavBarTitle = () => {
   const { siteData } = usePageData();

--- a/packages/theme-default/src/components/Nav/NavMenuSingleItem.tsx
+++ b/packages/theme-default/src/components/Nav/NavMenuSingleItem.tsx
@@ -5,7 +5,7 @@ import {
   withoutBase,
 } from '@rspress/shared';
 import { Link, Tag } from '@theme';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 interface Props {
   pathname: string;

--- a/packages/theme-default/src/components/Nav/NavTranslations.tsx
+++ b/packages/theme-default/src/components/Nav/NavTranslations.tsx
@@ -1,5 +1,5 @@
 import { NavMenuGroup } from './NavMenuGroup';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 import { useTranslationMenuData } from './menuDataHooks';
 
 export function NavTranslations() {

--- a/packages/theme-default/src/components/Nav/NavVersions.tsx
+++ b/packages/theme-default/src/components/Nav/NavVersions.tsx
@@ -1,5 +1,5 @@
 import { NavMenuGroup } from './NavMenuGroup';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 import { useVersionMenuData } from './menuDataHooks';
 
 export function NavVersions() {

--- a/packages/theme-default/src/components/Nav/index.tsx
+++ b/packages/theme-default/src/components/Nav/index.tsx
@@ -13,7 +13,7 @@ import { NavMenuGroup } from './NavMenuGroup';
 import { NavMenuSingleItem } from './NavMenuSingleItem';
 import { NavTranslations } from './NavTranslations';
 import { NavVersions } from './NavVersions';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 export interface NavProps {
   beforeNav?: React.ReactNode;

--- a/packages/theme-default/src/components/NavHamburger/index.tsx
+++ b/packages/theme-default/src/components/NavHamburger/index.tsx
@@ -3,7 +3,7 @@ import SmallMenu from '@theme-assets/small-menu';
 import { useNavScreen } from '../../logic/useNav';
 import { NavScreen } from '../NavScreen';
 import { SvgWrapper } from '../SvgWrapper';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 interface Props {
   siteData: SiteData<DefaultThemeConfig>;

--- a/packages/theme-default/src/components/NavScreen/NavScreenMenuGroup.tsx
+++ b/packages/theme-default/src/components/NavScreen/NavScreenMenuGroup.tsx
@@ -7,7 +7,7 @@ import type {
 import { Link } from '@theme';
 import Down from '@theme-assets/down';
 import { useState } from 'react';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 export interface NavScreenMenuGroupItem {
   text?: string | React.ReactElement;

--- a/packages/theme-default/src/components/NavScreen/index.tsx
+++ b/packages/theme-default/src/components/NavScreen/index.tsx
@@ -12,7 +12,7 @@ import {
 import { SocialLinks } from '../SocialLinks';
 import { SwitchAppearance } from '../SwitchAppearance';
 import { NavScreenMenuGroup } from './NavScreenMenuGroup';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 interface Props {
   isScreenOpen: boolean;
@@ -35,9 +35,7 @@ const NavScreenTranslations = () => {
 const NavScreenVersions = () => {
   const versionMenuData = useVersionMenuData();
   return (
-    <div
-      className={`${styles.navTranslations} flex text-sm font-bold justify-center`}
-    >
+    <div className={'flex text-sm font-bold justify-center'}>
       <div className="mx-1.5 my-1">
         <NavScreenMenuGroup {...versionMenuData} />
       </div>

--- a/packages/theme-default/src/components/Overview/index.tsx
+++ b/packages/theme-default/src/components/Overview/index.tsx
@@ -16,7 +16,7 @@ import { useLocaleSiteData } from '../../logic/useLocaleSiteData';
 import { useSidebarData } from '../../logic/useSidebarData';
 import { renderInlineMarkdown } from '../../logic/utils';
 import { isSidebarDivider, isSidebarSingleFile } from '../Sidebar/utils';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 import { findItemByRoutePath } from './utils';
 
 interface GroupItem {

--- a/packages/theme-default/src/components/PrevNextPage/index.tsx
+++ b/packages/theme-default/src/components/PrevNextPage/index.tsx
@@ -1,7 +1,7 @@
 import { Link } from '@theme';
 import { useLocaleSiteData } from '../../logic/useLocaleSiteData';
 import { preloadLink } from '../Sidebar/utils';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 interface PrevNextPageProps {
   type: 'prev' | 'next';

--- a/packages/theme-default/src/components/ScrollToTop/index.tsx
+++ b/packages/theme-default/src/components/ScrollToTop/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 export function ScrollToTop() {
   const [isVisible, setIsVisible] = useState(false);

--- a/packages/theme-default/src/components/Search/SearchButton.tsx
+++ b/packages/theme-default/src/components/Search/SearchButton.tsx
@@ -2,7 +2,7 @@ import SearchSvg from '@theme-assets/search';
 import { useEffect, useState } from 'react';
 import { useLocaleSiteData } from '../../logic/useLocaleSiteData';
 import { SvgWrapper } from '../SvgWrapper';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 export interface SearchButtonProps {
   setFocused: (focused: boolean) => void;

--- a/packages/theme-default/src/components/Search/SearchPanel.tsx
+++ b/packages/theme-default/src/components/Search/SearchPanel.tsx
@@ -16,7 +16,7 @@ import { SvgWrapper } from '../SvgWrapper';
 import { Tab, Tabs } from '../Tabs';
 import { NoSearchResult } from './NoSearchResult';
 import { SuggestItem } from './SuggestItem';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 import { PageSearcher } from './logic/search';
 import type {
   CustomMatchResult,
@@ -459,7 +459,7 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
     // accumulateIndex is used to calculate the index of the suggestion in the whole list.
     let accumulateIndex = -1;
     return (
-      <ul className={styles.suggestList}>
+      <ul>
         {Object.keys(normalizedSuggestions).map(group => {
           const groupSuggestions = normalizedSuggestions[group] || [];
           return (

--- a/packages/theme-default/src/components/Search/SuggestItem.tsx
+++ b/packages/theme-default/src/components/Search/SuggestItem.tsx
@@ -5,7 +5,7 @@ import JumpSvg from '@theme-assets/jump';
 import TitleSvg from '@theme-assets/title';
 import { useRef } from 'react';
 import { SvgWrapper } from '../SvgWrapper';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 import type { DefaultMatchResultItem, HighlightInfo } from './logic/types';
 import { getSlicedStrByByteLength, removeDomain } from './logic/util';
 
@@ -134,7 +134,7 @@ export function SuggestItem({
         target={inCurrentDocIndex ? '_self' : '_blank'}
       >
         <div className={styles.suggestItemContainer}>
-          <div className={styles.hitIcon}>
+          <div>
             <SvgWrapper icon={HitIcon} />
           </div>
           <div className={styles.contentWrapper}>

--- a/packages/theme-default/src/components/Sidebar/SidebarGroup.tsx
+++ b/packages/theme-default/src/components/Sidebar/SidebarGroup.tsx
@@ -13,7 +13,7 @@ import { renderInlineMarkdown } from '../../logic/utils';
 import { SvgWrapper } from '../SvgWrapper';
 import { SidebarDivider } from './SidebarDivider';
 import { SidebarItem as SidebarItemComp } from './SidebarItem';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 import { isSidebarDivider, preloadLink } from './utils';
 
 export function SidebarGroup(props: SidebarItemProps) {

--- a/packages/theme-default/src/components/Sidebar/SidebarItem.tsx
+++ b/packages/theme-default/src/components/Sidebar/SidebarItem.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from 'react';
 import { type SidebarItemProps, highlightTitleStyle } from '.';
 import { renderInlineMarkdown } from '../../logic/utils';
 import { SidebarGroup } from './SidebarGroup';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 import { preloadLink } from './utils';
 
 export function SidebarItem(props: SidebarItemProps) {

--- a/packages/theme-default/src/components/Sidebar/index.tsx
+++ b/packages/theme-default/src/components/Sidebar/index.tsx
@@ -15,7 +15,7 @@ import { SidebarItem } from './SidebarItem';
 import { SidebarSectionHeader } from './SidebarSectionHeader';
 
 import { useSidebarData } from '../../logic/useSidebarData';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 import {
   isSideBarCustomLink,
   isSidebarDivider,

--- a/packages/theme-default/src/components/SocialLinks/LinkContent.tsx
+++ b/packages/theme-default/src/components/SocialLinks/LinkContent.tsx
@@ -1,6 +1,6 @@
 import type { SocialLink } from '@rspress/shared';
 import { useState } from 'react';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 declare const process: {
   env: {

--- a/packages/theme-default/src/components/SocialLinks/index.tsx
+++ b/packages/theme-default/src/components/SocialLinks/index.tsx
@@ -2,7 +2,7 @@ import type { SocialLink } from '@rspress/shared';
 import { useCallback, useState } from 'react';
 import { HiddenLinks } from './HiddenLinks';
 import { ShownLinks } from './ShownLinks';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 const MORE_LENGTH = 5;
 

--- a/packages/theme-default/src/components/SourceCode/index.tsx
+++ b/packages/theme-default/src/components/SourceCode/index.tsx
@@ -2,7 +2,7 @@ import Github from '@theme-assets/github';
 import Gitlab from '@theme-assets/gitlab';
 import { useLocaleSiteData } from '../../logic/useLocaleSiteData';
 import { SvgWrapper } from '../SvgWrapper';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 interface SourceCodeProps {
   href: string;

--- a/packages/theme-default/src/components/Steps/index.tsx
+++ b/packages/theme-default/src/components/Steps/index.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 export function Steps({ children }: { children: ReactNode }) {
   return (

--- a/packages/theme-default/src/components/Tabs/index.tsx
+++ b/packages/theme-default/src/components/Tabs/index.tsx
@@ -13,7 +13,7 @@ import {
 } from 'react';
 import { TabDataContext } from '../../logic/TabDataContext';
 import { useStorageValue } from '../../logic/useStorageValue';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 type TabItem = {
   value?: string;

--- a/packages/theme-default/src/global.d.ts
+++ b/packages/theme-default/src/global.d.ts
@@ -5,6 +5,8 @@ declare module 'virtual-site-data' {
   export default data;
 }
 
+// for the first build when generating the module.scss.d.ts
+declare module '*.module.scss';
 declare module '@theme-assets/*' {
   const SvgIcon: React.FC<React.SVGProps<SVGSVGElement>> | string;
   export default SvgIcon;

--- a/packages/theme-default/src/global.d.ts
+++ b/packages/theme-default/src/global.d.ts
@@ -5,11 +5,6 @@ declare module 'virtual-site-data' {
   export default data;
 }
 
-declare module '*.module.scss' {
-  const classes: { [key: string]: string };
-  export default classes;
-}
-
 declare module '@theme-assets/*' {
   const SvgIcon: React.FC<React.SVGProps<SVGSVGElement>> | string;
   export default SvgIcon;

--- a/packages/theme-default/src/layout/DocLayout/docComponents/code/CopyCodeButton.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/code/CopyCodeButton.tsx
@@ -3,7 +3,7 @@ import IconSuccess from '@theme-assets/success';
 import copy from 'copy-to-clipboard';
 import { useRef } from 'react';
 import { SvgWrapper } from '../../../../components/SvgWrapper';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 const timeoutIdMap: Map<HTMLElement, NodeJS.Timeout> = new Map();
 

--- a/packages/theme-default/src/layout/DocLayout/docComponents/code/index.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/code/index.tsx
@@ -5,7 +5,7 @@ import { useRef, useState } from 'react';
 import { SvgWrapper } from '../../../../components/SvgWrapper';
 import { CopyCodeButton } from './CopyCodeButton';
 import { PrismSyntaxHighlighter } from './PrismSyntaxHighlighter';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 export interface CodeProps {
   children: string;
@@ -68,7 +68,6 @@ export function Code(props: CodeProps) {
       <div className={styles.codeButtonGroup}>
         <button
           ref={wrapButtonRef}
-          className={styles.codeWrapButton}
           onClick={() => toggleCodeWrap(wrapButtonRef.current)}
           title="Toggle code wrap"
         >

--- a/packages/theme-default/src/layout/DocLayout/docComponents/link.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/link.tsx
@@ -1,7 +1,7 @@
 import { Link } from '@theme';
 import type { ComponentProps } from 'react';
 import { usePathUtils } from '../../../logic/usePathUtils';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 export const A = (props: ComponentProps<'a'>) => {
   const { href = '', className = '' } = props;
@@ -15,7 +15,7 @@ export const A = (props: ComponentProps<'a'>) => {
   return (
     <Link
       {...props}
-      className={`${className} ${styles.link} ${styles['inline-link']}`}
+      className={`${className} ${styles.link} ${styles.inlineLink}`}
       href={normalizeLinkHref(href)}
     />
   );

--- a/packages/theme-default/src/layout/DocLayout/docComponents/paragraph.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/paragraph.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps } from 'react';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 export const P = (props: ComponentProps<'p'>) => {
   return <p {...props} className="my-4 leading-7" />;

--- a/packages/theme-default/src/layout/DocLayout/docComponents/title.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/title.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 export const H1 = (props: React.ComponentProps<'h1'>) => {
   return (

--- a/packages/theme-default/src/layout/DocLayout/index.tsx
+++ b/packages/theme-default/src/layout/DocLayout/index.tsx
@@ -12,7 +12,7 @@ import { useLocaleSiteData } from '../../logic/useLocaleSiteData';
 import type { UISwitchResult } from '../../logic/useUISwitch';
 import { A } from './docComponents/link';
 import { H1 } from './docComponents/title';
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 export interface DocLayoutProps {
   beforeSidebar?: React.ReactNode;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1730,6 +1730,9 @@ importers:
       '@rsbuild/plugin-svgr':
         specifier: ^1.0.7
         version: 1.0.7(@rsbuild/core@1.2.19)(typescript@5.8.2)
+      '@rsbuild/plugin-typed-css-modules':
+        specifier: ~1.0.2
+        version: 1.0.2(@rsbuild/core@1.2.19)
       '@rslib/core':
         specifier: 0.5.4
         version: 0.5.4(@microsoft/api-extractor@7.52.1(@types/node@22.10.2))(typescript@5.8.2)
@@ -3444,6 +3447,14 @@ packages:
     resolution: {integrity: sha512-+hCaG78P0nt8nrMvdWJ720c0WNj9ogNBL7ib8+UfyYezqliMRR++Zx6QIPXYBfTP+pCa/TKPph/ZQvAdPJq+Ig==}
     peerDependencies:
       '@rsbuild/core': 1.x
+
+  '@rsbuild/plugin-typed-css-modules@1.0.2':
+    resolution: {integrity: sha512-QX376pBXWeBrZBvYLP2HGGrHiWA5O0SDHwRoBNto5BqYDXhi6y+Eol2Hb/cY+h2ARKZVanMfUiJRABULOJ/FCQ==}
+    peerDependencies:
+      '@rsbuild/core': 1.x || ^1.0.1-beta.0
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
 
   '@rslib/core@0.5.4':
     resolution: {integrity: sha512-rJ+wG++/Y8SbyuJB1RhlgnOUPzsxubD0lBivZWXVhOGawAea7mUoI4kZQ6YmF0iybW1QA61wHOf3FY+R1BxvgQ==}
@@ -9444,6 +9455,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  '@rsbuild/plugin-typed-css-modules@1.0.2(@rsbuild/core@1.2.19)':
+    optionalDependencies:
+      '@rsbuild/core': 1.2.19
 
   '@rslib/core@0.5.4(@microsoft/api-extractor@7.52.1(@types/node@18.11.17))(typescript@5.8.2)':
     dependencies:


### PR DESCRIPTION
## Summary

WARNING: DANGEROUS PULL REQUSET

1. add `namedExport: true` for cssModules via https://github.com/web-infra-dev/rslib/pull/854

2. remove tons of unused className



## Related Issue

https://github.com/web-infra-dev/rslib/pull/854

https://github.com/web-infra-dev/rspress/issues/1967

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
