### PR TITLE
feat(theme): expose classname for crawler

### DIFF
--- a/packages/theme-default/src/components/Nav/NavMenuSingleItem.tsx
+++ b/packages/theme-default/src/components/Nav/NavMenuSingleItem.tsx
@@ -28,7 +28,7 @@ export function NavMenuSingleItem(
       <div
         key={item.text}
         className={`rspress-nav-menu-item ${styles.singleItem} ${
-          isActive ? styles.activeItem : ''
+          isActive ? `${styles.activeItem} rspress-nav-menu-item-active` : ''
         } rp-text-sm rp-font-medium rp-mx-0.5 rp-px-3 rp-py-2 rp-flex rp-items-center`}
       >
         <Tag tag={item.tag} />

--- a/packages/theme-default/src/components/Sidebar/SidebarItem.tsx
+++ b/packages/theme-default/src/components/Sidebar/SidebarItem.tsx
@@ -38,7 +38,9 @@ export function SidebarItem(props: SidebarItemProps) {
       <div
         ref={ref}
         className={`${
-          active ? styles.menuItemActive : styles.menuItem
+          active
+            ? `${styles.menuItemActive} rspress-sidebar-item-active`
+            : `${styles.menuItem} rspress-sidebar-item`
         } rp-mt-0.5 rp-py-2 rp-px-3 rp-font-medium rp-flex`}
         style={{
           // The first level menu item will have the same font size as the sidebar group

--- a/packages/theme-default/src/components/Sidebar/SidebarItem.tsx
+++ b/packages/theme-default/src/components/Sidebar/SidebarItem.tsx
@@ -40,7 +40,7 @@ export function SidebarItem(props: SidebarItemProps) {
         className={`${
           active
             ? `${styles.menuItemActive} rspress-sidebar-item-active`
-            : `${styles.menuItem}`
+            : styles.menuItem
         } rp-mt-0.5 rp-py-2 rp-px-3 rp-font-medium rp-flex`}
         style={{
           // The first level menu item will have the same font size as the sidebar group

--- a/packages/theme-default/src/components/Sidebar/SidebarItem.tsx
+++ b/packages/theme-default/src/components/Sidebar/SidebarItem.tsx
@@ -40,7 +40,7 @@ export function SidebarItem(props: SidebarItemProps) {
         className={`${
           active
             ? `${styles.menuItemActive} rspress-sidebar-item-active`
-            : `${styles.menuItem} rspress-sidebar-item`
+            : `${styles.menuItem}`
         } rp-mt-0.5 rp-py-2 rp-px-3 rp-font-medium rp-flex`}
         style={{
           // The first level menu item will have the same font size as the sidebar group


### PR DESCRIPTION
## Summary


add `.rspress-sidebar-item-active` and `.rspress-nav-menu-item-active` for algolia crawler


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
