### PR TITLE
chore(plugin-shiki): add all builtin-langs in shiki

### DIFF
--- a/packages/document/rspress.config.ts
+++ b/packages/document/rspress.config.ts
@@ -26,7 +26,6 @@ export default defineConfig({
   markdown: {
     checkDeadLinks: true,
     shiki: {
-      langs: ['mdx', 'html', 'toml'],
       transformers: [
         transformerNotationDiff(),
         transformerNotationErrorLevel(),

--- a/packages/plugin-shiki/src/shiki/pluginShiki.ts
+++ b/packages/plugin-shiki/src/shiki/pluginShiki.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url';
 import type { RspressPlugin } from '@rspress/shared';
 import rehypePluginShiki from '@shikijs/rehype';
 import type { RehypeShikiOptions } from '@shikijs/rehype';
-import { type BuiltinLanguage, createCssVariablesTheme } from 'shiki';
+import { createCssVariablesTheme } from 'shiki';
 import {
   SHIKI_TRANSFORMER_LINE_NUMBER,
   transformerLineNumber,
@@ -18,24 +18,6 @@ const __dirname = dirname(__filename);
  */
 export type PluginShikiOptions = RehypeShikiOptions;
 
-export const SHIKI_DEFAULT_HIGHLIGHT_LANGUAGES: BuiltinLanguage[] = [
-  'js',
-  'ts',
-  'jsx',
-  'tsx',
-  'vue',
-  'json',
-  'css',
-  'scss',
-  'less',
-  'xml',
-  'diff',
-  'yaml',
-  'md',
-  'mdx',
-  'bash',
-];
-
 const cssVariablesTheme = createCssVariablesTheme({
   name: 'css-variables',
   variablePrefix: '--shiki-',
@@ -49,7 +31,7 @@ const cssVariablesTheme = createCssVariablesTheme({
 export function pluginShiki(
   options?: Partial<PluginShikiOptions>,
 ): RspressPlugin {
-  const { langs = [], transformers = [], ...restOptions } = options || {};
+  const { langs, transformers = [], ...restOptions } = options || {};
 
   return {
     name: '@rspress/plugin-shiki',
@@ -77,7 +59,11 @@ export function pluginShiki(
           ...restOptions,
           addLanguageClass: true,
           transformers: newTransformers,
-          langs: [...SHIKI_DEFAULT_HIGHLIGHT_LANGUAGES, ...langs],
+          ...(langs
+            ? {
+                langs,
+              }
+            : {}),
         } satisfies RehypeShikiOptions,
       ]);
       return config;


### PR DESCRIPTION
## Summary

https://github.com/SoonIter/shiki/blob/f649d11c14aa31e4487a87e2cb0b547ce4f00d04/packages/rehype/src/index.ts#L30

drop the default value of langs in plugin-shiki, so langs option can be needless

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
