### PR TITLE
feat: add `localeRedirect: 'only-default-lang'` support

### DIFF
--- a/packages/document/docs/en/api/config/config-theme.mdx
+++ b/packages/document/docs/en/api/config/config-theme.mdx
@@ -677,10 +677,10 @@ export default defineConfig({
 
 ## localeRedirect
 
-- Type: `'auto' | 'never'`
+- Type: `'auto' | 'never' | 'only-default-lang'`
 - Default: `'auto'`
 
-Whether to redirect to the locale closest to `window.navigator.language` when the user visits the site, the default is `auto`, which means that the user will be redirected on the first visit. If you set it to `never`, the user will not be redirected. For example:
+Whether to redirect to the locale closest to `window.navigator.language` when the user visits the site, the default is `auto`, which means that the user will be redirected on the first visit. If you set it to `never`, the user will not be redirected. If you set it to `only-default-lang`, the user will only be redirected when visiting the default locale. For example:
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';

--- a/packages/document/docs/zh/api/config/config-theme.mdx
+++ b/packages/document/docs/zh/api/config/config-theme.mdx
@@ -663,10 +663,10 @@ export default defineConfig({
 
 ## localeRedirect
 
-- Type: `'auto' | 'never'`
+- Type: `'auto' | 'never' | 'only-default-lang'`
 - Default: `'auto'`
 
-是否在访问网站时重定向到最接近 `window.navigator.language` 的语言，默认为 `auto` 表示首次访问时将重定向，`never` 表示不重定向。比如:
+是否在访问网站时重定向到最接近 `window.navigator.language` 的语言，默认为 `auto` 表示首次访问时将重定向，`never` 表示不重定向，`only-default-lang` 表示仅在访问默认语言时重定向。比如:
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from 'rspress/config';

--- a/packages/shared/src/types/defaultTheme.ts
+++ b/packages/shared/src/types/defaultTheme.ts
@@ -114,7 +114,7 @@ export interface Config {
    * Whether to redirect to the closest locale when the user visits the site
    * @default 'auto'
    */
-  localeRedirect?: 'auto' | 'never';
+  localeRedirect?: 'auto' | 'never' | 'only-default-lang';
   /**
    * Whether to show the fallback heading title when the heading title is not presented but `frontmatter.title` exists
    * @default true

--- a/packages/theme-default/src/logic/useRedirect4FirstVisit.ts
+++ b/packages/theme-default/src/logic/useRedirect4FirstVisit.ts
@@ -13,7 +13,7 @@ export function useRedirect4FirstVisit() {
 
   useEffect(() => {
     const localeRedirect = siteData.themeConfig.localeRedirect ?? 'auto';
-    if (localeRedirect !== 'auto') {
+    if (localeRedirect === 'never') {
       return;
     }
 
@@ -50,15 +50,15 @@ export function useRedirect4FirstVisit() {
     if (targetLang === currentLang) {
       return;
     }
-    let newPath: string;
+    let newPath: string | undefined;
     if (targetLang === defaultLang) {
       // Redirect to the default language
       newPath = pathname.replace(`/${currentLang}`, '');
     } else if (currentLang === defaultLang) {
-      // Redirect to the current language
+      // Redirect to the target language
       newPath = withBase(`/${targetLang}${cleanPathname}`);
-    } else {
-      // Redirect to the current language
+    } else if (localeRedirect === 'auto') {
+      // Redirect to the target language
       newPath = pathname.replace(`/${currentLang}`, `/${targetLang}`);
     }
     if (newPath) {


### PR DESCRIPTION
## Summary

If you set it to `only-default-lang`, the user will only be redirected when visiting the default locale.

## Related Issue

<!--- Provide link of related issues -->

related #2125

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
