### PR TITLE
refactor(hmr): root component should be hmr friendly

### DIFF
--- a/packages/core/src/runtime/App.tsx
+++ b/packages/core/src/runtime/App.tsx
@@ -1,128 +1,14 @@
-import {
-  DataContext,
-  isEqualPath,
-  pathnameToRouteService,
-  useLocation,
-} from '@rspress/runtime';
-import {
-  type BaseRuntimePageInfo,
-  type FrontMatterMeta,
-  type Header,
-  MDX_OR_MD_REGEXP,
-  type PageData,
-  cleanUrl,
-} from '@rspress/shared';
+import { DataContext, useLocation } from '@rspress/runtime';
 import { Layout } from '@theme';
 import React, { useContext, useLayoutEffect } from 'react';
 import { HelmetProvider } from 'react-helmet-async';
 import globalComponents from 'virtual-global-components';
-import siteData from 'virtual-site-data';
 import 'virtual-global-styles';
+import { initPageData } from './initPageData';
 
-export enum QueryStatus {
+enum QueryStatus {
   Show = '1',
   Hide = '0',
-}
-
-type PageMeta = {
-  title: string;
-  headingTitle: string;
-  toc: Header[];
-  frontmatter: FrontMatterMeta;
-};
-
-export async function initPageData(routePath: string): Promise<PageData> {
-  const matchedRoute = pathnameToRouteService(routePath);
-  if (matchedRoute) {
-    // Preload route component
-    const mod = await matchedRoute.preload();
-    const pagePath = cleanUrl(matchedRoute.filePath);
-    const normalize = (p: string) =>
-      // compat the path that has no / suffix and ignore case
-      p
-        .replace(/\/$/, '')
-        .toLowerCase();
-    const extractPageInfo: BaseRuntimePageInfo = siteData.pages.find(page =>
-      isEqualPath(normalize(page.routePath), normalize(matchedRoute.path)),
-    )!;
-
-    // FIXME: when sidebar item is configured as link string, the sidebar text won't updated when page title changed
-    // Reason: The sidebar item text depends on pageData, which is not updated when page title changed, because the pageData is computed once when build
-    const encodedPagePath = encodeURIComponent(pagePath);
-    const meta: PageMeta =
-      (
-        mod.default as unknown as {
-          __RSPRESS_PAGE_META: Record<string, PageMeta>;
-        }
-      ).__RSPRESS_PAGE_META?.[encodedPagePath] || ({} as PageMeta);
-    // mdx loader will generate __RSPRESS_PAGE_META,
-    // if the filePath don't match it, we can get meta from j(t)sx if we customize it
-    const {
-      toc = [],
-      title = '',
-      frontmatter = {},
-      ...rest
-    } = MDX_OR_MD_REGEXP.test(matchedRoute.filePath)
-      ? meta
-      : (mod as unknown as PageMeta);
-    return {
-      siteData,
-      page: {
-        ...rest,
-        pagePath,
-        ...extractPageInfo,
-        pageType: frontmatter?.pageType || 'doc',
-        title,
-        frontmatter,
-        toc,
-      },
-    } satisfies PageData;
-  }
-
-  let lang = siteData.lang || '';
-  let version = siteData.multiVersion?.default || '';
-
-  if (siteData.lang && typeof window !== 'undefined') {
-    const path = location.pathname
-      .replace(siteData.base, '')
-      .split('/')
-      .slice(0, 2);
-
-    if (siteData.locales.length) {
-      const result = siteData.locales.find(({ lang }) => path.includes(lang));
-
-      if (result) {
-        lang = result.lang;
-      }
-    }
-
-    if (siteData.multiVersion.versions) {
-      const result = siteData.multiVersion.versions.find(version =>
-        path.includes(version),
-      );
-
-      if (result) {
-        version = result;
-      }
-    }
-  }
-
-  // 404 Page
-  return {
-    siteData,
-    page: {
-      pagePath: '',
-      pageType: '404',
-      routePath: '/404',
-      lang,
-      frontmatter: {},
-      title: '404',
-      toc: [],
-      version,
-      _filepath: '',
-      _relativePath: '',
-    },
-  };
 }
 
 export function App({ helmetContext }: { helmetContext?: object }) {

--- a/packages/core/src/runtime/ClientApp.tsx
+++ b/packages/core/src/runtime/ClientApp.tsx
@@ -1,0 +1,34 @@
+import { BrowserRouter, DataContext, ThemeContext } from '@rspress/runtime';
+import type { PageData } from '@rspress/shared';
+import { useThemeState } from '@theme';
+import { useEffect, useMemo, useState } from 'react';
+import { App } from './App';
+import { initPageData } from './initPageData';
+
+export function RootApp() {
+  const [data, setData] = useState<PageData>(null as any);
+  const [theme, setTheme] = useThemeState();
+
+  useEffect(() => {
+    initPageData(window.location.pathname).then(pageData => {
+      setData(pageData);
+    });
+  }, []);
+
+  const themeValue = useMemo(() => ({ theme, setTheme }), [theme, setTheme]);
+  const dataValue = useMemo(() => ({ data, setData }), [data, setData]);
+
+  if (!data) {
+    return <></>;
+  }
+
+  return (
+    <ThemeContext.Provider value={themeValue}>
+      <DataContext.Provider value={dataValue}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </DataContext.Provider>
+    </ThemeContext.Provider>
+  );
+}

--- a/packages/core/src/runtime/ClientApp.tsx
+++ b/packages/core/src/runtime/ClientApp.tsx
@@ -5,7 +5,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { App } from './App';
 import { initPageData } from './initPageData';
 
-export function RootApp() {
+export function ClientApp() {
   const [data, setData] = useState<PageData>(null as any);
   const [theme, setTheme] = useThemeState();
 

--- a/packages/core/src/runtime/clientEntry.tsx
+++ b/packages/core/src/runtime/clientEntry.tsx
@@ -1,6 +1,6 @@
 import { isProduction } from '@rspress/shared';
 import siteData from 'virtual-site-data';
-import { RootApp } from './ClientApp';
+import { ClientApp } from './ClientApp';
 
 const enableSSG = siteData.ssg;
 
@@ -12,16 +12,16 @@ export async function renderInBrowser() {
   if (process.env.__REACT_GTE_18__) {
     const { createRoot, hydrateRoot } = require('react-dom/client');
     if (isProduction() && enableSSG) {
-      hydrateRoot(container, <RootApp />);
+      hydrateRoot(container, <ClientApp />);
     } else {
-      createRoot(container).render(<RootApp />);
+      createRoot(container).render(<ClientApp />);
     }
   } else {
     const ReactDOM = require('react-dom');
     if (isProduction()) {
-      ReactDOM.hydrate(<RootApp />, container);
+      ReactDOM.hydrate(<ClientApp />, container);
     } else {
-      ReactDOM.render(<RootApp />, container);
+      ReactDOM.render(<ClientApp />, container);
     }
   }
 }

--- a/packages/core/src/runtime/clientEntry.tsx
+++ b/packages/core/src/runtime/clientEntry.tsx
@@ -1,9 +1,6 @@
-import { BrowserRouter, DataContext, ThemeContext } from '@rspress/runtime';
 import { isProduction } from '@rspress/shared';
-import { useThemeState } from '@theme';
-import { useMemo, useState } from 'react';
 import siteData from 'virtual-site-data';
-import { App, initPageData } from './App';
+import { RootApp } from './ClientApp';
 
 const enableSSG = siteData.ssg;
 
@@ -12,28 +9,6 @@ const enableSSG = siteData.ssg;
 export async function renderInBrowser() {
   const container = document.getElementById('root')!;
 
-  const enhancedApp = async () => {
-    const initialPageData = await initPageData(window.location.pathname);
-
-    return function RootApp() {
-      const [data, setData] = useState(initialPageData);
-      const [theme, setTheme] = useThemeState();
-      return (
-        <ThemeContext.Provider
-          value={useMemo(() => ({ theme, setTheme }), [theme, setTheme])}
-        >
-          <DataContext.Provider
-            value={useMemo(() => ({ data, setData }), [data, setData])}
-          >
-            <BrowserRouter>
-              <App />
-            </BrowserRouter>
-          </DataContext.Provider>
-        </ThemeContext.Provider>
-      );
-    };
-  };
-  const RootApp = await enhancedApp();
   if (process.env.__REACT_GTE_18__) {
     const { createRoot, hydrateRoot } = require('react-dom/client');
     if (isProduction() && enableSSG) {

--- a/packages/core/src/runtime/initPageData.ts
+++ b/packages/core/src/runtime/initPageData.ts
@@ -1,0 +1,112 @@
+import { isEqualPath, pathnameToRouteService } from '@rspress/runtime';
+import {
+  type BaseRuntimePageInfo,
+  type FrontMatterMeta,
+  type Header,
+  MDX_OR_MD_REGEXP,
+  type PageData,
+  cleanUrl,
+} from '@rspress/shared';
+import 'virtual-global-styles';
+import siteData from 'virtual-site-data';
+
+type PageMeta = {
+  title: string;
+  headingTitle: string;
+  toc: Header[];
+  frontmatter: FrontMatterMeta;
+};
+
+export async function initPageData(routePath: string): Promise<PageData> {
+  const matchedRoute = pathnameToRouteService(routePath);
+  if (matchedRoute) {
+    // Preload route component
+    const mod = await matchedRoute.preload();
+    const pagePath = cleanUrl(matchedRoute.filePath);
+    const normalize = (p: string) =>
+      // compat the path that has no / suffix and ignore case
+      p
+        .replace(/\/$/, '')
+        .toLowerCase();
+    const extractPageInfo: BaseRuntimePageInfo = siteData.pages.find(page =>
+      isEqualPath(normalize(page.routePath), normalize(matchedRoute.path)),
+    )!;
+
+    // FIXME: when sidebar item is configured as link string, the sidebar text won't updated when page title changed
+    // Reason: The sidebar item text depends on pageData, which is not updated when page title changed, because the pageData is computed once when build
+    const encodedPagePath = encodeURIComponent(pagePath);
+    const meta: PageMeta =
+      (
+        mod.default as unknown as {
+          __RSPRESS_PAGE_META: Record<string, PageMeta>;
+        }
+      ).__RSPRESS_PAGE_META?.[encodedPagePath] || ({} as PageMeta);
+    // mdx loader will generate __RSPRESS_PAGE_META,
+    // if the filePath don't match it, we can get meta from j(t)sx if we customize it
+    const {
+      toc = [],
+      title = '',
+      frontmatter = {},
+      ...rest
+    } = MDX_OR_MD_REGEXP.test(matchedRoute.filePath)
+      ? meta
+      : (mod as unknown as PageMeta);
+    return {
+      siteData,
+      page: {
+        ...rest,
+        pagePath,
+        ...extractPageInfo,
+        pageType: frontmatter?.pageType || 'doc',
+        title,
+        frontmatter,
+        toc,
+      },
+    } satisfies PageData;
+  }
+
+  let lang = siteData.lang || '';
+  let version = siteData.multiVersion?.default || '';
+
+  if (siteData.lang && typeof window !== 'undefined') {
+    const path = location.pathname
+      .replace(siteData.base, '')
+      .split('/')
+      .slice(0, 2);
+
+    if (siteData.locales.length) {
+      const result = siteData.locales.find(({ lang }) => path.includes(lang));
+
+      if (result) {
+        lang = result.lang;
+      }
+    }
+
+    if (siteData.multiVersion.versions) {
+      const result = siteData.multiVersion.versions.find(version =>
+        path.includes(version),
+      );
+
+      if (result) {
+        version = result;
+      }
+    }
+  }
+
+  // 404 Page
+  return {
+    siteData,
+    page: {
+      pagePath: '',
+      pageType: '404',
+      routePath: '/404',
+      lang,
+      frontmatter: {},
+      title: '404',
+      toc: [],
+      version,
+      _filepath: '',
+      _relativePath: '',
+    },
+  };
+}

--- a/packages/core/src/runtime/ssrEntry.tsx
+++ b/packages/core/src/runtime/ssrEntry.tsx
@@ -2,7 +2,8 @@ import { DataContext, ThemeContext } from '@rspress/runtime';
 import { StaticRouter } from '@rspress/runtime/server';
 import type { PageData } from '@rspress/shared';
 import { renderToString } from 'react-dom/server';
-import { App, initPageData } from './App';
+import { App } from './App';
+import { initPageData } from './initPageData';
 
 const DEFAULT_THEME = 'light';
 

--- a/packages/theme-default/src/logic/useUISwitch.ts
+++ b/packages/theme-default/src/logic/useUISwitch.ts
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useEnableNav, useHiddenNav } from './useHiddenNav';
 import { useLocaleSiteData } from './useLocaleSiteData';
 
-export enum QueryStatus {
+enum QueryStatus {
   Show = '1',
   Hide = '0',
 }


### PR DESCRIPTION
## Summary

https://github.com/facebook/react/tree/main/packages/react-refresh

https://biomejs.dev/linter/rules/use-component-export-only-modules/

This is the prerequisite task for implementing the virtual module hmr, which allows the client here to be a React component that conforms to the react-refresh specification.

Or it won't trigger react-refresh

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
