### PR TITLE
docs: add Rstest to homepage

### DIFF
--- a/packages/document/i18n.json
+++ b/packages/document/i18n.json
@@ -42,13 +42,5 @@
   "communityPlugins": {
     "zh": "社区插件",
     "en": "Community Plugins"
-  },
-  "toolStackTitle": {
-    "zh": "Rstack",
-    "en": "Rstack"
-  },
-  "toolStackDesc": {
-    "zh": "围绕 Rspack 打造的高性能工具链，助力现代 Web 开发",
-    "en": "High-performance toolchain built around Rspack to boost modern web development"
   }
 }

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -20,7 +20,7 @@
     "@rspress/plugin-algolia": "workspace:*",
     "@rspress/plugin-llms": "workspace:*",
     "@rspress/plugin-shiki": "workspace:*",
-    "@rstack-dev/doc-ui": "1.8.0",
+    "@rstack-dev/doc-ui": "1.10.0",
     "@shikijs/transformers": "^3.2.2",
     "@types/react": "^18.3.21",
     "framer-motion": "12.0.6",

--- a/packages/document/theme/components/ToolStack.tsx
+++ b/packages/document/theme/components/ToolStack.tsx
@@ -1,16 +1,11 @@
 import { ToolStack as BaseToolStack } from '@rstack-dev/doc-ui/tool-stack';
-import { useI18n, useLang } from 'rspress/runtime';
+import { useLang } from 'rspress/runtime';
 import styles from './ToolStack.module.scss';
 
 export function ToolStack() {
-  const t = useI18n<typeof import('i18n')>();
   const lang = useLang();
   return (
     <div className={styles.root}>
-      <div className={styles.header}>
-        <h2 className={styles.title}>{t('toolStackTitle')}</h2>
-        <p className={styles.desc}>{t('toolStackDesc')}</p>
-      </div>
       <BaseToolStack lang={lang === 'zh' ? 'zh' : 'en'} />
     </div>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -944,8 +944,8 @@ importers:
         specifier: workspace:*
         version: link:../plugin-shiki
       '@rstack-dev/doc-ui':
-        specifier: 1.8.0
-        version: 1.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 1.10.0
+        version: 1.10.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@shikijs/transformers':
         specifier: ^3.2.2
         version: 3.2.2
@@ -3140,8 +3140,8 @@ packages:
     resolution: {integrity: sha512-NpNhTKBIlV3O6ADhoZkgHvBFvXMW2TYlIWmIT1ysJESUBqDpaN9H3Teve5fugjU2pQ2ORBZO6SQGKliMw/8m/Q==}
     engines: {node: '>= 10'}
 
-  '@rstack-dev/doc-ui@1.8.0':
-    resolution: {integrity: sha512-ejQxDIX/nghX/k6g0Uhmvw/1Y2vNlMfA82Jb9zlhh8pwGQ4jwXTFIFwkfVW09NuLg2RlLOAONLPfrCYZ91x8Wg==}
+  '@rstack-dev/doc-ui@1.10.0':
+    resolution: {integrity: sha512-PRACISyGl8vnqQ1occngpVIfDT0ShKtpi+Tb/HIG7KK+WBV4DaZeNsN1JC5+LHWObEgYsyemCTwxHA9+i3PKIw==}
 
   '@rushstack/node-core-library@5.13.1':
     resolution: {integrity: sha512-5yXhzPFGEkVc9Fu92wsNJ9jlvdwz4RNb2bMso+/+TH0nMm1jDDDsOIf4l8GAkPxGuwPw5DH24RliWVfSPhlW/Q==}
@@ -4404,8 +4404,8 @@ packages:
       react-dom:
         optional: true
 
-  framer-motion@12.6.2:
-    resolution: {integrity: sha512-7LgPRlPs5aG8UxeZiMCMZz8firC53+2+9TnWV22tuSi38D3IFRxHRUqOREKckAkt6ztX+Dn6weLcatQilJTMcg==}
+  framer-motion@12.11.4:
+    resolution: {integrity: sha512-kyE5oWZCUxhDb7LtpEyyadNThJJvoE8a6bfUTBqz++zw3XxDOosPAvw1lqNhYbjOgy57YuAlJ5qG/Cx5BigiEQ==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0 || ^19.0.0
@@ -5428,11 +5428,17 @@ packages:
   monaco-editor@0.51.0:
     resolution: {integrity: sha512-xaGwVV1fq343cM7aOYB6lVE4Ugf0UyimdD/x5PWcWBMKENwectaEu77FAN7c5sFiyumqeJdX1RPTh1ocioyDjw==}
 
+  motion-dom@12.11.4:
+    resolution: {integrity: sha512-1z/qYsrDjSx5QjOH8GfJ2RfFBvEzI2gdAEt2zNW+f7QkLlqjM3sQieESJr5+QtVmvD81qPANM7t97ROixKIt9Q==}
+
   motion-dom@12.6.1:
     resolution: {integrity: sha512-8XVsriTUEVOepoIDgE/LDGdg7qaKXWdt+wQA/8z0p8YzJDLYL8gbimZ3YkCLlj7bB2i/4UBD/g+VO7y9ZY0zHQ==}
 
   motion-utils@12.5.0:
     resolution: {integrity: sha512-+hFFzvimn0sBMP9iPxBa9OtRX35ZQ3py0UHnb8U29VD+d8lQ8zH3dTygJWqK7av2v6yhg7scj9iZuvTS0f4+SA==}
+
+  motion-utils@12.9.4:
+    resolution: {integrity: sha512-BW3I65zeM76CMsfh3kHid9ansEJk9Qvl+K5cu4DVHKGsI52n76OJ4z2CUJUV+Mn3uEP9k1JJA3tClG0ggSrRcg==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -8409,9 +8415,9 @@ snapshots:
       '@rspress/mdx-rs-win32-arm64-msvc': 0.6.6
       '@rspress/mdx-rs-win32-x64-msvc': 0.6.6
 
-  '@rstack-dev/doc-ui@1.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@rstack-dev/doc-ui@1.10.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      framer-motion: 12.6.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      framer-motion: 12.11.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - react
@@ -9885,10 +9891,10 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  framer-motion@12.6.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  framer-motion@12.11.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
-      motion-dom: 12.6.1
-      motion-utils: 12.5.0
+      motion-dom: 12.11.4
+      motion-utils: 12.9.4
       tslib: 2.8.1
     optionalDependencies:
       react: 19.1.0
@@ -11442,11 +11448,17 @@ snapshots:
 
   monaco-editor@0.51.0: {}
 
+  motion-dom@12.11.4:
+    dependencies:
+      motion-utils: 12.9.4
+
   motion-dom@12.6.1:
     dependencies:
       motion-utils: 12.5.0
 
   motion-utils@12.5.0: {}
+
+  motion-utils@12.9.4: {}
 
   mri@1.2.0: {}
 


### PR DESCRIPTION
## Summary

- Update @rstack-dev/doc-ui to 1.10.0 to add Rstest to homepage.
- This update also includes some UI and text improvements.

Related: https://github.com/rspack-contrib/rstack-doc-ui/releases

## Rstack List

### Before

<img width="1472" alt="Screenshot 2025-05-15 at 22 09 54" src="https://github.com/user-attachments/assets/984c7df8-05f3-41ea-a743-8384400cfe72" />

### After

![image](https://github.com/user-attachments/assets/965ec88d-8087-48ed-b8ee-a897ed76fa1d)


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
