### PR TITLE
fix(plugin-llms): group routes correctly without locales config

### DIFF
--- a/packages/plugin-llms/src/plugin.ts
+++ b/packages/plugin-llms/src/plugin.ts
@@ -336,7 +336,7 @@ export function pluginLlms(options: Options = {}): RspressPlugin {
           ? locales
               .filter(i => Boolean(i.nav))
               .map(i => ({ nav: i.nav, lang: i.lang }))
-          : [{ nav: config.themeConfig?.nav, lang: config.lang }]
+          : [{ nav: config.themeConfig?.nav, lang: config.lang ?? '' }]
       ) as {
         nav: Nav;
         lang: string;
@@ -345,7 +345,7 @@ export function pluginLlms(options: Options = {}): RspressPlugin {
 
       titleRef.current = config.title;
       descriptionRef.current = config.description;
-      langRef.current = config.lang;
+      langRef.current = config.lang ?? '';
       baseRef.current = config.base ?? '/';
       docDirectoryRef.current = config.root ?? 'docs';
     },

--- a/packages/plugin-llms/src/plugin.ts
+++ b/packages/plugin-llms/src/plugin.ts
@@ -319,19 +319,25 @@ export function pluginLlms(options: Options = {}): RspressPlugin {
       }
     },
     beforeBuild(config) {
-      const configSidebar = config?.themeConfig?.locales
-        ?.map(i => i.sidebar)
-        .reduce((prev: Sidebar, curr) => {
-          Object.assign(prev, curr);
-          return prev;
-        }, {} as Sidebar);
+      const locales = config.themeConfig?.locales;
+      const isMultiLang = locales && locales.length > 0;
+      const sidebars = isMultiLang
+        ? locales.map(i => i.sidebar)
+        : [config.themeConfig?.sidebar];
+
+      const configSidebar = sidebars.reduce((prev: Sidebar, curr) => {
+        Object.assign(prev, curr);
+        return prev;
+      }, {} as Sidebar);
       Object.assign(sidebar, configSidebar);
 
-      const configNav = config.themeConfig?.locales
-        ?.filter(i => Boolean(i.nav))
-        ?.map(i => {
-          return { nav: i.nav, lang: i.lang };
-        }) as {
+      const configNav = (
+        isMultiLang
+          ? locales
+              .filter(i => Boolean(i.nav))
+              .map(i => ({ nav: i.nav, lang: i.lang }))
+          : [{ nav: config.themeConfig?.nav, lang: config.lang }]
+      ) as {
         nav: Nav;
         lang: string;
       }[];


### PR DESCRIPTION
## Summary

When `config.themeConfig.locales` is not configured, `plugin-llms` will group every route under `others` instead of grouping them using root navigation. This PR fixes this behaviour by using `config.themeConfig.sidebar` & `config.themeConfig.nav` when no locales are configured.

### Outputs

<details>
<summary>llms.txt before</summary>

```md

# Rspress

> Rsbuild based static site generator

## Other

- [Built-in components](/api/client-api/api-components.md)
- [Runtime API](/api/client-api/api-runtime.md)
- [Commands](/api/commands.md)
- [Basic config](/api/config/config-basic.md)
- [Build config](/api/config/config-build.md)
- [Front matter config](/api/config/config-frontmatter.md)
- [Theme config](/api/config/config-theme.md)
- [API Overview](/api/index.md)
- [Customize search functions](/guide/advanced/custom-search.md)
- [Custom theme](/guide/advanced/custom-theme.md)
- [Build extension](/guide/advanced/extend-build.md)
- [Autogenerated navigation](/guide/basic/auto-nav-sidebar.md)
- [Conventional route](/guide/basic/conventional-route.md)
- [Customizing page](/guide/basic/custom-page.md)
- [Deployment](/guide/basic/deploy.md)
- [Static site generation](/guide/basic/ssg.md)
- [Static assets](/guide/basic/static-assets.md)
- [Use MDX](/guide/basic/use-mdx.md)
- [Built-in components](/guide/default-theme/components.md)
- [Doc page](/guide/default-theme/doc-page.md)
- [Home page](/guide/default-theme/home-page.md)
- [Internationalization](/guide/default-theme/i18n.md)
- [Multi version](/guide/default-theme/multi-version.md)
- [Navbar](/guide/default-theme/navbar.md)
- [Overview page](/guide/default-theme/overview-page.md)
- [Quick start](/guide/start/getting-started.md)
- [Introduction](/guide/start/introduction.md)
- [Overview](/plugin/community-plugins/overview.md)
- [@rspress/plugin-algolia](/plugin/official-plugins/algolia.md)
- [@rspress/plugin-api-docgen](/plugin/official-plugins/api-docgen.md)
- [@rspress/plugin-client-redirects](/plugin/official-plugins/client-redirects.md)
- [@rspress/plugin-container-syntax](/plugin/official-plugins/container-syntax.md)
- [@rspress/plugin-last-updated](/plugin/official-plugins/last-updated.md)
- [@rspress/plugin-llms](/plugin/official-plugins/llms.md)
- [@rspress/plugin-medium-zoom](/plugin/official-plugins/medium-zoom.md)
- [Overview](/plugin/official-plugins/overview.md)
- [@rspress/plugin-playground](/plugin/official-plugins/playground.md)
- [@rspress/plugin-preview](/plugin/official-plugins/preview.md)
- [@rspress/plugin-rss](/plugin/official-plugins/rss.md)
- [@rspress/plugin-shiki](/plugin/official-plugins/shiki.md)
- [@rspress/plugin-typedoc](/plugin/official-plugins/typedoc.md)
- [Introduction](/plugin/system/introduction.md)
- [Plugin API](/plugin/system/plugin-api.md)
- [Write a plugin](/plugin/system/write-a-plugin.md)

```

</details>

<details>
<summary>llms.txt after</summary>

```md

# Rspress

> Rsbuild based static site generator

## Guide

- [Introduction](/guide/start/introduction.md)
- [Quick start](/guide/start/getting-started.md)
- [Conventional route](/guide/basic/conventional-route.md)
- [Autogenerated navigation](/guide/basic/auto-nav-sidebar.md)
- [Use MDX](/guide/basic/use-mdx.md)
- [Static assets](/guide/basic/static-assets.md)
- [Customizing page](/guide/basic/custom-page.md)
- [Static site generation](/guide/basic/ssg.md)
- [Deployment](/guide/basic/deploy.md)
- [Navbar](/guide/default-theme/navbar.md)
- [Home page](/guide/default-theme/home-page.md)
- [Doc page](/guide/default-theme/doc-page.md)
- [Overview page](/guide/default-theme/overview-page.md)
- [Internationalization](/guide/default-theme/i18n.md)
- [Multi version](/guide/default-theme/multi-version.md)
- [Built-in components](/guide/default-theme/components.md)
- [Build extension](/guide/advanced/extend-build.md)
- [Custom theme](/guide/advanced/custom-theme.md)
- [Customize search functions](/guide/advanced/custom-search.md)

## Plugin

- [Introduction](/plugin/system/introduction.md)
- [Write a plugin](/plugin/system/write-a-plugin.md)
- [Plugin API](/plugin/system/plugin-api.md)
- [Overview](/plugin/official-plugins/overview.md)
- [@rspress/plugin-llms](/plugin/official-plugins/llms.md)
- [@rspress/plugin-medium-zoom](/plugin/official-plugins/medium-zoom.md)
- [@rspress/plugin-client-redirects](/plugin/official-plugins/client-redirects.md)
- [@rspress/plugin-last-updated](/plugin/official-plugins/last-updated.md)
- [@rspress/plugin-container-syntax](/plugin/official-plugins/container-syntax.md)
- [@rspress/plugin-typedoc](/plugin/official-plugins/typedoc.md)
- [@rspress/plugin-api-docgen](/plugin/official-plugins/api-docgen.md)
- [@rspress/plugin-preview](/plugin/official-plugins/preview.md)
- [@rspress/plugin-playground](/plugin/official-plugins/playground.md)
- [@rspress/plugin-rss](/plugin/official-plugins/rss.md)
- [@rspress/plugin-shiki](/plugin/official-plugins/shiki.md)
- [@rspress/plugin-algolia](/plugin/official-plugins/algolia.md)
- [Overview](/plugin/community-plugins/overview.md)

## API

- [API Overview](/api/index.md)
- [Basic config](/api/config/config-basic.md)
- [Theme config](/api/config/config-theme.md)
- [Front matter config](/api/config/config-frontmatter.md)
- [Build config](/api/config/config-build.md)
- [Runtime API](/api/client-api/api-runtime.md)
- [Built-in components](/api/client-api/api-components.md)
- [Commands](/api/commands.md)

```

</details>


## Related Issue

n/a

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
