### PR TITLE
fix(firefox): location too much change firefox issue

### DIFF
--- a/packages/theme-default/src/logic/useUISwitch.ts
+++ b/packages/theme-default/src/logic/useUISwitch.ts
@@ -105,13 +105,6 @@ export function useUISwitch(): UISwitchResult {
     };
   }, [location.search]);
 
-  // Control the scroll behavior of the browser when location hash changed
-  useEffect(() => {
-    if (inBrowser() && history.scrollRestoration) {
-      history.scrollRestoration = 'manual';
-    }
-  }, []);
-
   const navbarHeight = hiddenNav ? 0 : width <= 768 ? 56 : 72;
   const sidebarMenuHeight = showSidebarMenu ? 46 : 0;
   const scrollPaddingTop = navbarHeight + sidebarMenuHeight;

--- a/packages/theme-default/src/logic/useUISwitch.ts
+++ b/packages/theme-default/src/logic/useUISwitch.ts
@@ -1,5 +1,4 @@
 import { useLocation, usePageData, useWindowSize } from '@rspress/runtime';
-import { inBrowser } from '@rspress/shared';
 import { useEffect, useState } from 'react';
 import { useEnableNav, useHiddenNav } from './useHiddenNav';
 import { useLocaleSiteData } from './useLocaleSiteData';


### PR DESCRIPTION
## Summary

<img width="400" alt="image" src="https://github.com/user-attachments/assets/2a523ee8-e57a-42d3-9e78-6a3a3d0ef861" />


removed feature: scrollRestoration after reloading

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
