### PR TITLE
fix(plugin-container): incorrect trimming in some cases

### DIFF
--- a/packages/plugin-container-syntax/src/remarkPlugin.ts
+++ b/packages/plugin-container-syntax/src/remarkPlugin.ts
@@ -271,7 +271,7 @@ function transformer(tree: Parent) {
           REGEX_END.test(lastChildInNode.value)
         ) {
           const lastChildInNodeText = lastChildInNode.value;
-          const matchedEndContent = lastChildInNodeText.slice(0, -3).trim();
+          const matchedEndContent = lastChildInNodeText.slice(0, -3).trimEnd();
           // eslint-disable-next-line max-depth
           if (wrappedChildren.length) {
             (wrappedChildren[0] as Paragraph).children.push({

--- a/packages/plugin-container-syntax/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-container-syntax/tests/__snapshots__/index.test.ts.snap
@@ -125,3 +125,10 @@ exports[`remark-container > nested in unordered list inside mdx component 1`] = 
 </li>
 </ul></div></div></div>"
 `;
+
+exports[`remark-container > start with a link 1`] = `"<div class="rspress-directive tip"><div class="rspress-directive-title">TIP</div><div class="rspress-directive-content"><p><a href="https://example.com">link</a> is a link</p></div></div>"`;
+
+exports[`remark-container > start with a link 2`] = `
+"<div class="rspress-directive tip"><div class="rspress-directive-title">TIP</div><div class="rspress-directive-content"><p>
+<a href="https://example.com">link</a> is a link</p></div></div>"
+`;

--- a/packages/plugin-container-syntax/tests/index.test.ts
+++ b/packages/plugin-container-syntax/tests/index.test.ts
@@ -15,6 +15,12 @@ describe('remark-container', () => {
     .use(remarkRehype)
     .use(rehypeStringify);
 
+  const processorWithoutDirective = unified()
+    .use(remarkParse)
+    .use(remarkPluginContainer)
+    .use(remarkRehype)
+    .use(rehypeStringify);
+
   const mdxProcessor = processor().use(remarkMdx);
 
   test('No newline', () => {
@@ -287,5 +293,23 @@ This is a details block.
 `);
 
     expect(result.value).toMatchSnapshot();
+  });
+
+  test('start with a link', () => {
+    const result = processor.processSync(`
+:::tip
+[link](https://example.com) is a link
+:::
+`);
+
+    expect(result.value).toMatchSnapshot();
+
+    const resultWithoutDirective = processorWithoutDirective.processSync(`
+:::tip
+[link](https://example.com) is a link
+:::
+`);
+
+    expect(resultWithoutDirective.value).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## Summary

Fixed an issue where the space after the link might be lost in the container syntax.

Found on Rsbuild documentation:

![image](https://github.com/user-attachments/assets/2d0c43e0-be82-4c47-b7c7-14a76e46b925)

## Related Issue

https://rsbuild.dev/guide/basic/css-usage#lightning-css

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
