### PR TITLE
feat(theme/dynamic-toc): add .rspress-toc-exclude escape hatch

### DIFF
--- a/packages/theme-default/src/components/Aside/processTitleElement.ts
+++ b/packages/theme-default/src/components/Aside/processTitleElement.ts
@@ -13,7 +13,16 @@ export function processTitleElement(element: Element): Element {
     elementClone.removeChild(anchorElement);
   }
 
-  // 2. skip a element, replace a elements with their children
+  // 2. delete ".rspress-toc-exclude" element
+  const excludeElements = elementClone.querySelectorAll('.rspress-toc-exclude');
+  excludeElements.forEach(excludeElement => {
+    const parentElement = excludeElement.parentElement;
+    if (parentElement) {
+      parentElement.removeChild(excludeElement);
+    }
+  });
+
+  // 3. skip a element, replace a elements with their children
   const anchorElements = elementClone.querySelectorAll('a');
 
   anchorElements.forEach(anchor => {


### PR DESCRIPTION
## Summary

1. remove .header-anchor

2. skip ".rspress-toc-exclude" element

3. skip <a/ > element, replace a elements with their children


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
