### PR TITLE
feat: support `file://` protocol and `URL` for icon

### DIFF
--- a/e2e/fixtures/icon-file-url/docs/index.md
+++ b/e2e/fixtures/icon-file-url/docs/index.md
@@ -1,0 +1,1 @@
+# Hello world

--- a/e2e/fixtures/icon-file-url/package.json
+++ b/e2e/fixtures/icon-file-url/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@rspress-fixture/icon-file-url",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "rspress build",
+    "dev": "rspress dev",
+    "preview": "rspress preview"
+  },
+  "dependencies": {
+    "rspress": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^18.11.17"
+  }
+}

--- a/e2e/fixtures/icon-file-url/rspress.config.ts
+++ b/e2e/fixtures/icon-file-url/rspress.config.ts
@@ -1,0 +1,8 @@
+import * as path from 'node:path';
+import { defineConfig } from 'rspress/config';
+
+export default defineConfig({
+  title: 'Rspress',
+  root: path.join(__dirname, 'docs'),
+  icon: new URL('../public-dir/doc/public/rspress-icon.png', import.meta.url),
+});

--- a/e2e/fixtures/icon-file-url/tsconfig.json
+++ b/e2e/fixtures/icon-file-url/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
+  }
+}

--- a/e2e/tests/icon-file-url.test.ts
+++ b/e2e/tests/icon-file-url.test.ts
@@ -1,0 +1,27 @@
+import { access, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { expect, test } from '@playwright/test';
+import { runBuildCommand } from '../utils/runCommands';
+
+const fixtureDir = path.resolve(__dirname, '../fixtures');
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+test.describe('icon file url', async () => {
+  test('should use specified file URL icon path', async () => {
+    const appDir = path.join(fixtureDir, 'icon-file-url');
+    await runBuildCommand(appDir);
+
+    const existsImg = pathExists(
+      path.resolve(appDir, 'doc_build', 'rspress-icon.png'),
+    );
+    expect(existsImg).toBeTruthy();
+  });
+});

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type {
   RsbuildConfig,
   RsbuildInstance,
@@ -75,12 +76,16 @@ async function createInternalBuildConfig(
     : '';
   const reactVersion = await detectReactVersion();
 
-  const normalizeIcon = (icon: string | undefined) => {
+  const normalizeIcon = (icon: string | URL | undefined) => {
     if (!icon) {
       return undefined;
     }
 
-    if (path.isAbsolute(icon)) {
+    icon = icon.toString();
+
+    if (icon.startsWith('file://')) {
+      icon = fileURLToPath(icon);
+    } else if (path.isAbsolute(icon)) {
       return path.join(userDocRoot, PUBLIC_DIR, icon);
     }
 

--- a/packages/core/src/node/runtimeModule/siteData/index.ts
+++ b/packages/core/src/node/runtimeModule/siteData/index.ts
@@ -3,6 +3,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { SEARCH_INDEX_NAME, type SiteData } from '@rspress/shared';
+import { getIconUrlPath } from '@rspress/shared/node-utils';
 import { groupBy } from 'lodash-es';
 import { type FactoryContext, RuntimeModuleID } from '..';
 import { TEMP_DIR, isProduction } from '../../constants';
@@ -118,7 +119,7 @@ export async function siteDataVMPlugin(context: FactoryContext) {
   const siteData: Omit<SiteData, 'root'> = {
     title: userConfig?.title || '',
     description: userConfig?.description || '',
-    icon: userConfig?.icon || '',
+    icon: getIconUrlPath(userConfig?.icon) || '',
     route: userConfig?.route || {},
     themeConfig: normalizeThemeConfig(userConfig, pages),
     base: userConfig?.base || '/',

--- a/packages/document/docs/en/api/config/config-basic.mdx
+++ b/packages/document/docs/en/api/config/config-basic.mdx
@@ -71,7 +71,7 @@ export default defineConfig({
 
 ## icon
 
-- Type: `string`
+- Type: `string | URL`
 - Default: `""`
 
 Site icon. This path will be used as the icon path for the HTML page. For example:
@@ -84,7 +84,7 @@ export default defineConfig({
 });
 ```
 
-The framework will find your icon in the `public` directory, of course you can also set it to a CDN address.
+For normal path, Rspress will find your icon in the `public` directory, of course you can also set it to a CDN address, or use the `file://` protocol or `URL` to use local absolute path.
 
 ## lang
 

--- a/packages/document/docs/en/guide/basic/static-assets.mdx
+++ b/packages/document/docs/en/guide/basic/static-assets.mdx
@@ -73,11 +73,12 @@ export default defineConfig({
 });
 ```
 
-The icon field supports string config, with the following specific ways:
+The icon field supports string or URL config, with the following specific ways:
 
 - Configured as an **external link**, like the above example.
 - Configured as an **absolute path**, such as `/favicon.ico`. In this case, Rspress will automatically find the `favicon.ico` icon in the `public directory` of your **document root directory** and display it.
 - Configured as a **relative path**, such as `./docs/public/favicon.ico`. In this case, Rspress will find the `favicon.ico` icon based on the project root directory and display it.
+- Configured as a `file://` protocol or `URL`, such as `file:///local_path/favicon.ico`. In this case, Rspress will use the local absolute path `/local_path/favicon.ico` icon directly and display it.
 
 ## Homepage logo
 

--- a/packages/document/docs/zh/api/config/config-basic.mdx
+++ b/packages/document/docs/zh/api/config/config-basic.mdx
@@ -71,7 +71,7 @@ export default defineConfig({
 
 ## icon
 
-- Type: `string`
+- Type: `string | URL`
 - Default: `""`
 
 站点图标。这个路径将用作 HTML 页面的图标路径。例如：
@@ -84,7 +84,7 @@ export default defineConfig({
 });
 ```
 
-框架会在 `public` 目录中找到你的图标，当然你也可以设置成一个 CDN 地址。
+对于普通路径，Rspress 会在 `public` 目录中找到你的图标，当然你也可以设置成一个 CDN 地址，或使用 `file://` 协议或 `URL` 来使用本地文件绝对路径。
 
 ## lang
 

--- a/packages/document/docs/zh/guide/basic/static-assets.mdx
+++ b/packages/document/docs/zh/guide/basic/static-assets.mdx
@@ -74,11 +74,12 @@ export default defineConfig({
 });
 ```
 
-icon 字段支持字符串配置，具体配置方式如下：
+icon 字段支持字符串或 URL 配置，具体配置方式如下：
 
 - 配置为**外链**，如上面的例子。
 - 配置为**绝对路径**，如 `/favicon.ico`，这样 Rspress 在框架内部会自动在你的**文档根目录**的 `public 目录`中找到 `favicon.ico` 图标并进行展示。
 - 配置为**相对路径**，如 `./docs/public/favicon.ico`，这样 Rspress 基于项目根目录寻找到 `favicon.ico` 图标并进行展示。
+- 配置为 `file://` 协议或 `URL`，如 `file:///local_path/favicon.ico`，这样 Rspress 直接使用本地绝对路径 `/local_path/favicon.ico` 图标并进行展示。
 
 ## 主页 logo
 

--- a/packages/plugin-rss/src/plugin-rss.ts
+++ b/packages/plugin-rss/src/plugin-rss.ts
@@ -3,10 +3,11 @@
 import NodePath from 'node:path';
 import { resolve as resolveUrl } from 'node:url';
 import type { PageIndexInfo, RspressPlugin, UserConfig } from '@rspress/shared';
+import { getIconUrlPath } from '@rspress/shared/node-utils';
 import { Feed } from 'feed';
+
 import { createFeed, generateFeedItem } from './createFeed';
 import { PluginComponents, PluginName } from './exports';
-
 import { type ResolvedOutput, concatArray, writeFile } from './internals';
 import { getDefaultFeedOption, getOutputInfo, testPage } from './options';
 import type { FeedChannel, FeedItem, PluginRssOptions } from './type';
@@ -23,7 +24,7 @@ class FeedsSet {
     ).map(options => ({
       title: config.title || '',
       description: config.description || '',
-      favicon: config.icon && resolveUrl(siteUrl, config.icon),
+      favicon: config.icon && resolveUrl(siteUrl, getIconUrlPath(config.icon)),
       copyright: config.themeConfig?.footer?.message || '',
       link: siteUrl,
       docs: '',

--- a/packages/shared/src/node-utils.ts
+++ b/packages/shared/src/node-utils.ts
@@ -1,4 +1,5 @@
 export { extractTextAndId } from './node-utils/extractTextAndId';
+export { getIconUrlPath } from './node-utils/getIconUrlPath';
 export { getNodeAttribute } from './node-utils/getNodeAttribute';
 export { loadFrontMatter } from './node-utils/loadFrontMatter';
 export { mergeDocConfig } from './node-utils/merge';

--- a/packages/shared/src/node-utils/getIconUrlPath.ts
+++ b/packages/shared/src/node-utils/getIconUrlPath.ts
@@ -1,0 +1,33 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Transform `config.icon` into final url path in the web app
+ *
+ * @param icon original icon in config
+ * @returns final url path in the web app
+ */
+export function getIconUrlPath(icon: '' | undefined): undefined;
+export function getIconUrlPath(icon: string | URL): string;
+export function getIconUrlPath(
+  icon: string | URL | undefined,
+): string | undefined;
+export function getIconUrlPath(icon: string | URL | undefined) {
+  if (!icon) {
+    return undefined;
+  }
+
+  icon = icon.toString();
+
+  if (icon.startsWith('file://')) {
+    icon = fileURLToPath(icon);
+  }
+
+  // data:, http:, https:, etc
+  if (!path.isAbsolute(icon)) {
+    return icon;
+  }
+
+  // https://rsbuild.dev/config/html/favicon#example
+  return `/${path.basename(icon)}`;
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -76,7 +76,7 @@ export interface UserConfig<ThemeConfig = DefaultThemeConfig> {
   /**
    * Path to html icon file.
    */
-  icon?: string;
+  icon?: string | URL;
   /**
    * Default language of the site.
    */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,6 +259,16 @@ importers:
         specifier: ^18.11.17
         version: 18.11.17
 
+  e2e/fixtures/icon-file-url:
+    dependencies:
+      rspress:
+        specifier: workspace:*
+        version: link:../../../packages/cli
+    devDependencies:
+      '@types/node':
+        specifier: ^18.11.17
+        version: 18.11.17
+
   e2e/fixtures/inline-markdown:
     dependencies:
       rspress:


### PR DESCRIPTION
## Summary

So that the user can use lcoal absolute path or `data:` url as they whatever want

## Related Issue

<!--- Provide link of related issues -->

related #2167

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
