### PR TITLE
docs: add `editLink` and `outline` config

### DIFF
--- a/packages/document/docs/en/api/config/config-theme.mdx
+++ b/packages/document/docs/en/api/config/config-theme.mdx
@@ -218,6 +218,25 @@ export default defineConfig({
 });
 ```
 
+## outline
+
+- Type: `boolean`
+- Default: `true`
+
+Whether to show the sidebar in right position.
+
+For example:
+
+```ts title="rspress.config.ts"
+import { defineConfig } from 'rspress/config';
+
+export default defineConfig({
+  themeConfig: {
+    outline: false,
+  },
+});
+```
+
 ## outlineTitle
 
 - Type: `string`
@@ -509,8 +528,6 @@ export interface LocaleConfig {
    */
   // Right outline title
   outlineTitle?: string;
-  // Whether to display the outline title
-  outline?: boolean;
   // Whether to display the last update time
   lastUpdated?: boolean;
   // Last update time text
@@ -525,6 +542,8 @@ export interface LocaleConfig {
   searchNoResultsText?: string;
   // The text of suggested query text when no search result
   searchSuggestedQueryText?: string;
+  // Info for the edit link.
+  editLink?: EditLink;
 }
 ```
 
@@ -582,6 +601,46 @@ import { defineConfig } from 'rspress/config';
 export default defineConfig({
   themeConfig: {
     hideNavbar: 'auto',
+  },
+});
+```
+
+## editLink
+
+- Type:
+
+```ts
+interface EditLink {
+  /**
+   * Custom repository url for edit link.
+   */
+  docRepoBaseUrl: string;
+
+  /**
+   * Custom text for edit link.
+   *
+   * @default 'Edit this page'
+   */
+  text?: string;
+}
+```
+
+- Default: `undefined`
+
+Display a link to edit the page on Git management services such as GitHub, or GitLab.
+
+For example:
+
+```ts title="rspress.config.ts"
+import { defineConfig } from 'rspress/config';
+
+export default defineConfig({
+  themeConfig: {
+    editLink: {
+      docRepoBaseUrl:
+        'https://github.com/web-infra-dev/rspress/tree/main/packages/document/docs',
+      text: '📝 Edit this page on GitHub',
+    },
   },
 });
 ```

--- a/packages/document/docs/zh/api/config/config-theme.mdx
+++ b/packages/document/docs/zh/api/config/config-theme.mdx
@@ -204,6 +204,24 @@ export default defineConfig({
 });
 ```
 
+## outline
+
+- Type: `boolean`
+- Default: `true`
+
+是否显示右侧大纲。
+
+比如:
+
+````ts title="rspress.config.ts"
+import { defineConfig } from 'rspress/config';
+
+export default defineConfig({
+  themeConfig: {
+    outline: false,
+  },
+});
+
 ## outlineTitle
 
 - Type: `string`
@@ -221,7 +239,7 @@ export default defineConfig({
     outlineTitle: 'Outline',
   },
 });
-```
+````
 
 ## lastUpdated
 
@@ -495,8 +513,6 @@ export interface LocaleConfig {
    */
   // 右侧大纲标题
   outlineTitle?: string;
-  // 是否显示右侧大纲
-  outline?: boolean;
   // 最后更新时间文本
   lastUpdatedText?: string;
   // 是否显示最后更新时间
@@ -511,6 +527,8 @@ export interface LocaleConfig {
   searchNoResultsText?: string;
   // 没有搜索结果时的建议查询提示文本
   searchSuggestedQueryText?: string;
+  // 配置编辑链接
+  editLink?: EditLink;
 }
 ```
 
@@ -568,6 +586,46 @@ import { defineConfig } from 'rspress/config';
 export default defineConfig({
   themeConfig: {
     hideNavbar: 'never',
+  },
+});
+```
+
+## editLink
+
+- Type:
+
+```ts
+interface EditLink {
+  /**
+   * 自定义编辑链接的 URL
+   */
+  docRepoBaseUrl: string;
+
+  /**
+   * 自定义编辑链接的文本
+   *
+   * @default 'Edit this page'
+   */
+  text?: string;
+}
+```
+
+- Default: `undefined`
+
+用于配置编辑链接，以在 GitHub 或 GitLab 等 Git 管理服务上编辑页面。
+
+比如：
+
+```ts title="rspress.config.ts"
+import { defineConfig } from 'rspress/config';
+
+export default defineConfig({
+  themeConfig: {
+    editLink: {
+      docRepoBaseUrl:
+        'https://github.com/web-infra-dev/rspress/tree/main/packages/document/docs',
+      text: '📝 在 GitHub 上编辑此页',
+    },
   },
 });
 ```

--- a/packages/document/docs/zh/api/config/config-theme.mdx
+++ b/packages/document/docs/zh/api/config/config-theme.mdx
@@ -213,7 +213,7 @@ export default defineConfig({
 
 比如:
 
-````ts title="rspress.config.ts"
+```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';
 
 export default defineConfig({
@@ -221,6 +221,7 @@ export default defineConfig({
     outline: false,
   },
 });
+```
 
 ## outlineTitle
 
@@ -239,7 +240,7 @@ export default defineConfig({
     outlineTitle: 'Outline',
   },
 });
-````
+```
 
 ## lastUpdated
 


### PR DESCRIPTION
## Summary

Add configuration for `editLink` and `outline` to the doc based on the type definition.

BTW, `docFooter` is not documented and does not seem to be used.

https://github.com/web-infra-dev/rspress/blob/a9cdd91364ba44a80b149f09a862b9ac34e70d75/packages/shared/src/types/defaultTheme.ts

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
