### PR TITLE
docs: replace `Helmet` with `Head`

### DIFF
--- a/packages/document/docs/en/api/config/config-frontmatter.mdx
+++ b/packages/document/docs/en/api/config/config-frontmatter.mdx
@@ -106,7 +106,7 @@ The generated head tags are as follows:
 ::: tip Note
 
 - `head` only works in the production build, Rspress will inject the tags into the SSG generated HTML. You can run `rspress build && rspress preview` to see the effect.
-- Make sure to correctly define the header tag names and their attribute names. For tags and attribute names that contain a hyphen (`-`), use the camelCase format. For example, `http-equiv="refresh"` should be defined as `httpEquiv: refresh`. This is because under the hood, headers are handled by React and `react-helmet-async`.
+- Make sure to correctly define the header tag names and their attribute names. For tags and attribute names that contain a hyphen (`-`), use the camelCase format. For example, `http-equiv="refresh"` should be defined as `httpEquiv: refresh`. This is because under the hood, headers are handled by React and `unhead`.
 
 :::
 

--- a/packages/document/docs/en/fragments/builtin-components.mdx
+++ b/packages/document/docs/en/fragments/builtin-components.mdx
@@ -178,19 +178,19 @@ interface LinkCardProps {
 }
 ```
 
-## Helmet
+## Head
 
-It is generally used to set custom head content in documents (based on [react-helmet-async](https://www.npmjs.com/package/react-helmet-async)). The usage is as follows:
+It is generally used to set custom head content in documents (based on [unhead](https://www.npmjs.com/package/unhead)). The usage is as follows:
 
 ```tsx title="index.tsx"
 // Below is a custom component, you can import it into your document
-import { Helmet } from 'rspress/runtime';
+import { Head } from 'rspress/runtime';
 
 function App() {
   return (
-    <Helmet>
+    <Head>
       <meta property="og:description" content="Out-of-box Rspack build tools" />
-    </Helmet>
+    </Head>
   );
 }
 ```

--- a/packages/document/docs/zh/api/config/config-frontmatter.mdx
+++ b/packages/document/docs/zh/api/config/config-frontmatter.mdx
@@ -106,7 +106,7 @@ head:
 ::: tip
 
 - `head` 仅在生产构建时生效，Rspress 会将标签注入到 SSG 生成的 HTML 中。你可以运行 `rspress build && rspress preview` 来查看效果。
-- 请确保为 head 标签和属性名称使用正确的格式。对于包含连字符（-）的标签或属性名，需要采用驼峰式命名法。例如，HTML 中的 `http-equiv="refresh"` 在配置中应写为 `httpEquiv: refresh`。这是因为 Rspress 底层使用 React 和 `react-helmet-async` 处理这些 headers。
+- 请确保为 head 标签和属性名称使用正确的格式。对于包含连字符（-）的标签或属性名，需要采用驼峰式命名法。例如，HTML 中的 `http-equiv="refresh"` 在配置中应写为 `httpEquiv: refresh`。这是因为 Rspress 底层使用 React 和 `unhead` 处理这些 headers。
 
 :::
 

--- a/packages/document/docs/zh/fragments/builtin-components.mdx
+++ b/packages/document/docs/zh/fragments/builtin-components.mdx
@@ -178,19 +178,19 @@ interface LinkCardProps {
 }
 ```
 
-## Helmet
+## Head
 
-一般用于在文档中设置自定义 head 内容（基于 [react-helmet-async](https://www.npmjs.com/package/react-helmet-async)）。使用方法如下：
+一般用于在文档中设置自定义 head 内容（基于 [unhead](https://www.npmjs.com/package/unhead)）。使用方法如下：
 
 ```tsx title="index.tsx"
 // 以下为一个自定义组件，你可以将其引入到文档中
-import { Helmet } from 'rspress/runtime';
+import { Head } from 'rspress/runtime';
 
 function App() {
   return (
-    <Helmet>
+    <Head>
       <meta property="og:description" content="Out-of-box Rspack build tools" />
-    </Helmet>
+    </Head>
   );
 }
 ```


### PR DESCRIPTION
## Summary

updated the docs to include the change in builtin components from `Helmet` to `Head` 

## Related Issue

n/a

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
