### PR TITLE
feat!: drop support for Node 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "packageManager": "pnpm@10.2.0",
   "engines": {
-    "node": ">=16.18.1"
+    "node": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -111,7 +111,7 @@
     "vfile": "^5.3.7"
   },
   "engines": {
-    "node": ">=14.17.6"
+    "node": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
       dts: {
         bundle: true,
       },
-      syntax: 'es2020',
+      syntax: 'es2022',
       shims: {
         esm: {
           require: true,
@@ -30,7 +30,7 @@ export default defineConfig({
     },
     {
       format: 'esm',
-      syntax: 'es2020',
+      syntax: 'es2022',
       dts: {
         bundle: true,
       },
@@ -54,7 +54,7 @@ export default defineConfig({
       bundle: false,
       dts: true,
       format: 'esm',
-      syntax: 'es2020',
+      syntax: 'es2022',
       source: {
         entry: {
           index: './src/runtime/*',

--- a/packages/create-rspress/package.json
+++ b/packages/create-rspress/package.json
@@ -38,7 +38,7 @@
     "typescript": "^5.8.2"
   },
   "engines": {
-    "node": ">=16.7.0"
+    "node": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-algolia/package.json
+++ b/packages/plugin-algolia/package.json
@@ -59,7 +59,7 @@
     "@rspress/runtime": "workspace:^2.0.0-beta.0"
   },
   "engines": {
-    "node": ">=14.17.6"
+    "node": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-api-docgen/package.json
+++ b/packages/plugin-api-docgen/package.json
@@ -59,7 +59,7 @@
     }
   },
   "engines": {
-    "node": ">=14.17.6"
+    "node": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-api-docgen/rslib.config.ts
+++ b/packages/plugin-api-docgen/rslib.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
         bundle: true,
       },
       format: 'esm',
-      syntax: 'es2020',
+      syntax: 'es2022',
     },
   ],
 });

--- a/packages/plugin-auto-nav-sidebar/package.json
+++ b/packages/plugin-auto-nav-sidebar/package.json
@@ -47,7 +47,7 @@
     "typescript": "^5.8.2"
   },
   "engines": {
-    "node": ">=14.17.6"
+    "node": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-client-redirects/package.json
+++ b/packages/plugin-client-redirects/package.json
@@ -51,7 +51,7 @@
     "@rspress/runtime": "workspace:^2.0.0-beta.0"
   },
   "engines": {
-    "node": ">=14.17.6"
+    "node": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-container-syntax/package.json
+++ b/packages/plugin-container-syntax/package.json
@@ -51,7 +51,7 @@
     "unified": "^11.0.5"
   },
   "engines": {
-    "node": ">=14.17.6"
+    "node": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-last-updated/package.json
+++ b/packages/plugin-last-updated/package.json
@@ -49,7 +49,7 @@
     "typescript": "^5.8.2"
   },
   "engines": {
-    "node": ">=14.17.6"
+    "node": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-medium-zoom/package.json
+++ b/packages/plugin-medium-zoom/package.json
@@ -52,7 +52,7 @@
     "@rspress/runtime": "workspace:^2.0.0-beta.0"
   },
   "engines": {
-    "node": ">=14.17.6"
+    "node": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-playground/package.json
+++ b/packages/plugin-playground/package.json
@@ -66,7 +66,7 @@
     "react-router-dom": "^6.8.1"
   },
   "engines": {
-    "node": ">=14.17.6"
+    "node": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-playground/rslib.config.ts
+++ b/packages/plugin-playground/rslib.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
         },
         externals: ['@types/react'],
       },
-      syntax: 'es2020',
+      syntax: 'es2022',
       dts: { bundle: true },
     },
     {
@@ -36,7 +36,7 @@ export default defineConfig({
           root: 'dist/web',
         },
       },
-      syntax: 'es2020',
+      syntax: 'es2022',
       dts: { bundle: true },
     },
   ],

--- a/packages/plugin-preview/package.json
+++ b/packages/plugin-preview/package.json
@@ -62,7 +62,7 @@
     "react-router-dom": "^6.8.1"
   },
   "engines": {
-    "node": ">=14.17.6"
+    "node": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-preview/rslib.config.ts
+++ b/packages/plugin-preview/rslib.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
           utils: 'src/utils.ts',
         },
       },
-      syntax: 'es2020',
+      syntax: 'es2022',
       dts: {
         bundle: true,
       },

--- a/packages/plugin-rss/package.json
+++ b/packages/plugin-rss/package.json
@@ -45,7 +45,7 @@
     "rspress": "workspace:^2.0.0-beta.0"
   },
   "engines": {
-    "node": ">=14.17.6"
+    "node": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-rss/rslib.config.ts
+++ b/packages/plugin-rss/rslib.config.ts
@@ -4,6 +4,6 @@ import { pluginPublint } from 'rsbuild-plugin-publint';
 export default defineConfig({
   plugins: [pluginPublint()],
   lib: [
-    { bundle: true, syntax: 'es2020', format: 'esm', dts: { bundle: true } },
+    { bundle: true, syntax: 'es2022', format: 'esm', dts: { bundle: true } },
   ],
 });

--- a/packages/plugin-shiki/package.json
+++ b/packages/plugin-shiki/package.json
@@ -56,7 +56,7 @@
     "typescript": "^5.8.2"
   },
   "engines": {
-    "node": ">=14.17.6"
+    "node": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-typedoc/package.json
+++ b/packages/plugin-typedoc/package.json
@@ -52,7 +52,7 @@
     "rspress": "workspace:^2.0.0-beta.0"
   },
   "engines": {
-    "node": ">=14.17.6"
+    "node": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -58,7 +58,7 @@
     "typescript": "^5.8.2"
   },
   "engines": {
-    "node": ">=14.17.6"
+    "node": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/runtime/rslib.config.ts
+++ b/packages/runtime/rslib.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
       },
       dts: true,
       format: 'esm',
-      syntax: 'es2020',
+      syntax: 'es2022',
       output: {
         externals: [
           ...COMMON_EXTERNALS,

--- a/packages/theme-default/package.json
+++ b/packages/theme-default/package.json
@@ -81,7 +81,7 @@
     "typescript": "^5.8.2"
   },
   "engines": {
-    "node": ">=14.17.6"
+    "node": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/theme-default/rslib.config.ts
+++ b/packages/theme-default/rslib.config.ts
@@ -83,7 +83,7 @@ export default defineConfig({
         },
       },
       format: 'esm',
-      syntax: 'es2020',
+      syntax: 'es2022',
       output: {
         distPath: {
           root: 'dist/node',
@@ -94,7 +94,7 @@ export default defineConfig({
     // pre-built svg files
     {
       format: 'esm',
-      syntax: 'es2020',
+      syntax: 'es2022',
       bundle: false,
       plugins: [
         pluginReact(),


### PR DESCRIPTION
## Summary

Node16 has reached EOL on September 11th, 2023, see https://nodejs.org/en/blog/announcements/nodejs16-eol

Rspress 2.0 will drop support for Node 16 and the minimum supported Node version is 18.

This PR also changed the Rslib build target to `es2022` to match with the current Node version.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
