### PR TITLE
fix(theme): highlight the <PackageManagerTabs /> manually

### DIFF
--- a/e2e/tests/package-manager-tabs.test.ts
+++ b/e2e/tests/package-manager-tabs.test.ts
@@ -47,8 +47,10 @@ test.describe('tabs-component test', async () => {
       npmSpanElements.map(element => element.textContent()),
     );
     expect(npmCode).toEqual([
-      'npm create rspress@latest',
-      'npm install rspress -D',
+      'npm',
+      ' create rspress@latest',
+      'npm',
+      ' install rspress -D',
     ]);
 
     await clickTabs[1].click();
@@ -64,8 +66,10 @@ test.describe('tabs-component test', async () => {
       pnpmSpanElements.map(element => element.textContent()),
     );
     expect(pnpmCode).toEqual([
-      'pnpm create rspress@latest',
-      'pnpm install rspress -D',
+      'pnpm',
+      ' create rspress@latest',
+      'pnpm',
+      ' install rspress -D',
     ]);
 
     await clickTabs[3].click();
@@ -74,8 +78,10 @@ test.describe('tabs-component test', async () => {
       bunSpanElements.map(element => element.textContent()),
     );
     expect(bunCode).toEqual([
-      'bun create rspress@latest',
-      'bun add rspress -D',
+      'bun',
+      ' create rspress@latest',
+      'bun',
+      ' add rspress -D',
     ]);
   });
 });

--- a/e2e/tests/package-manager-tabs.test.ts
+++ b/e2e/tests/package-manager-tabs.test.ts
@@ -58,7 +58,12 @@ test.describe('tabs-component test', async () => {
     const yarnCode = await Promise.all(
       yarnSpanElements.map(element => element.textContent()),
     );
-    expect(yarnCode).toEqual(['yarn create rspress', 'yarn add rspress -D']);
+    expect(yarnCode).toEqual([
+      'yarn',
+      ' create rspress',
+      'yarn',
+      ' add rspress -D',
+    ]);
 
     await clickTabs[2].click();
     const pnpmSpanElements = await page.$$('code > span > span');

--- a/packages/theme-default/src/components/PackageManagerTabs/index.tsx
+++ b/packages/theme-default/src/components/PackageManagerTabs/index.tsx
@@ -44,6 +44,16 @@ function normalizeCommand(command: string): string {
   return command.replace('install', 'add');
 }
 
+/**
+ * 'npm install foo@latest' -> ['npm', ' install foo@latest']
+ */
+function splitTo2Parts(command: string): [string, string] {
+  const parts = command.split(' ');
+  const firstPart = parts[0];
+  const secondPart = command.slice(firstPart.length);
+  return [firstPart, secondPart];
+}
+
 export function PackageManagerTabs({
   command,
   additionalTabs = [],
@@ -96,18 +106,27 @@ export function PackageManagerTabs({
         </div>
       ))}
     >
-      {Object.entries(commandInfo).map(([key, value]) => (
-        <Tab key={key}>
-          <Pre>
-            {/* For this case, we has no highlight */}
-            <code className="language-bash" style={{ whiteSpace: 'pre' }}>
-              <span style={{ display: 'block', padding: '0px 1.25rem' }}>
-                <span>{value}</span>
-              </span>
-            </code>
-          </Pre>
-        </Tab>
-      ))}
+      {Object.entries(commandInfo).map(([key, value]) => {
+        const [packageManager, command] = splitTo2Parts(value);
+
+        return (
+          <Tab key={key}>
+            <Pre>
+              {/* For this case, we highlight the command manually */}
+              <code className="language-bash" style={{ whiteSpace: 'pre' }}>
+                <span style={{ display: 'block', padding: '0px 1.25rem' }}>
+                  <span style={{ color: 'var(--shiki-token-function)' }}>
+                    {packageManager}
+                  </span>
+                  <span style={{ color: 'var(--shiki-token-string)' }}>
+                    {command}
+                  </span>
+                </span>
+              </code>
+            </Pre>
+          </Tab>
+        );
+      })}
     </Tabs>
   );
 }


### PR DESCRIPTION
## Summary

> in Rspress v2 we enable shiki by default to highlight languages in compile process, and code blocks in dynamic components can not be highlighted yet. We plan to provide a `<CodeBlockRuntime />` component to resolve this issue, tracking in https://github.com/web-infra-dev/rspress/issues/2126.


`<CodeBlockRuntime />` means that we imports the whole shiki in runtime, but the cost is indeed too high.

So we parse it in runtime manually to support shiki highlight

before

<img width="1069" alt="image" src="https://github.com/user-attachments/assets/e5498350-25a2-471c-9d2d-98595bb07ae7" />


after

<img width="1260" alt="image" src="https://github.com/user-attachments/assets/32235e45-9526-4446-8991-f47d641ee1ed" />


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
