### PR TITLE
chore(theme): export type `CodeProps` to use `getCustomMDXComponent()`

### DIFF
--- a/packages/theme-default/src/index.ts
+++ b/packages/theme-default/src/index.ts
@@ -12,7 +12,10 @@ export default {
   useSetup,
 };
 
-export { getCustomMDXComponent } from './layout/DocLayout/docComponents';
+export {
+  getCustomMDXComponent,
+  type CodeProps,
+} from './layout/DocLayout/docComponents';
 
 export * from './logic';
 

--- a/packages/theme-default/src/layout/DocLayout/docComponents/index.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/index.tsx
@@ -8,6 +8,8 @@ import { Pre } from './pre';
 import { Table, Td, Th, Tr } from './table';
 import { H1, H2, H3, H4, H5, H6 } from './title';
 
+export type { CodeProps } from './code';
+
 export function getCustomMDXComponent() {
   return {
     h1: H1,


### PR DESCRIPTION
## Summary

chore: export `CodeProps` to use `getCustomMDXComponent()` on the top

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
