### PR TITLE
feat(config)!: force successful SSG generation,  remove `ssg.strict` and add `ssg.fallback`

### DIFF
--- a/e2e/fixtures/ssg-fail-strict/rspress.config.ts
+++ b/e2e/fixtures/ssg-fail-strict/rspress.config.ts
@@ -4,6 +4,6 @@ import { defineConfig } from 'rspress/config';
 export default defineConfig({
   root: path.join(__dirname, 'doc'),
   ssg: {
-    strict: true,
+    fallback: false,
   },
 });

--- a/packages/core/src/node/build.ts
+++ b/packages/core/src/node/build.ts
@@ -36,6 +36,10 @@ interface BuildOptions {
   config: UserConfig;
 }
 
+function isCSRFallback(ssgConfig: SSGConfig) {
+  return typeof ssgConfig === 'object' && ssgConfig.fallback === 'csr';
+}
+
 export async function bundle(
   docDirectory: string,
   config: UserConfig,
@@ -95,19 +99,18 @@ export async function renderPages(
         );
         ({ render } = ssrExports as SSRBundleExports);
       } catch (e) {
-        // skip fallback to CSR if ssg config is strict
-        if (typeof ssgConfig === 'object' && ssgConfig.strict) {
+        if (isCSRFallback(ssgConfig)) {
+          // fallback to CSR
+          logger.error(e);
+          logger.warn(
+            `Failed to load SSG bundle: ${picocolors.yellow(ssrBundlePath)}, fallback to CSR.`,
+          );
+        } else {
           logger.error(
             `Failed to load SSG bundle: ${picocolors.yellow(ssrBundlePath)}.`,
           );
           throw e;
         }
-
-        // fallback to CSR
-        logger.error(e);
-        logger.warn(
-          `Failed to load SSG bundle: ${picocolors.yellow(ssrBundlePath)}, fallback to CSR.`,
-        );
       }
     }
 
@@ -143,18 +146,18 @@ export async function renderPages(
             try {
               ({ appHtml } = await render(routePath, helmetContext.context));
             } catch (e) {
-              if (typeof ssgConfig === 'object' && ssgConfig.strict) {
+              if (isCSRFallback(ssgConfig)) {
+                // fallback to CSR
+                logger.warn(
+                  `Page "${picocolors.yellow(routePath)}" SSG rendering error, fallback to CSR.`,
+                  e,
+                );
+              } else {
                 logger.error(
                   `Page "${picocolors.yellow(routePath)}" SSG rendering failed.`,
                 );
                 throw e;
               }
-
-              // fallback to CSR
-              logger.warn(
-                `Page "${picocolors.yellow(routePath)}" SSG rendering error, fallback to CSR.`,
-                e,
-              );
             }
           }
 
@@ -234,7 +237,7 @@ export async function build(options: BuildOptions) {
   const modifiedConfig = await pluginDriver.modifyConfig();
 
   await pluginDriver.beforeBuild();
-  const ssgConfig = modifiedConfig.ssg ?? { strict: true };
+  const ssgConfig = modifiedConfig.ssg ?? true;
 
   // empty temp dir before build
   await emptyDir(TEMP_DIR);

--- a/packages/core/src/node/build.ts
+++ b/packages/core/src/node/build.ts
@@ -96,8 +96,6 @@ export async function renderPages(
         ({ render } = ssrExports as SSRBundleExports);
       } catch (e) {
         // skip fallback to CSR if ssg config is strict
-        // TODO: strict by default in v2
-        // see: https://github.com/web-infra-dev/rspress/issues/1317
         if (typeof ssgConfig === 'object' && ssgConfig.strict) {
           logger.error(
             `Failed to load SSG bundle: ${picocolors.yellow(ssrBundlePath)}.`,
@@ -236,7 +234,7 @@ export async function build(options: BuildOptions) {
   const modifiedConfig = await pluginDriver.modifyConfig();
 
   await pluginDriver.beforeBuild();
-  const ssgConfig = modifiedConfig.ssg ?? true;
+  const ssgConfig = modifiedConfig.ssg ?? { strict: true };
 
   // empty temp dir before build
   await emptyDir(TEMP_DIR);

--- a/packages/document/docs/en/api/config/config-basic.mdx
+++ b/packages/document/docs/en/api/config/config-basic.mdx
@@ -469,9 +469,11 @@ export default defineConfig({
 ## ssg
 
 - Type: `boolean | { strict?: boolean }`
-- Default: `true`
+- Default: `{ strict: true }`
 
-Determines whether to enable Static Site Generation. It is enabled by default, but you can disable it by setting `ssg` to `false`.
+Whether to enable static site generation, Rspress is enabled by default to generate CSR outputs and SSG outputs.
+
+If your document site is only required to be used in CSR scenarios, you can set `ssg` to `false`, and Rspress will only generate CSR outputs.
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';
@@ -481,12 +483,12 @@ export default defineConfig({
 });
 ```
 
-If SSG fails, it will fallback to CSR by default. You can set `ssg` to `{ strict: true }` to strictly require SSG to succeed, otherwise an error will be thrown.
+If you do not strictly require SSG generation in your scenario, you can set `ssg` to `{ strict: false }`. When SSG fails, it will fallback to generate only CSR outputs.
 
 ```ts title="rspress.config.ts"
 export default {
   ssg: {
-    strict: true,
+    strict: false,
   },
 };
 ```

--- a/packages/document/docs/en/api/config/config-basic.mdx
+++ b/packages/document/docs/en/api/config/config-basic.mdx
@@ -471,7 +471,7 @@ export default defineConfig({
 - Type: `boolean | { fallback?: false | 'csr' }`
 - Default: `true`
 
-Whether to enable static site generation, Rspress is enabled by default to generate CSR outputs and SSG outputs.
+Whether to enable static site generation. Rspress enable it by default to generate CSR outputs and SSG outputs.
 
 If your document site is only required to be used in CSR scenarios, you can set `ssg` to `false`, and Rspress will only generate CSR outputs.
 

--- a/packages/document/docs/en/api/config/config-basic.mdx
+++ b/packages/document/docs/en/api/config/config-basic.mdx
@@ -468,8 +468,8 @@ export default defineConfig({
 
 ## ssg
 
-- Type: `boolean | { strict?: boolean }`
-- Default: `{ strict: true }`
+- Type: `boolean | { fallback?: false | 'csr' }`
+- Default: `true`
 
 Whether to enable static site generation, Rspress is enabled by default to generate CSR outputs and SSG outputs.
 
@@ -483,12 +483,12 @@ export default defineConfig({
 });
 ```
 
-If you do not strictly require SSG generation in your scenario, you can set `ssg` to `{ strict: false }`. When SSG fails, it will fallback to generate only CSR outputs.
+If you do not strictly require SSG generation in your scenario, you can set `ssg` to `{ fallback: 'csr' }`. When SSG fails, it will fallback to generate only CSR outputs.
 
 ```ts title="rspress.config.ts"
 export default {
   ssg: {
-    strict: false,
+    fallback: 'csr',
   },
 };
 ```

--- a/packages/document/docs/zh/api/config/config-basic.mdx
+++ b/packages/document/docs/zh/api/config/config-basic.mdx
@@ -482,7 +482,7 @@ export default defineConfig({
 });
 ```
 
-如果你的场景中不严格要求必须生成 SSG，可以设置 `ssg` 为 `{ fallback: 'csr' }`， SSG 失败时，会 fallback 到仅生成 CSR 产物。
+如果你的场景中不严格要求必须生成 SSG 产物，可以设置 `ssg` 为 `{ fallback: 'csr' }`。当 SSG 失败时，会 fallback 到仅生成 CSR 产物。
 
 ```ts title="rspress.config.ts"
 export default {

--- a/packages/document/docs/zh/api/config/config-basic.mdx
+++ b/packages/document/docs/zh/api/config/config-basic.mdx
@@ -468,9 +468,11 @@ export default defineConfig({
 ## ssg
 
 - Type: `boolean | { strict?: boolean }`
-- Default: `true`
+- Default: `{ strict: true }`
 
-是否开启静态站点生成。默认开启，你可以通过设置 `ssg` 为 `false` 来关闭。
+是否开启静态站点生成，Rspress 默认开启，生成 CSR 产物和 SSG 产物。
+
+若你的文档站只要求在 CSR 场景下使用，你可以设置 `ssg` 为 `false`，此时 Rspress 会仅生成 CSR 产物。
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';
@@ -480,12 +482,12 @@ export default defineConfig({
 });
 ```
 
-当 SSG 失败时，默认会 fallback 到 CSR。你可以通过设置 `ssg` 为 `{ strict: true }` 来严格要求 SSG 必须成功，否则抛出错误。
+如果你的场景中不严格要求必须生成 SSG，可以设置 `ssg` 为 `{ strict: false }`， SSG 失败时，会 fallback 到仅生成 CSR 产物。
 
 ```ts title="rspress.config.ts"
 export default {
   ssg: {
-    strict: true,
+    strict: false,
   },
 };
 ```

--- a/packages/document/docs/zh/api/config/config-basic.mdx
+++ b/packages/document/docs/zh/api/config/config-basic.mdx
@@ -470,9 +470,9 @@ export default defineConfig({
 - Type: `boolean | { fallback?: false | 'csr' }`
 - Default: `true`
 
-是否开启静态站点生成，Rspress 默认开启，生成 CSR 产物和 SSG 产物。
+是否开启静态站点生成。Rspress 默认开启该功能，生成 CSR 产物和 SSG 产物。
 
-若你的文档站只要求在 CSR 场景下使用，你可以设置 `ssg` 为 `false`，此时 Rspress 会仅生成 CSR 产物。
+如果你的文档站只要求在 CSR 场景下使用，你可以设置 `ssg` 为 `false`，此时 Rspress 会仅生成 CSR 产物。
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';

--- a/packages/document/docs/zh/api/config/config-basic.mdx
+++ b/packages/document/docs/zh/api/config/config-basic.mdx
@@ -467,8 +467,8 @@ export default defineConfig({
 
 ## ssg
 
-- Type: `boolean | { strict?: boolean }`
-- Default: `{ strict: true }`
+- Type: `boolean | { fallback?: false | 'csr' }`
+- Default: `true`
 
 是否开启静态站点生成，Rspress 默认开启，生成 CSR 产物和 SSG 产物。
 
@@ -482,12 +482,12 @@ export default defineConfig({
 });
 ```
 
-如果你的场景中不严格要求必须生成 SSG，可以设置 `ssg` 为 `{ strict: false }`， SSG 失败时，会 fallback 到仅生成 CSR 产物。
+如果你的场景中不严格要求必须生成 SSG，可以设置 `ssg` 为 `{ fallback: 'csr' }`， SSG 失败时，会 fallback 到仅生成 CSR 产物。
 
 ```ts title="rspress.config.ts"
 export default {
   ssg: {
-    strict: false,
+    fallback: 'csr',
   },
 };
 ```

--- a/packages/document/rspress.config.ts
+++ b/packages/document/rspress.config.ts
@@ -19,9 +19,6 @@ export default defineConfig({
   markdown: {
     checkDeadLinks: true,
   },
-  ssg: {
-    strict: true,
-  },
   plugins: [
     pluginFontOpenSans(),
     pluginSitemap({

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -51,7 +51,7 @@ export interface Locale {
   description?: string;
 }
 
-export type SSGConfig = boolean | { strict?: boolean };
+export type SSGConfig = boolean | { fallback?: false | 'csr' };
 
 export interface UserConfig<ThemeConfig = DefaultThemeConfig> {
   /**


### PR DESCRIPTION
## Summary

Rspress now requires ssg to be successful

It means rspress would emit error if ssg generation fails. The process will be directly terminated, rather than fallback to the csr products

Remove `ssg.strict` and add `ssg.fallback` in Rspress v2, see https://github.com/web-infra-dev/rspress/discussions/1105#discussioncomment-10324815


## Related Issue

https://github.com/web-infra-dev/rspress/issues/1317

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
