### PR TITLE
docs: format command bash space

### DIFF
--- a/packages/document/docs/en/api/commands.mdx
+++ b/packages/document/docs/en/api/commands.mdx
@@ -10,11 +10,11 @@ The `rspress dev` command is used to start a local development server, providing
 Usage: rspress dev [root] [options]
 
 Options:
-   root specify the root directory of the project, which is `docs` in current directory by default, Optional
+   root                 specify the root directory of the project, which is `docs` in current directory by default, Optional
    -c --config <config> specify config file path, which can be a relative path or an absolute path
-   --port <port> specify port number
-   --host <host> specify host
-   -h, --help show command help
+   --port <port>        specify port number
+   --host <host>        specify host
+   -h, --help           show command help
 ```
 
 ## rspress build
@@ -25,9 +25,9 @@ The `rspress build` command is used to build documentation site for production.
 Usage: rspress build [root] [options]
 
 Options:
-   root specify the root directory of the project, which is `docs` in current directory by default, Optional
+   root                 specify the root directory of the project, which is `docs` in current directory by default, Optional
    -c --config <config> specify config file path, which can be a relative path or an absolute path
-   -h, --help show command help
+   -h, --help           show command help
 ```
 
 ## rspress preview
@@ -38,11 +38,11 @@ The `rspress preview` command is used to preview the output files of the `rspres
 Usage: rspress preview [root] [options]
 
 Options:
-   root specify the root directory of the project, which is `docs` in current directory by default, Optional
+   root                 specify the root directory of the project, which is `docs` in current directory by default, Optional
    -c --config <config> specify config file path, which can be a relative path or an absolute path
-   --port <port> specify port number
-   --host <host> specify host
-   -h, --help show command help
+   --port <port>        specify port number
+   --host <host>        specify host
+   -h, --help           show command help
 ```
 
 ## rspress update

--- a/packages/document/docs/zh/api/commands.mdx
+++ b/packages/document/docs/zh/api/commands.mdx
@@ -27,7 +27,7 @@ Usage: rspress build [root] [options]
 Options:
   root                  指定文档根目录，默认为当前工作目录下的 docs 目录，可选
   -c --config <config>  指定配置文件路径，可以为相对路径或绝对路径
-  -h, --help  显示命令帮助
+  -h, --help            显示命令帮助
 ```
 
 ## rspress preview
@@ -42,7 +42,7 @@ Options:
   -c --config <config>  指定配置文件路径，可以为相对路径或绝对路径
   --port <port>         指定端口号
   --host <host>         指定 host
-  -h, --help  显示命令帮助
+  -h, --help            显示命令帮助
 ```
 
 ## rspress update


### PR DESCRIPTION
## Summary

before:
<img width="967" alt="image" src="https://github.com/user-attachments/assets/cbfb5146-e017-4e31-b1ef-af347c1c0d01" />


after:
<img width="947" alt="image" src="https://github.com/user-attachments/assets/c073698e-a7c6-4848-9dcc-a5c0fbc0a393" />


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
