### PR TITLE
fix(theme/dynamic-toc): should abandon all elements with `display: none`.

### DIFF
--- a/packages/theme-default/src/components/Aside/index.tsx
+++ b/packages/theme-default/src/components/Aside/index.tsx
@@ -43,7 +43,7 @@ export function Aside({ outlineTitle }: { outlineTitle: string }) {
   const headers = useDynamicToc();
 
   // For outline text highlight
-  const baseHeaderLevel = headers[0]?.depth || 2;
+  const baseHeaderLevel = 2;
 
   const { hash: locationHash = '', pathname } = useLocation();
   const decodedHash: string = useMemo(
@@ -81,9 +81,9 @@ export function Aside({ outlineTitle }: { outlineTitle: string }) {
         </div>
         <nav className="rp-mt-1">
           <ul className="rp-relative">
-            {headers.map(header => (
+            {headers.map((header, index) => (
               <TocItem
-                key={`${header.depth}_${header.text}_${header.id}`}
+                key={`${header.depth}_${header.text}_${header.id}_${index}`}
                 baseHeaderLevel={baseHeaderLevel}
                 header={header}
               />


### PR DESCRIPTION
## Summary

1. fix the edge case, should abandon all elements with `display: none`

2. always set baseLevel = 2


before
<img width="500" alt="image" src="https://github.com/user-attachments/assets/10ec97a4-d034-4296-9c46-a287e463b993" />

after

<img width="500" alt="image" src="https://github.com/user-attachments/assets/415de1e5-5f85-452a-94fb-8c29cd3b3b86" />



## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
