### PR TITLE
fix: the pkg type error in moduleResolution: node16

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,6 +60,7 @@
     "@rspress/runtime": "workspace:*",
     "@rspress/shared": "workspace:*",
     "@rspress/theme-default": "workspace:*",
+    "@types/unist": "^3.0.0",
     "@unhead/react": "^2.0.0",
     "enhanced-resolve": "5.18.1",
     "github-slugger": "^2.0.0",

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -57,7 +57,7 @@ export default defineConfig({
       syntax: 'es2022',
       source: {
         entry: {
-          index: './src/runtime/*',
+          index: './src/runtime/*.{tsx,ts}',
         },
         tsconfigPath: './src/runtime/tsconfig.json',
       },

--- a/packages/plugin-algolia/rslib.config.ts
+++ b/packages/plugin-algolia/rslib.config.ts
@@ -14,6 +14,11 @@ export default defineConfig({
       dts: true,
       format: 'esm',
       syntax: 'esnext',
+      redirect: {
+        dts: {
+          extension: true,
+        },
+      },
     },
     {
       source: {

--- a/packages/runtime/rslib.config.ts
+++ b/packages/runtime/rslib.config.ts
@@ -39,6 +39,11 @@ export default defineConfig({
           js: '[name].js',
         },
       },
+      redirect: {
+        dts: {
+          extension: true,
+        },
+      },
     },
   ],
   plugins: [pluginReact(), pluginPublint()],

--- a/packages/theme-default/.theme-entry.d.ts
+++ b/packages/theme-default/.theme-entry.d.ts
@@ -1,4 +1,4 @@
 // @ts-expect-error
-export * from './bundle';
+export * from './bundle.js';
 // @ts-expect-error
-export { default } from './bundle';
+export { default } from './bundle.js';

--- a/packages/theme-default/.theme-entry.js
+++ b/packages/theme-default/.theme-entry.js
@@ -1,4 +1,4 @@
 // Since the js bundle won't import css code after module tools build, we need to generate a entry file to import the css code.
 import './bundle.css';
 // @ts-expect-error
-export * from './bundle';
+export * from './bundle.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -758,6 +758,9 @@ importers:
       '@rspress/theme-default':
         specifier: workspace:*
         version: link:../theme-default
+      '@types/unist':
+        specifier: ^3.0.0
+        version: 3.0.2
       '@unhead/react':
         specifier: ^2.0.0
         version: 2.0.8(react@19.1.0)


### PR DESCRIPTION
## Summary

fix: the pkg type error in moduleResolution: node16

1. @types/unist Phantom dependency

<img width="870" alt="image" src="https://github.com/user-attachments/assets/2b1b69d7-ed1b-4755-a613-1b6d266be5e2" />


2. node16 moduleResolution


https://lib.rsbuild.dev/config/lib/redirect#redirectdtsextension

```ts
redirect: {
  dts: {
    extension: true
  }
}
```

## Related Issue

close #2114

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
