### PR TITLE
docs: correct meta tags generation example

### DIFF
--- a/packages/document/docs/en/api/config/config-frontmatter.mdx
+++ b/packages/document/docs/en/api/config/config-frontmatter.mdx
@@ -105,12 +105,8 @@ The generated head tags are as follows:
 
 ::: tip Note
 
-Make sure to correctly define the header tag names and their attribute names.
-
-For tags and attribute names that contain a hyphen (`-`), use the camelCase format.
-For example, `http-equiv="refresh"` should be defined as `httpEquiv: refresh`.
-
-This is because under the hood, headers are handled by React and react-helmet-async.
+- `head` only works in the production build, Rspress will inject the tags into the SSG generated HTML. You can run `rspress build && rspress preview` to see the effect.
+- Make sure to correctly define the header tag names and their attribute names. For tags and attribute names that contain a hyphen (`-`), use the camelCase format. For example, `http-equiv="refresh"` should be defined as `httpEquiv: refresh`. This is because under the hood, headers are handled by React and `react-helmet-async`.
 
 :::
 

--- a/packages/document/docs/en/api/config/config-frontmatter.mdx
+++ b/packages/document/docs/en/api/config/config-frontmatter.mdx
@@ -80,17 +80,27 @@ For example, you can use these headers to specify custom meta tags for [Open Gra
 head:
   - - meta
     - property: og:title
-      content: The Rock
+      content: My Home Page
   - - meta
     - property: og:url
-      content: https://www.imdb.com/title/tt0117500/
+      content: https://example.com/foo/
   - - meta
     - property: og:image
-      content: https://ia.media-imdb.com/images/rock.jpg
+      content: https://example.com/bar.jpg
 # - - [htmlTag]
 #   - [attributeName]: [attributeValue]
 #     [attributeName]: [attributeValue]
 ---
+```
+
+The generated head tags are as follows:
+
+```html
+<head>
+  <meta property="og:title" content="My Home Page" />
+  <meta property="og:url" content="https://example.com/foo/" />
+  <meta property="og:image" content="https://example.com/bar.jpg" />
+</head>
 ```
 
 ::: tip Note

--- a/packages/document/docs/en/guide/basic/custom-page.mdx
+++ b/packages/document/docs/en/guide/basic/custom-page.mdx
@@ -219,8 +219,13 @@ For example, if you want to add `<meta name="description" content="This is descr
 
 ```md title="example.mdx"
 ---
-title: This is title
-description: This is description
+head:
+  - - meta
+    - name: title
+      content: This is title
+  - - meta
+    - name: description
+      content: This is description
 ---
 ```
 

--- a/packages/document/docs/zh/api/config/config-frontmatter.mdx
+++ b/packages/document/docs/zh/api/config/config-frontmatter.mdx
@@ -103,15 +103,10 @@ head:
 </head>
 ```
 
-::: tip Note
+::: tip
 
-确保正确定义 head 的标签（tag）名称及其属性（attribute）名称。
-
-对于包含连字符（`-`）的标签和属性名称，请使用驼峰式大小写格式。
-
-例如，`http-equiv="refresh"` 应定义为 `httpEquiv: refresh`。
-
-这是因为 headers 在底层由 React 和 react-helmet-async 处理。
+- `head` 仅在生产构建时生效，Rspress 会将标签注入到 SSG 生成的 HTML 中。你可以运行 `rspress build && rspress preview` 来查看效果。
+- 请确保为 head 标签和属性名称使用正确的格式。对于包含连字符（-）的标签或属性名，需要采用驼峰式命名法。例如，HTML 中的 `http-equiv="refresh"` 在配置中应写为 `httpEquiv: refresh`。这是因为 Rspress 底层使用 React 和 `react-helmet-async` 处理这些 headers。
 
 :::
 

--- a/packages/document/docs/zh/api/config/config-frontmatter.mdx
+++ b/packages/document/docs/zh/api/config/config-frontmatter.mdx
@@ -80,17 +80,27 @@ titleSuffix: '| 基于 Rsbuild 的静态站点生成器'
 head:
   - - meta
     - property: og:title
-      content: The Rock
+      content: My Home Page
   - - meta
     - property: og:url
-      content: https://www.imdb.com/title/tt0117500/
+      content: https://example.com/foo/
   - - meta
     - property: og:image
-      content: https://ia.media-imdb.com/images/rock.jpg
+      content: https://example.com/bar.jpg
 # - - [htmlTag]
 #   - [attributeName]: [attributeValue]
 #     [attributeName]: [attributeValue]
 ---
+```
+
+生成的 head 标签如下：
+
+```html
+<head>
+  <meta property="og:title" content="My Home Page" />
+  <meta property="og:url" content="https://example.com/foo/" />
+  <meta property="og:image" content="https://example.com/bar.jpg" />
+</head>
 ```
 
 ::: tip Note

--- a/packages/document/docs/zh/guide/basic/custom-page.mdx
+++ b/packages/document/docs/zh/guide/basic/custom-page.mdx
@@ -224,8 +224,13 @@ http://YOUR_DOMAIN/foo?navbar=0&outline=0
 
 ```md title="example.mdx"
 ---
-title: This is title
-description: This is description
+head:
+  - - meta
+    - name: title
+      content: This is title
+  - - meta
+    - name: description
+      content: This is description
 ---
 ```
 


### PR DESCRIPTION
## Summary

Correct the meta tags generation examples. We should use the `head` front matter to generate meta tags instead of using `title` and `description`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
