### PR TITLE
chore(deps): migrate react-helmet to @unhead/react@2.0.0

### DIFF
--- a/e2e/tests/custom-headers.test.ts
+++ b/e2e/tests/custom-headers.test.ts
@@ -90,7 +90,10 @@ test.describe('custom headers', async () => {
 
     const htmlContent = await page.content();
     expect(htmlContent).toContain(
-      '<meta name="custom-meta" content="custom-meta-content"><meta name="custom-meta-2" content="custom-meta-content-2">',
+      '<meta name="custom-meta" content="custom-meta-content">',
+    );
+    expect(htmlContent).toContain(
+      '<meta name="custom-meta-2" content="custom-meta-content-2">',
     );
   });
 });

--- a/e2e/tests/title-suffix.test.ts
+++ b/e2e/tests/title-suffix.test.ts
@@ -10,12 +10,12 @@ test('title suffix', async () => {
   expect(
     (
       await readFile(path.join(appDir, 'doc_build/index.html'), 'utf-8')
-    ).includes('<title data-rh="true">Default Title - Index Suffix</title>'),
+    ).includes('<title>Default Title - Index Suffix</title>'),
   ).toBeTruthy();
 
   expect(
     (await readFile(path.join(appDir, 'doc_build/foo.html'), 'utf-8')).includes(
-      '<title data-rh="true">Foo | Foo Suffix</title>',
+      '<title>Foo | Foo Suffix</title>',
     ),
   ).toBeTruthy();
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,6 @@
     "reset": "rimraf ./**/node_modules"
   },
   "dependencies": {
-    "@dr.pogodin/react-helmet": "2.0.4",
     "@mdx-js/loader": "^3.1.0",
     "@mdx-js/mdx": "^3.1.0",
     "@mdx-js/react": "^3.1.0",
@@ -61,6 +60,7 @@
     "@rspress/runtime": "workspace:*",
     "@rspress/shared": "workspace:*",
     "@rspress/theme-default": "workspace:*",
+    "@unhead/react": "^2.0.0",
     "enhanced-resolve": "5.18.1",
     "github-slugger": "^2.0.0",
     "hast-util-from-html": "^2.0.3",

--- a/packages/core/src/node/constants.ts
+++ b/packages/core/src/node/constants.ts
@@ -57,8 +57,6 @@ export const OUTPUT_DIR = 'doc_build';
 export const APP_HTML_MARKER = '<!--<?- DOC_CONTENT ?>-->';
 export const HEAD_MARKER = '<!--<?- HEAD ?>-->';
 export const META_GENERATOR = '<!--<?- GENERATOR ?>-->';
-export const HTML_START_TAG = '<html';
-export const BODY_START_TAG = '<body';
 
 export const DEFAULT_TITLE = 'Rspress';
 

--- a/packages/core/src/runtime/App.tsx
+++ b/packages/core/src/runtime/App.tsx
@@ -1,4 +1,3 @@
-import { HelmetProvider } from '@dr.pogodin/react-helmet';
 import { DataContext, useLocation } from '@rspress/runtime';
 import { Layout } from '@theme';
 import React, { useContext, useLayoutEffect } from 'react';
@@ -11,7 +10,7 @@ enum QueryStatus {
   Hide = '0',
 }
 
-export function App({ helmetContext }: { helmetContext?: object }) {
+export function App() {
   const { setData: setPageData, data } = useContext(DataContext);
   const { pathname, search } = useLocation();
   useLayoutEffect(() => {
@@ -41,7 +40,7 @@ export function App({ helmetContext }: { helmetContext?: object }) {
     query.get(GLOBAL_COMPONENTS_KEY) === QueryStatus.Hide;
 
   return (
-    <HelmetProvider context={helmetContext}>
+    <>
       <Layout />
       {
         // Global UI
@@ -64,6 +63,6 @@ export function App({ helmetContext }: { helmetContext?: object }) {
             });
           })
       }
-    </HelmetProvider>
+    </>
   );
 }

--- a/packages/core/src/runtime/ClientApp.tsx
+++ b/packages/core/src/runtime/ClientApp.tsx
@@ -22,11 +22,11 @@ export function ClientApp({
       <DataContext.Provider
         value={useMemo(() => ({ data, setData }), [data, setData])}
       >
-        <UnheadProvider head={head}>
-          <BrowserRouter>
+        <BrowserRouter>
+          <UnheadProvider head={head}>
             <App />
-          </BrowserRouter>
-        </UnheadProvider>
+          </UnheadProvider>
+        </BrowserRouter>
       </DataContext.Provider>
     </ThemeContext.Provider>
   );

--- a/packages/core/src/runtime/ClientApp.tsx
+++ b/packages/core/src/runtime/ClientApp.tsx
@@ -1,8 +1,11 @@
 import { BrowserRouter, DataContext, ThemeContext } from '@rspress/runtime';
 import type { PageData } from '@rspress/shared';
 import { useThemeState } from '@theme';
+import { UnheadProvider, createHead } from '@unhead/react/client';
 import { useMemo, useState } from 'react';
 import { App } from './App';
+
+const head = createHead();
 
 // eslint-disable-next-line import/no-commonjs
 
@@ -19,9 +22,11 @@ export function ClientApp({
       <DataContext.Provider
         value={useMemo(() => ({ data, setData }), [data, setData])}
       >
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
+        <UnheadProvider head={head}>
+          <BrowserRouter>
+            <App />
+          </BrowserRouter>
+        </UnheadProvider>
       </DataContext.Provider>
     </ThemeContext.Provider>
   );

--- a/packages/core/src/runtime/ssrServerEntry.tsx
+++ b/packages/core/src/runtime/ssrServerEntry.tsx
@@ -1,7 +1,9 @@
 import { DataContext, ThemeContext } from '@rspress/runtime';
 import { StaticRouter } from '@rspress/runtime/server';
 import type { PageData } from '@rspress/shared';
+import { type Unhead, UnheadProvider } from '@unhead/react/server';
 import { renderToString } from 'react-dom/server';
+
 import { App } from './App';
 import { initPageData } from './initPageData';
 
@@ -9,7 +11,7 @@ const DEFAULT_THEME = 'light';
 
 export async function render(
   pagePath: string,
-  helmetContext: object,
+  head: Unhead,
 ): Promise<{ appHtml: string; pageData: PageData }> {
   const initialPageData = await initPageData(pagePath);
 
@@ -17,7 +19,9 @@ export async function render(
     <ThemeContext.Provider value={{ theme: DEFAULT_THEME }}>
       <DataContext.Provider value={{ data: initialPageData }}>
         <StaticRouter location={pagePath}>
-          <App helmetContext={helmetContext} />
+          <UnheadProvider value={head}>
+            <App />
+          </UnheadProvider>
         </StaticRouter>
       </DataContext.Provider>
     </ThemeContext.Provider>,

--- a/packages/plugin-rss/static/global-components/FeedsAnnotations.tsx
+++ b/packages/plugin-rss/static/global-components/FeedsAnnotations.tsx
@@ -1,14 +1,14 @@
 /// <reference path="../../index.d.ts" />
 
 import type { LinkHTMLAttributes } from 'react';
-import { Helmet, usePageData } from 'rspress/runtime';
+import { Head, usePageData } from 'rspress/runtime';
 
 export default function FeedsAnnotations() {
   const { page } = usePageData();
   const feeds = page.feeds || [];
 
   return (
-    <Helmet>
+    <Head>
       {feeds.map(({ language, url, mime }) => {
         const props: LinkHTMLAttributes<HTMLLinkElement> = {
           rel: 'alternate',
@@ -21,6 +21,6 @@ export default function FeedsAnnotations() {
         // biome-ignore lint/correctness/useJsxKeyInIterable: no key props
         return <link {...props} />;
       })}
-    </Helmet>
+    </Head>
   );
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -41,8 +41,8 @@
     "reset": "rimraf ./**/node_modules"
   },
   "dependencies": {
-    "@dr.pogodin/react-helmet": "2.0.4",
     "@rspress/shared": "workspace:*",
+    "@unhead/react": "^2.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^6.29.0"

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -37,5 +37,5 @@ export {
   pathnameToRouteService,
   normalizeRoutePath,
 } from './route';
-export { Helmet } from '@dr.pogodin/react-helmet';
+export { Head } from '@unhead/react';
 export { NoSSR } from './NoSSR';

--- a/packages/theme-default/package.json
+++ b/packages/theme-default/package.json
@@ -44,10 +44,10 @@
     "reset": "rimraf ./**/node_modules"
   },
   "dependencies": {
-    "@dr.pogodin/react-helmet": "2.0.4",
     "@mdx-js/react": "2.3.0",
     "@rspress/runtime": "workspace:*",
     "@rspress/shared": "workspace:*",
+    "@unhead/react": "^2.0.0",
     "body-scroll-lock": "4.0.0-beta.0",
     "copy-to-clipboard": "^3.3.3",
     "flexsearch": "0.7.43",

--- a/packages/theme-default/src/layout/Layout/index.tsx
+++ b/packages/theme-default/src/layout/Layout/index.tsx
@@ -1,12 +1,13 @@
 import 'nprogress/nprogress.css';
 import '../../styles';
-import { Helmet } from '@dr.pogodin/react-helmet';
 import { Content, usePageData } from '@rspress/runtime';
 import {
   HomeLayout as DefaultHomeLayout,
   NotFoundLayout as DefaultNotFoundLayout,
   Nav,
 } from '@theme';
+import { useHead } from '@unhead/react';
+import { Head } from '@unhead/react';
 import type React from 'react';
 import type { NavProps } from '../../components/Nav';
 import { useSetup } from '../../logic/sideEffects';
@@ -155,16 +156,18 @@ export function Layout(props: LayoutProps) {
     }
   };
 
+  useHead({
+    htmlAttrs: {
+      lang: currentLang || 'en',
+    },
+  });
+
   return (
     <>
-      <Helmet
-        htmlAttributes={{
-          lang: currentLang || 'en',
-        }}
-      >
+      <Head>
         {title ? <title>{title}</title> : null}
         {description ? <meta name="description" content={description} /> : null}
-      </Helmet>
+      </Head>
       {top}
 
       {pageType !== 'blank' && uiSwitch.showNavbar && (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -719,9 +719,6 @@ importers:
 
   packages/core:
     dependencies:
-      '@dr.pogodin/react-helmet':
-        specifier: 2.0.4
-        version: 2.0.4(react@19.1.0)
       '@mdx-js/loader':
         specifier: ^3.1.0
         version: 3.1.0(acorn@8.14.0)(webpack@5.99.3)
@@ -761,6 +758,9 @@ importers:
       '@rspress/theme-default':
         specifier: workspace:*
         version: link:../theme-default
+      '@unhead/react':
+        specifier: ^2.0.0
+        version: 2.0.8(react@19.1.0)
       enhanced-resolve:
         specifier: 5.18.1
         version: 5.18.1
@@ -1613,12 +1613,12 @@ importers:
 
   packages/runtime:
     dependencies:
-      '@dr.pogodin/react-helmet':
-        specifier: 2.0.4
-        version: 2.0.4(react@19.1.0)
       '@rspress/shared':
         specifier: workspace:*
         version: link:../shared
+      '@unhead/react':
+        specifier: ^2.0.0
+        version: 2.0.8(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -1702,9 +1702,6 @@ importers:
 
   packages/theme-default:
     dependencies:
-      '@dr.pogodin/react-helmet':
-        specifier: 2.0.4
-        version: 2.0.4(react@19.1.0)
       '@mdx-js/react':
         specifier: 2.3.0
         version: 2.3.0(react@19.1.0)
@@ -1714,6 +1711,9 @@ importers:
       '@rspress/shared':
         specifier: workspace:*
         version: link:../shared
+      '@unhead/react':
+        specifier: ^2.0.0
+        version: 2.0.8(react@19.1.0)
       body-scroll-lock:
         specifier: 4.0.0-beta.0
         version: 4.0.0-beta.0
@@ -2531,11 +2531,6 @@ packages:
         optional: true
       search-insights:
         optional: true
-
-  '@dr.pogodin/react-helmet@2.0.4':
-    resolution: {integrity: sha512-NXSgzBKiyvHF4UvR40fKRB0gTIlezfnyvmTqJKZy5Gbtv23SXMuneZbtovvG/sKxbOYPVn1lZl211bTKhd5g4w==}
-    peerDependencies:
-      react: '19'
 
   '@emnapi/core@1.3.0':
     resolution: {integrity: sha512-9hRqVlhwqBqCoToZ3hFcNVqL+uyHV06Y47ax4UB8L6XgVRqYz7MFnfessojo6+5TK89pKwJnpophwjTMOeKI9Q==}
@@ -3518,6 +3513,11 @@ packages:
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+
+  '@unhead/react@2.0.8':
+    resolution: {integrity: sha512-H/DmGG2Nz2OU3ASEZzLOIlwzQl027yOl0YhnlLEu3y6pvV/myLtgogcb68hXyHAtmpMAfnxhivUxCaiuFW7C6w==}
+    peerDependencies:
+      react: '>=18'
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
@@ -4582,10 +4582,6 @@ packages:
     resolution: {integrity: sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==}
     engines: {node: '>=8'}
 
-  get-stdin@9.0.0:
-    resolution: {integrity: sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==}
-    engines: {node: '>=12'}
-
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
@@ -4762,6 +4758,9 @@ packages:
   highlightjs-vue@1.0.0:
     resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
 
+  hookable@5.5.3:
+    resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
+
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
@@ -4855,9 +4854,6 @@ packages:
 
   inline-style-parser@0.2.4:
     resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
-
-  invariant@2.2.4:
-    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
   is-absolute-url@4.0.1:
     resolution: {integrity: sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==}
@@ -5152,10 +5148,6 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
-
-  loose-envify@1.4.0:
-    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
-    hasBin: true
 
   loupe@3.1.2:
     resolution: {integrity: sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==}
@@ -5986,9 +5978,6 @@ packages:
     peerDependencies:
       react: ^19.1.0
 
-  react-fast-compare@3.2.2:
-    resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
-
   react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
 
@@ -6442,9 +6431,6 @@ packages:
     resolution: {integrity: sha512-zTEg4HL0RwVrqcWs3ztF+x1vkxfm0lP+MQQFPiMJTKVceBwEV0A569Ou8l9IYQG8jOZdMVI1hGsc0tmeD2o/Lw==}
     engines: {node: '>=11.0'}
 
-  shallowequal@1.1.0:
-    resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
-
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -6827,6 +6813,9 @@ packages:
 
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+
+  unhead@2.0.8:
+    resolution: {integrity: sha512-63WR+y08RZE7ChiFdgNY64haAkhCtUS5/HM7xo4Q83NA63txWbEh2WGmrKbArdQmSct+XlqbFN8ZL1yWpQEHEA==}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -8122,13 +8111,6 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@dr.pogodin/react-helmet@2.0.4(react@19.1.0)':
-    dependencies:
-      invariant: 2.2.4
-      react: 19.1.0
-      react-fast-compare: 3.2.2
-      shallowequal: 1.1.0
-
   '@emnapi/core@1.3.0':
     dependencies:
       '@emnapi/wasi-threads': 1.0.1
@@ -9191,6 +9173,11 @@ snapshots:
       '@types/yargs-parser': 21.0.0
 
   '@ungap/structured-clone@1.2.0': {}
+
+  '@unhead/react@2.0.8(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      unhead: 2.0.8
 
   '@vitest/expect@2.1.9':
     dependencies:
@@ -10381,8 +10368,6 @@ snapshots:
 
   get-port@5.1.1: {}
 
-  get-stdin@9.0.0: {}
-
   get-stream@8.0.1: {}
 
   git-hooks-list@4.1.1: {}
@@ -10687,6 +10672,8 @@ snapshots:
 
   highlightjs-vue@1.0.0: {}
 
+  hookable@5.5.3: {}
+
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
@@ -10768,10 +10755,6 @@ snapshots:
   ini@4.1.1: {}
 
   inline-style-parser@0.2.4: {}
-
-  invariant@2.2.4:
-    dependencies:
-      loose-envify: 1.4.0
 
   is-absolute-url@4.0.1: {}
 
@@ -11053,10 +11036,6 @@ snapshots:
       wrap-ansi: 9.0.0
 
   longest-streak@3.1.0: {}
-
-  loose-envify@1.4.0:
-    dependencies:
-      js-tokens: 4.0.0
 
   loupe@3.1.2: {}
 
@@ -12349,8 +12328,6 @@ snapshots:
       react: 19.1.0
       scheduler: 0.26.0
 
-  react-fast-compare@3.2.2: {}
-
   react-is@18.2.0: {}
 
   react-lazy-with-preload@2.2.1: {}
@@ -12888,8 +12865,6 @@ snapshots:
       is-plain-object: 2.0.4
       is-primitive: 3.0.1
 
-  shallowequal@1.1.0: {}
-
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -13335,6 +13310,10 @@ snapshots:
 
   undici-types@6.20.0:
     optional: true
+
+  unhead@2.0.8:
+    dependencies:
+      hookable: 5.5.3
 
   unicorn-magic@0.1.0: {}
 

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -145,6 +145,7 @@ transpiling
 treeshaking
 tsbuildinfo
 tsdoc
+Unhead
 unocss
 unpatch
 unplugin


### PR DESCRIPTION
## Summary

![image](https://github.com/user-attachments/assets/c79d92db-0020-4be8-b666-90c4cf83428f)

`index.esm.js` should be `index.mjs`, we need a better react-helmet package.

## Related Issue

https://x.com/sebastienlorber/status/1918228101743493423?s=12&t=Ffc3Msu3HnW1tEsd7H6XfQ

https://github.com/web-infra-dev/rspress/issues/2111

react-helmet-async -> @dr.pogodin/react-helmet -> @unhead/react@2.0.0 

https://unhead.unjs.io/

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
