### PR TITLE
feat:improve some translation options

### DIFF
--- a/packages/document/i18n.json
+++ b/packages/document/i18n.json
@@ -62,5 +62,17 @@
   "toolStackDesc": {
     "zh": "围绕 Rspack 打造的高性能工具链，助力现代 Web 开发",
     "en": "High-performance toolchain built around Rspack to boost modern web development"
+  },
+  "menuText": {
+    "zh": "菜单",
+    "en": "Menu"
+  },
+  "copyCode": {
+    "zh": "复制代码",
+    "en": "Copy code"
+  },
+  "toggleCodeWrap": {
+    "zh": "切换代码换行",
+    "en": "Toggle code wrap"
   }
 }

--- a/packages/theme-default/src/components/SidebarMenu/index.tsx
+++ b/packages/theme-default/src/components/SidebarMenu/index.tsx
@@ -1,4 +1,4 @@
-import { useLocation, usePageData } from '@rspress/runtime';
+import { useI18n, useLocation, usePageData } from '@rspress/runtime';
 import ArrowRight from '@theme-assets/arrow-right';
 import MenuIcon from '@theme-assets/menu';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -22,6 +22,7 @@ export function SidebarMenu({
   const { page } = usePageData();
   const tocContainerRef = useRef<HTMLDivElement>(null);
   const outlineButtonRef = useRef<HTMLButtonElement>(null);
+  const t = useI18n();
 
   const [isTocOpen, setIsTocOpen] = useState<boolean>(false);
 
@@ -80,7 +81,7 @@ export function SidebarMenu({
               <div className="text-md mr-2">
                 <SvgWrapper icon={MenuIcon} />
               </div>
-              <span className="text-sm">Menu</span>
+              <span className="text-sm">{t('menuText')}</span>
             </button>
             {isSidebarOpen && (
               <div

--- a/packages/theme-default/src/layout/DocLayout/docComponents/code/CopyCodeButton.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/code/CopyCodeButton.tsx
@@ -1,3 +1,4 @@
+import { useI18n } from '@rspress/runtime';
 import IconCopy from '@theme-assets/copy';
 import IconSuccess from '@theme-assets/success';
 import copy from 'copy-to-clipboard';
@@ -48,13 +49,14 @@ export function CopyCodeButton({
   codeBlockRef: React.RefObject<HTMLDivElement>;
 }) {
   const copyButtonRef = useRef<HTMLButtonElement>(null);
+  const t = useI18n();
 
   return (
     <button
       className={styles.codeCopyButton}
       onClick={() => copyCode(codeBlockRef.current, copyButtonRef.current!)}
       ref={copyButtonRef}
-      title="Copy code"
+      title={t('copyCode')}
     >
       <SvgWrapper icon={IconCopy} className={styles.iconCopy} />
       <SvgWrapper icon={IconSuccess} className={styles.iconSuccess} />

--- a/packages/theme-default/src/layout/DocLayout/docComponents/code/index.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/code/index.tsx
@@ -1,4 +1,4 @@
-import { usePageData } from '@rspress/runtime';
+import { useI18n, usePageData } from '@rspress/runtime';
 import IconWrap from '@theme-assets/wrap';
 import IconWrapped from '@theme-assets/wrapped';
 import { useRef, useState } from 'react';
@@ -22,6 +22,7 @@ export function Code(props: CodeProps) {
   const [codeWrap, setCodeWrap] = useState(defaultWrapCode);
   const wrapButtonRef = useRef<HTMLButtonElement>(null);
   const codeBlockRef = useRef<HTMLDivElement>(null);
+  const t = useI18n();
 
   const { className } = props;
   const language = className?.replace(/language-/, '');
@@ -69,7 +70,7 @@ export function Code(props: CodeProps) {
         <button
           ref={wrapButtonRef}
           onClick={() => toggleCodeWrap(wrapButtonRef.current)}
-          title="Toggle code wrap"
+          title={t('toggleCodeWrap')}
         >
           <SvgWrapper icon={IconWrapped} className={styles.iconWrapped} />
           <SvgWrapper icon={IconWrap} className={styles.iconWrap} />


### PR DESCRIPTION
## Summary

This pull request addresses [issue #1971](https://github.com/web-infra-dev/rspress/issues/1971) by adding configurable translation options to the `theme-default` package in `Rspress`. The changes enable dynamic translation for the following components:

- `SidebarMenu/index.tsx`: Replaced hardcoded `"Menu"` with `t('menuText')`.
- `CopyCodeButton.tsx`: Replaced hardcoded `"Copy code"` with `t('copyCode')`.
- `code/index.tsx`: Replaced hardcoded `"Toggle code wrap"` with `t('toggleCodeWrap')`.

To support these translations, I added new entries (`menuText`, `copyCode`, `toggleCodeWrap`) to `i18n.json` with default English and Chinese values. The `useI18n` hook is utilized to dynamically fetch translations

**Note**:I personally believe the search box width adjustment (to 960px with full-screen below 640px) is not necessary, as the current design appears sufficient

## Related Issue

- [Issue #1971](https://github.com/web-infra-dev/rspress/issues/1971)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).