### PR TITLE
chore(theme-default/style): right asideContainer should exist even no headers

### DIFF
--- a/packages/theme-default/src/layout/DocLayout/index.tsx
+++ b/packages/theme-default/src/layout/DocLayout/index.tsx
@@ -141,7 +141,7 @@ export function DocLayout(props: DocLayoutProps) {
               <ScrollToTop />
             </NoSSR>
           )}
-          {uiSwitch?.showAside && headers.length > 0 && (
+          {uiSwitch?.showAside && (
             <div
               className={styles.asideContainer}
               style={
@@ -150,9 +150,15 @@ export function DocLayout(props: DocLayoutProps) {
                   : { marginTop: 0, paddingTop: '32px' }
               }
             >
-              {beforeOutline}
-              <Aside headers={headers} outlineTitle={outlineTitle} />
-              {afterOutline}
+              {headers.length === 0 ? (
+                <></>
+              ) : (
+                <>
+                  {beforeOutline}
+                  <Aside headers={headers} outlineTitle={outlineTitle} />
+                  {afterOutline}
+                </>
+              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary

revert a style adjust to original behavior

<img width="400" alt="image" src="https://github.com/user-attachments/assets/ce57c56e-74a9-42be-9f1e-5947bc747009" />


#### before

<img width="400" alt="image" src="https://github.com/user-attachments/assets/d32f54e9-bea7-43fb-9ca4-28ca3a34931a" />

#### after

<img width="400" alt="image" src="https://github.com/user-attachments/assets/2112dbbb-236d-49d9-8da5-f84c85b733e7" />






## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
