### PR TITLE
fix: use loose type of Rsbuild plugins

### DIFF
--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,4 +1,4 @@
-import type { RsbuildConfig, RsbuildPlugin } from '@rsbuild/core';
+import type { RsbuildConfig, RsbuildPlugins } from '@rsbuild/core';
 import type { loadConfig } from '@rsbuild/core';
 import type { ZoomOptions } from 'medium-zoom';
 import type { PluggableList } from 'unified';
@@ -169,7 +169,7 @@ export interface UserConfig<ThemeConfig = DefaultThemeConfig> {
   /**
    * Add some extra builder plugins
    */
-  builderPlugins?: RsbuildPlugin[];
+  builderPlugins?: RsbuildPlugins;
   /**
    * Multi version config
    */


### PR DESCRIPTION
## Summary

use loose type of Rsbuild plugins

## Related Issue

https://github.com/web-infra-dev/rsbuild/blob/5f66734e1746ab1f8be990ce540fb0e68b19a83a/packages/core/src/types/plugin.ts#L225

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
