### PR TITLE
fix(plugin-api-doc-gen): plugin-api-doc-gen  should have anchor

### DIFF
--- a/e2e/tests/plugin-api-docgen.test.ts
+++ b/e2e/tests/plugin-api-docgen.test.ts
@@ -23,6 +23,9 @@ test.describe('api-docgen test', async () => {
 
   test('Index page', async ({ page }) => {
     await page.goto(`http://localhost:${appPort}`);
+    const tableH3 = await page.$('#button');
+    expect(tableH3).toBeTruthy();
+
     const table = await page.$('table');
     const tableContent = await page.evaluate(table => table?.innerHTML, table);
 

--- a/packages/plugin-api-docgen/package.json
+++ b/packages/plugin-api-docgen/package.json
@@ -26,6 +26,7 @@
     "@rspress/shared": "workspace:*",
     "chokidar": "^3.6.0",
     "documentation": "14.0.3",
+    "github-slugger": "^2.0.0",
     "react-docgen-typescript": "2.2.2",
     "react-markdown": "8.0.7",
     "remark-gfm": "3.0.1"
@@ -33,6 +34,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.49.2",
     "@rslib/core": "0.5.2",
+    "@types/hast": "^2.3.10",
     "@types/mdast": "^3.0.15",
     "@types/node": "^18.11.17",
     "@types/react": "^18.3.18",

--- a/packages/plugin-api-docgen/package.json
+++ b/packages/plugin-api-docgen/package.json
@@ -29,7 +29,8 @@
     "github-slugger": "^2.0.0",
     "react-docgen-typescript": "2.2.2",
     "react-markdown": "8.0.7",
-    "remark-gfm": "3.0.1"
+    "remark-gfm": "3.0.1",
+    "unist-util-visit": "^4.1.2"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.49.2",
@@ -43,8 +44,7 @@
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.29.0",
     "typescript": "^5.5.3",
-    "unified": "^10.1.2",
-    "unist-util-visit": "^4.1.2"
+    "unified": "^10.1.2"
   },
   "peerDependencies": {
     "@rspress/core": "workspace:^1.43.13",

--- a/packages/plugin-api-docgen/static/global-components/API.tsx
+++ b/packages/plugin-api-docgen/static/global-components/API.tsx
@@ -5,6 +5,97 @@ import { getCustomMDXComponent } from '@rspress/core/theme';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import './API.scss';
+import GithubSlugger from 'github-slugger';
+import type { Content, Element, Root } from 'hast';
+// biome-ignore lint/style/useImportType: <exact>
+import React from 'react';
+import type { Plugin } from 'unified';
+import { visit } from 'unist-util-visit';
+
+function headingRank(node: Root | Content): number | null {
+  const name =
+    (node && node.type === 'element' && node.tagName.toLowerCase()) || '';
+  const code =
+    name.length === 2 && name.charCodeAt(0) === 104 /* `h` */
+      ? name.charCodeAt(1)
+      : 0;
+  return code > 48 /* `0` */ && code < 55 /* `7` */
+    ? code - 48 /* `0` */
+    : null;
+}
+
+const rehypeHeaderAnchor: Plugin<[], Root> = () => {
+  const slugger = new GithubSlugger();
+  return tree => {
+    visit(tree, 'element', node => {
+      if (!headingRank(node)) {
+        return;
+      }
+      // generate id
+
+      if (!node.properties?.id) {
+        const text = collectHeaderText(node);
+        node.properties ??= {};
+        node.properties.id = slugger.slug(text);
+      }
+      // apply to headings
+      node.children.unshift(create(node));
+    });
+  };
+};
+
+/**
+ * Create an `a`.
+ *
+ * @param {Readonly<Element>} node
+ *   Related heading.
+ * @returns {Element}
+ *   Link.
+ */
+function create(node: Element): Element {
+  return {
+    type: 'element',
+    tagName: 'a',
+    properties: {
+      class: 'header-anchor',
+      ariaHidden: 'true',
+      href: `#${node.properties!.id}`,
+    },
+    children: [
+      {
+        type: 'text',
+        value: '#',
+      },
+    ],
+  };
+}
+
+const extractTextAndId = (title?: string): string => {
+  if (!title) {
+    return '';
+  }
+  const text = title.trimEnd();
+  return text;
+};
+
+const collectHeaderText = (node: Element): string => {
+  let text = '';
+  node.children.forEach(child => {
+    if (child.type === 'text') {
+      const textPart = extractTextAndId(child.value);
+      child.value = textPart;
+      text += textPart;
+    }
+    if (child.type === 'element') {
+      child.children.forEach(c => {
+        if (c.type === 'text') {
+          text += c.value;
+        }
+      });
+    }
+  });
+  return text;
+};
 
 export default (props: { moduleName: string }) => {
   const lang = useLang();
@@ -18,6 +109,7 @@ export default (props: { moduleName: string }) => {
   return (
     <ReactMarkdown
       remarkPlugins={[[remarkGfm]]}
+      rehypePlugins={[[rehypeHeaderAnchor]]}
       components={getCustomMDXComponent() as Record<string, React.ElementType>}
       skipHtml={true}
       className="rspress-plugin-api-docgen"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1018,6 +1018,9 @@ importers:
       documentation:
         specifier: 14.0.3
         version: 14.0.3
+      github-slugger:
+        specifier: ^2.0.0
+        version: 2.0.0
       react-docgen-typescript:
         specifier: 2.2.2
         version: 2.2.2(typescript@5.8.2)
@@ -1034,6 +1037,9 @@ importers:
       '@rslib/core':
         specifier: 0.5.2
         version: 0.5.2(@microsoft/api-extractor@7.49.2(@types/node@18.11.17))(typescript@5.8.2)
+      '@types/hast':
+        specifier: ^2.3.10
+        version: 2.3.10
       '@types/mdast':
         specifier: ^3.0.15
         version: 3.0.15

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1030,6 +1030,9 @@ importers:
       remark-gfm:
         specifier: 3.0.1
         version: 3.0.1
+      unist-util-visit:
+        specifier: ^4.1.2
+        version: 4.1.2
     devDependencies:
       '@microsoft/api-extractor':
         specifier: ^7.49.2
@@ -1067,9 +1070,6 @@ importers:
       unified:
         specifier: ^10.1.2
         version: 10.1.2
-      unist-util-visit:
-        specifier: ^4.1.2
-        version: 4.1.2
 
   packages/plugin-auto-nav-sidebar:
     dependencies:


### PR DESCRIPTION
## Summary

should have anchor, but still no toc now in V1

<img width="400" alt="image" src="https://github.com/user-attachments/assets/474ec051-89e5-450c-9c34-f4f2b5c0664a" />

Toc is implemented in rspress 2.0


## Related Issue

https://github.com/web-infra-dev/rspress/issues/1320

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
