### PR TITLE
fix(plugin-container): avoid unexpected line breaks

### DIFF
--- a/packages/plugin-container-syntax/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-container-syntax/tests/__snapshots__/index.test.ts.snap
@@ -54,6 +54,27 @@ exports[`remark-container > details 1`] = `
 This is a details block.</p></div></details>"
 `;
 
+exports[`remark-container > end with a link 1`] = `"<div class="rspress-directive tip"><div class="rspress-directive-title">TIP</div><div class="rspress-directive-content"><p>Line 1.</p><p>Line 2 with <a href="http://example.com">link</a>.</p></div></div>"`;
+
+exports[`remark-container > end with a link 2`] = `
+"<div class="rspress-directive tip"><div class="rspress-directive-title">TIP</div><div class="rspress-directive-content"><p>
+Line 1.</p><p>Line 2 with <a href="http://example.com">link</a>.</p></div></div>"
+`;
+
+exports[`remark-container > end with a new line 1`] = `"<div class="rspress-directive tip"><div class="rspress-directive-title">TIP</div><div class="rspress-directive-content"><p>Line 1.</p><p>Line 2 with <a href="http://example.com">link</a>.</p></div></div>"`;
+
+exports[`remark-container > end with a new line 2`] = `
+"<div class="rspress-directive tip"><div class="rspress-directive-title">TIP</div><div class="rspress-directive-content"><p>
+Line 1.</p><p>Line 2 with <a href="http://example.com">link</a>.</p></div></div>"
+`;
+
+exports[`remark-container > end with an inline code 1`] = `"<div class="rspress-directive tip"><div class="rspress-directive-title">TIP</div><div class="rspress-directive-content"><p>Line 1.</p><p>Line 2 with <code>code</code>.</p></div></div>"`;
+
+exports[`remark-container > end with an inline code 2`] = `
+"<div class="rspress-directive tip"><div class="rspress-directive-title">TIP</div><div class="rspress-directive-content"><p>
+Line 1.</p><p>Line 2 with <code>code</code>.</p></div></div>"
+`;
+
 exports[`remark-container > github alerts ~ caution 1`] = `
 "<div class="rspress-directive caution"><div class="rspress-directive-title">CAUTION</div><div class="rspress-directive-content"><p>Use this code:-</p><pre><code class="language-javascript">console.log(69);
 </code></pre></div></div>"

--- a/packages/plugin-container-syntax/tests/index.test.ts
+++ b/packages/plugin-container-syntax/tests/index.test.ts
@@ -312,4 +312,72 @@ This is a details block.
 
     expect(resultWithoutDirective.value).toMatchSnapshot();
   });
+
+  test('end with a link', () => {
+    const result = processor.processSync(`
+:::tip
+Line 1.
+
+Line 2 with [link](http://example.com).
+:::
+`);
+
+    expect(result.value).toMatchSnapshot();
+
+    const resultWithoutDirective = processorWithoutDirective.processSync(`
+:::tip
+Line 1.
+
+Line 2 with [link](http://example.com).
+:::
+`);
+
+    expect(resultWithoutDirective.value).toMatchSnapshot();
+  });
+
+  test('end with an inline code', () => {
+    const result = processor.processSync(`
+:::tip
+Line 1.
+
+Line 2 with \`code\`.
+:::
+`);
+
+    expect(result.value).toMatchSnapshot();
+
+    const resultWithoutDirective = processorWithoutDirective.processSync(`
+:::tip
+Line 1.
+
+Line 2 with \`code\`.
+:::
+`);
+
+    expect(resultWithoutDirective.value).toMatchSnapshot();
+  });
+
+  test('end with a new line', () => {
+    const result = processor.processSync(`
+:::tip
+Line 1.
+
+Line 2 with [link](http://example.com).
+
+:::
+`);
+
+    expect(result.value).toMatchSnapshot();
+
+    const resultWithoutDirective = processorWithoutDirective.processSync(`
+:::tip
+Line 1.
+
+Line 2 with [link](http://example.com).
+
+:::
+`);
+
+    expect(resultWithoutDirective.value).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
## Summary

Fix unexpected line breaks when using the container syntax with mdx-js.

- Input:

```md
:::tip
Line 1.

Line 2 with [link](http://example.com).
:::
```

- Current output:

![image](https://github.com/user-attachments/assets/7f9abac8-8d23-4d54-b3e6-34ff685ca475)

- Expected output:

<img width="814" alt="Screenshot 2025-04-09 at 22 34 35" src="https://github.com/user-attachments/assets/5ad44dd8-e8a1-4a99-82f3-089f7998c82e" />

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
