### PR TITLE
docs: add v2 website link to v1 website

### DIFF
--- a/packages/document/docs/en/_meta.json
+++ b/packages/document/docs/en/_meta.json
@@ -13,5 +13,18 @@
     "text": "api",
     "link": "/api/",
     "activeMatch": "/api/"
+  },
+  {
+    "text": "Version",
+    "items": [
+      {
+        "text": "Changelog",
+        "link": "https://github.com/web-infra-dev/rspress/releases"
+      },
+      {
+        "text": "Rspress 2.x Doc",
+        "link": "http://v2.rspress.dev/"
+      }
+    ]
   }
 ]

--- a/packages/document/docs/zh/_meta.json
+++ b/packages/document/docs/zh/_meta.json
@@ -13,5 +13,18 @@
     "text": "api",
     "link": "/api/",
     "activeMatch": "/api/"
+  },
+  {
+    "text": "版本",
+    "items": [
+      {
+        "text": "更新日志",
+        "link": "https://github.com/web-infra-dev/rspress/releases"
+      },
+      {
+        "text": "Rspress 2.x 文档",
+        "link": "http://v2.rspress.dev/zh/"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

Add Rspress v2 website link to v1 website.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
