### PR TITLE
feat: upgrade create-rspress to support `npm create rspress@beta`

### DIFF
--- a/packages/create-rspress/template-basic/package.json
+++ b/packages/create-rspress/template-basic/package.json
@@ -8,7 +8,7 @@
     "preview": "rspress preview"
   },
   "dependencies": {
-    "rspress": "^1.40.2"
+    "rspress": "^2.0.0-beta.4"
   },
   "devDependencies": {
     "@types/node": "^18.11.17"

--- a/packages/document/theme/index.tsx
+++ b/packages/document/theme/index.tsx
@@ -2,6 +2,7 @@ import {
   Search as PluginAlgoliaSearch,
   ZH_LOCALES,
 } from '@rspress/plugin-algolia/runtime';
+import { Announcement } from '@rstack-dev/doc-ui/announcement';
 import { NavIcon } from '@rstack-dev/doc-ui/nav-icon';
 import {
   HomeLayout as BasicHomeLayout,
@@ -11,7 +12,7 @@ import {
 import { ToolStack } from './components/ToolStack';
 
 import './index.css';
-import { useLang } from 'rspress/runtime';
+import { NoSSR, useLang } from 'rspress/runtime';
 
 function HomeLayout() {
   const { pre: Pre, code: Code } = getCustomMDXComponent();
@@ -44,7 +45,25 @@ function HomeLayout() {
 }
 
 const Layout = () => {
-  return <BasicLayout beforeNavTitle={<NavIcon />} />;
+  const lang = useLang();
+  return (
+    <BasicLayout
+      beforeNavTitle={<NavIcon />}
+      beforeNav={
+        <NoSSR>
+          <Announcement
+            href="/"
+            message={
+              lang === 'en'
+                ? '🚧 Rspress 2.0 document is under development'
+                : '🚧 Rspress 2.0 文档还在开发中'
+            }
+            localStorageKey="rspress-announcement-closed"
+          />
+        </NoSSR>
+      }
+    />
+  );
 };
 
 const Search = () => {

--- a/packages/document/theme/index.tsx
+++ b/packages/document/theme/index.tsx
@@ -3,15 +3,44 @@ import {
   ZH_LOCALES,
 } from '@rspress/plugin-algolia/runtime';
 import { NavIcon } from '@rstack-dev/doc-ui/nav-icon';
-import { Layout as BasicLayout } from 'rspress/theme';
-import { HomeLayout as BasicHomeLayout } from 'rspress/theme';
+import {
+  HomeLayout as BasicHomeLayout,
+  Layout as BasicLayout,
+  getCustomMDXComponent,
+} from 'rspress/theme';
 import { ToolStack } from './components/ToolStack';
 
 import './index.css';
 import { useLang } from 'rspress/runtime';
 
 function HomeLayout() {
-  return <BasicHomeLayout afterFeatures={<ToolStack />} />;
+  const { pre: Pre, code: Code } = getCustomMDXComponent();
+  return (
+    <BasicHomeLayout
+      afterFeatures={<ToolStack />}
+      afterHeroActions={
+        <div
+          className="rspress-doc"
+          style={{ minHeight: 'auto', width: '100%', maxWidth: 400 }}
+        >
+          <Pre
+            codeHighlighter="shiki"
+            codeButtonGroupProps={{
+              showCodeWrapButton: false,
+            }}
+          >
+            <Code
+              className="language-bash"
+              codeHighlighter="shiki"
+              style={{ textAlign: 'center' }}
+            >
+              npm create rspress@beta
+            </Code>
+          </Pre>
+        </div>
+      }
+    />
+  );
 }
 
 const Layout = () => {

--- a/packages/theme-default/src/layout/DocLayout/docComponents/code/CodeButtonGroup.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/code/CodeButtonGroup.tsx
@@ -6,8 +6,18 @@ import { SvgWrapper } from '../../../../components/SvgWrapper';
 import { CopyCodeButton } from './CopyCodeButton';
 import * as styles from './index.module.scss';
 
-interface CodeButtonGroupProps extends ReturnType<typeof useCodeButtonGroup> {
+export interface CodeButtonGroupProps
+  extends ReturnType<typeof useCodeButtonGroup> {
   preElementRef: React.RefObject<HTMLPreElement>;
+
+  /**
+   * @default true
+   */
+  showCodeWrapButton?: boolean;
+  /**
+   * @default true
+   */
+  showCopyButton?: boolean;
 }
 
 export const useCodeButtonGroup = () => {
@@ -29,19 +39,25 @@ export function CodeButtonGroup({
   codeWrap,
   toggleCodeWrap,
   preElementRef,
+  showCodeWrapButton = true,
+  showCopyButton = true,
 }: CodeButtonGroupProps) {
   return (
     <>
       <div className={styles.codeButtonGroup}>
-        <button
-          className={codeWrap ? styles.wrappedBtn : ''}
-          onClick={() => toggleCodeWrap()}
-          title="Toggle code wrap"
-        >
-          <SvgWrapper icon={IconWrapped} className={styles.iconWrapped} />
-          <SvgWrapper icon={IconWrap} className={styles.iconWrap} />
-        </button>
-        <CopyCodeButton codeBlockRef={preElementRef as any} />
+        {showCodeWrapButton && (
+          <button
+            className={codeWrap ? styles.wrappedBtn : ''}
+            onClick={() => toggleCodeWrap()}
+            title="Toggle code wrap"
+          >
+            <SvgWrapper icon={IconWrapped} className={styles.iconWrapped} />
+            <SvgWrapper icon={IconWrap} className={styles.iconWrap} />
+          </button>
+        )}
+        {showCopyButton && (
+          <CopyCodeButton codeBlockRef={preElementRef as any} />
+        )}
       </div>
     </>
   );

--- a/packages/theme-default/src/layout/DocLayout/docComponents/code/CopyCodeButton.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/code/CopyCodeButton.tsx
@@ -8,7 +8,7 @@ import * as styles from './index.module.scss';
 const timeoutIdMap: Map<HTMLElement, NodeJS.Timeout> = new Map();
 
 function copyCode(
-  codeBlockElement: HTMLDivElement | null,
+  codeBlockElement: HTMLElement | null,
   copyButtonElement: HTMLButtonElement | null,
 ) {
   let text = '';
@@ -45,7 +45,7 @@ function copyCode(
 export function CopyCodeButton({
   codeBlockRef,
 }: {
-  codeBlockRef: React.RefObject<HTMLDivElement>;
+  codeBlockRef: React.RefObject<HTMLElement>;
 }) {
   const copyButtonRef = useRef<HTMLButtonElement>(null);
 

--- a/packages/theme-default/src/layout/DocLayout/docComponents/code/index.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/code/index.tsx
@@ -14,7 +14,7 @@ export interface CodeProps {
   meta?: string;
 }
 
-export function Code(props: CodeProps) {
+export function Code(props: CodeProps & React.HTMLProps<HTMLElement>) {
   const { siteData } = usePageData();
   const codeHighlighter =
     props.codeHighlighter ?? siteData.markdown.codeHighlighter;

--- a/packages/theme-default/src/layout/DocLayout/docComponents/pre.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/pre.tsx
@@ -79,7 +79,7 @@ export function Pre({
   className?: string;
   title?: string;
   codeHighlighter?: string;
-} & ShikiPreProps) {
+} & Partial<ShikiPreProps>) {
   const { siteData } = usePageData();
   const codeHighlighter =
     codeHighlighterFromProps ?? siteData.markdown.codeHighlighter;

--- a/packages/theme-default/src/layout/DocLayout/docComponents/pre.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/pre.tsx
@@ -1,7 +1,11 @@
 import { usePageData } from '@rspress/runtime';
 import { useRef } from 'react';
 import type { CodeProps } from './code';
-import { CodeButtonGroup, useCodeButtonGroup } from './code/CodeButtonGroup';
+import {
+  CodeButtonGroup,
+  type CodeButtonGroupProps,
+  useCodeButtonGroup,
+} from './code/CodeButtonGroup';
 
 const DEFAULT_LANGUAGE_CLASS = 'language-bash';
 
@@ -19,21 +23,24 @@ export function parseTitleFromMeta(meta: string | undefined): string {
   return result?.replace(/["'`]/g, '');
 }
 
+type ShikiPreProps = {
+  codeElementClassName: string | undefined;
+  codeTitle: string | undefined;
+  child: React.ReactElement;
+  preElementRef: React.RefObject<HTMLPreElement>;
+  className: string | undefined;
+  codeButtonGroupProps?: CodeButtonGroupProps;
+} & React.HTMLProps<HTMLPreElement>;
+
 function ShikiPre({
   child,
   codeElementClassName,
   preElementRef,
   codeTitle,
   className,
+  codeButtonGroupProps,
   ...otherProps
-}: {
-  codeElementClassName: string | undefined;
-  codeTitle: string | undefined;
-  child: React.ReactElement;
-  preElementRef: React.RefObject<HTMLPreElement>;
-  className: string | undefined;
-  [key: string]: any;
-}) {
+}: ShikiPreProps) {
   const { codeWrap, toggleCodeWrap } = useCodeButtonGroup();
   return (
     <div className={codeElementClassName ?? ''}>
@@ -54,6 +61,7 @@ function ShikiPre({
           preElementRef={preElementRef}
           codeWrap={codeWrap}
           toggleCodeWrap={toggleCodeWrap}
+          {...codeButtonGroupProps}
         />
       </div>
     </div>
@@ -64,15 +72,17 @@ export function Pre({
   children,
   className,
   title,
+  codeHighlighter: codeHighlighterFromProps,
   ...otherProps
 }: {
   children: React.ReactElement[] | React.ReactElement;
   className?: string;
   title?: string;
-  [key: string]: any;
-}) {
+  codeHighlighter?: string;
+} & ShikiPreProps) {
   const { siteData } = usePageData();
-  const codeHighlighter = siteData.markdown.codeHighlighter;
+  const codeHighlighter =
+    codeHighlighterFromProps ?? siteData.markdown.codeHighlighter;
   const preElementRef = useRef<HTMLPreElement>(null);
 
   const renderChild = (child: React.ReactElement) => {
@@ -81,12 +91,12 @@ export function Pre({
     if (codeHighlighter === 'shiki') {
       return (
         <ShikiPre
-          child={child}
           className={className}
+          {...otherProps}
+          child={child}
           codeElementClassName={codeElementClassName}
           codeTitle={title}
           preElementRef={preElementRef}
-          {...otherProps}
         />
       );
     }

--- a/packages/theme-default/src/layout/DocLayout/docComponents/pre.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/pre.tsx
@@ -29,7 +29,10 @@ type ShikiPreProps = {
   child: React.ReactElement;
   preElementRef: React.RefObject<HTMLPreElement>;
   className: string | undefined;
-  codeButtonGroupProps?: CodeButtonGroupProps;
+  codeButtonGroupProps?: Omit<
+    CodeButtonGroupProps,
+    'preElementRef' | 'codeWrap' | 'toggleCodeWrap'
+  >;
 } & React.HTMLProps<HTMLPreElement>;
 
 function ShikiPre({
@@ -58,10 +61,10 @@ function ShikiPre({
           </pre>
         </div>
         <CodeButtonGroup
+          {...codeButtonGroupProps}
           preElementRef={preElementRef}
           codeWrap={codeWrap}
           toggleCodeWrap={toggleCodeWrap}
-          {...codeButtonGroupProps}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary

`npm create rspress@beta`

before

<img width="500" alt="image" src="https://github.com/user-attachments/assets/5450ca69-36e1-456e-bca6-4c854b810196" />

after

<img width="500" alt="image" src="https://github.com/user-attachments/assets/5f73b5b8-44c9-4542-8b05-42058acb1e3f" />



## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
