### PR TITLE
fix: wrong hydration, hydrate twice

### DIFF
--- a/packages/core/src/node/runtimeModule/siteData/index.ts
+++ b/packages/core/src/node/runtimeModule/siteData/index.ts
@@ -126,7 +126,7 @@ export async function siteDataVMPlugin(context: FactoryContext) {
     locales: userConfig?.locales || userConfig.themeConfig?.locales || [],
     logo: userConfig?.logo || '',
     logoText: userConfig?.logoText || '',
-    ssg: Boolean(userConfig?.ssg) ?? true,
+    ssg: Boolean(userConfig?.ssg ?? true),
     multiVersion: {
       default: userConfig?.multiVersion?.default || '',
       versions: userConfig?.multiVersion?.versions || [],

--- a/packages/core/src/runtime/ClientApp.tsx
+++ b/packages/core/src/runtime/ClientApp.tsx
@@ -1,30 +1,21 @@
 import { BrowserRouter, DataContext, ThemeContext } from '@rspress/runtime';
 import type { PageData } from '@rspress/shared';
 import { useThemeState } from '@theme';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { App } from './App';
-import { initPageData } from './initPageData';
 
-export function ClientApp() {
-  const [data, setData] = useState<PageData>(null as any);
+// eslint-disable-next-line import/no-commonjs
+
+export function ClientApp({ initialPageData }: { initialPageData: PageData }) {
+  const [data, setData] = useState(initialPageData);
   const [theme, setTheme] = useThemeState();
-
-  useEffect(() => {
-    initPageData(window.location.pathname).then(pageData => {
-      setData(pageData);
-    });
-  }, []);
-
-  const themeValue = useMemo(() => ({ theme, setTheme }), [theme, setTheme]);
-  const dataValue = useMemo(() => ({ data, setData }), [data, setData]);
-
-  if (!data) {
-    return <></>;
-  }
-
   return (
-    <ThemeContext.Provider value={themeValue}>
-      <DataContext.Provider value={dataValue}>
+    <ThemeContext.Provider
+      value={useMemo(() => ({ theme, setTheme }), [theme, setTheme])}
+    >
+      <DataContext.Provider
+        value={useMemo(() => ({ data, setData }), [data, setData])}
+      >
         <BrowserRouter>
           <App />
         </BrowserRouter>

--- a/packages/core/src/runtime/clientEntry.tsx
+++ b/packages/core/src/runtime/clientEntry.tsx
@@ -1,6 +1,7 @@
 import { isProduction } from '@rspress/shared';
 import siteData from 'virtual-site-data';
 import { ClientApp } from './ClientApp';
+import { initPageData } from './initPageData';
 
 const enableSSG = siteData.ssg;
 
@@ -8,20 +9,29 @@ const enableSSG = siteData.ssg;
 
 async function renderInBrowser() {
   const container = document.getElementById('root')!;
+  const initialPageData = await initPageData(window.location.pathname);
 
   if (process.env.__REACT_GTE_18__) {
     const { createRoot, hydrateRoot } = await import('react-dom/client');
     if (isProduction() && enableSSG) {
-      hydrateRoot(container, <ClientApp />);
+      hydrateRoot(container, <ClientApp initialPageData={initialPageData} />);
     } else {
-      createRoot(container).render(<ClientApp />);
+      createRoot(container).render(
+        <ClientApp initialPageData={initialPageData} />,
+      );
     }
   } else {
     const ReactDOM = await import('react-dom');
     if (isProduction()) {
-      ReactDOM.hydrate(<ClientApp />, container);
+      ReactDOM.hydrate(
+        <ClientApp initialPageData={initialPageData} />,
+        container,
+      );
     } else {
-      ReactDOM.render(<ClientApp />, container);
+      ReactDOM.render(
+        <ClientApp initialPageData={initialPageData} />,
+        container,
+      );
     }
   }
 }


### PR DESCRIPTION
## Summary

in https://github.com/web-infra-dev/rspress/pull/2033, introduced a `useEffect` hook to get initialData (after rendering)

```ts
 useEffect(() => {
    initPageData(window.location.pathname).then(pageData => {
      setData(pageData);
    });
  }, []);
```

### before this pr

1. beforeHydration, `initialData: null`

2. afterHydration, render the html

3. useEffect, get initialData and render the html again

so we get two html in the same page

### after this pr

1. beforeHydration, `initialData: {...}`

2. afterHydration, render the html, hydrate successfully

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
