### PR TITLE
fix(style): change flex to rp-flex

### DIFF
--- a/packages/plugin-preview/static/global-components/Container.tsx
+++ b/packages/plugin-preview/static/global-components/Container.tsx
@@ -45,7 +45,7 @@ const Container: React.FC<ContainerProps> = props => {
     <NoSSR>
       <div className="rspress-preview">
         {isMobile === 'true' ? (
-          <div className="rspress-preview-wrapper flex">
+          <div className="rspress-preview-wrapper rp-flex">
             <div className="rspress-preview-code">{children?.[0]}</div>
             <div className="rspress-preview-device">
               <iframe src={getPageUrl()} key={iframeKey}></iframe>


### PR DESCRIPTION
## Summary

Issue from https://github.com/web-infra-dev/rspress/pull/1990.

Change className `flex` to `rp-flex`.

## Related Issue

none

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
