### PR TITLE
fix(plugin-playground): disable monaco editor ts check for supporting tsx

### DIFF
--- a/packages/plugin-playground/static/global-components/Playground.tsx
+++ b/packages/plugin-playground/static/global-components/Playground.tsx
@@ -92,6 +92,13 @@ export default function Playground(props: PlaygroundProps) {
         value={code}
         onChange={handleCodeChange}
         language={monacoLanguage}
+        beforeMount={monaco => {
+          monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
+            noSemanticValidation: true,
+            noSyntaxValidation: true,
+            noSuggestionDiagnostics: true,
+          });
+        }}
       />
       {renderChildren?.(props, code, direction)}
     </div>


### PR DESCRIPTION
## Summary

目前 monaco-editor 还不能很好支持 tsx，相关 issue：https://github.com/microsoft/monaco-editor/issues/264  
可以临时禁用 monaco-editor 对 ts 的校验保持语法高亮并不报错。

## Related Issue

<!--- Provide link of related issues -->

https://github.com/web-infra-dev/rspress/issues/1324

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
