### PR TITLE
chore(theme): rename Pre -> PreWithCodeButtonGroup, the only element that differs from the original element

### DIFF
--- a/packages/document/theme/index.tsx
+++ b/packages/document/theme/index.tsx
@@ -15,7 +15,7 @@ import './index.css';
 import { NoSSR, useLang } from 'rspress/runtime';
 
 function HomeLayout() {
-  const { pre: Pre, code: Code } = getCustomMDXComponent();
+  const { pre: PreWithCodeButtonGroup, code: Code } = getCustomMDXComponent();
   return (
     <BasicHomeLayout
       afterFeatures={<ToolStack />}
@@ -24,20 +24,15 @@ function HomeLayout() {
           className="rspress-doc"
           style={{ minHeight: 'auto', width: '100%', maxWidth: 400 }}
         >
-          <Pre
-            codeHighlighter="shiki"
+          <PreWithCodeButtonGroup
             codeButtonGroupProps={{
               showCodeWrapButton: false,
             }}
           >
-            <Code
-              className="language-bash"
-              codeHighlighter="shiki"
-              style={{ textAlign: 'center' }}
-            >
+            <Code className="language-bash" style={{ textAlign: 'center' }}>
               npm create rspress@beta
             </Code>
-          </Pre>
+          </PreWithCodeButtonGroup>
         </div>
       }
     />

--- a/packages/theme-default/src/components/PackageManagerTabs/index.tsx
+++ b/packages/theme-default/src/components/PackageManagerTabs/index.tsx
@@ -1,5 +1,5 @@
 import { Tab, Tabs } from '@theme';
-import { Pre } from '../../layout/DocLayout/docComponents/pre';
+import { PreWithCodeButtonGroup } from '../../layout/DocLayout/docComponents/pre';
 import { Bun } from './icons/Bun';
 import { Npm } from './icons/Npm';
 import { Pnpm } from './icons/Pnpm';
@@ -111,7 +111,7 @@ export function PackageManagerTabs({
 
         return (
           <Tab key={key}>
-            <Pre>
+            <PreWithCodeButtonGroup>
               {/* For this case, we highlight the command manually */}
               <code className="language-bash" style={{ whiteSpace: 'pre' }}>
                 <span style={{ display: 'block', padding: '0px 1.25rem' }}>
@@ -123,7 +123,7 @@ export function PackageManagerTabs({
                   </span>
                 </span>
               </code>
-            </Pre>
+            </PreWithCodeButtonGroup>
           </Tab>
         );
       })}

--- a/packages/theme-default/src/layout/DocLayout/docComponents/index.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/index.tsx
@@ -4,7 +4,7 @@ import { Hr } from './hr';
 import { Img } from './img';
 import { Li, Ol, Ul } from './list';
 import { Blockquote, P, Strong } from './paragraph';
-import { Pre } from './pre';
+import { PreWithCodeButtonGroup } from './pre';
 import { Table, Td, Th, Tr } from './table';
 import { H1, H2, H3, H4, H5, H6 } from './title';
 
@@ -29,7 +29,7 @@ export function getCustomMDXComponent() {
     strong: Strong,
     a: A,
     code: Code,
-    pre: Pre,
+    pre: PreWithCodeButtonGroup,
     img: Img,
   };
 }

--- a/packages/theme-default/src/layout/DocLayout/docComponents/pre.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/pre.tsx
@@ -67,7 +67,7 @@ function ShikiPre({
   );
 }
 
-export function Pre({
+export function PreWithCodeButtonGroup({
   children,
   className,
   title,


### PR DESCRIPTION
## Summary

chore: rename Pre -> PreWithCodeButtonGroup, the only element that differs from the original element

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
