### PR TITLE
perf: remove React 17 compatibility code

### DIFF
--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -206,7 +206,6 @@ async function createInternalBuildConfig(
     source: {
       include: [PACKAGE_ROOT, path.join(cwd, 'node_modules', RSPRESS_TEMP_DIR)],
       define: {
-        'process.env.__REACT_GTE_18__': JSON.stringify(reactVersion >= 18),
         'process.env.TEST': JSON.stringify(process.env.TEST),
         'process.env.RSPRESS_SOCIAL_ICONS': JSON.stringify(
           getSocialIcons(config.themeConfig?.socialLinks),

--- a/packages/core/src/node/utils/detectReactVersion.ts
+++ b/packages/core/src/node/utils/detectReactVersion.ts
@@ -75,11 +75,10 @@ export async function resolveReactAlias(reactVersion: number, isSSR: boolean) {
     'react/jsx-runtime',
     'react/jsx-dev-runtime',
     'react-dom',
+    'react-dom/client',
     'react-dom/server',
   ];
-  if (reactVersion >= 18) {
-    libPaths.push('react-dom/client');
-  }
+
   const alias: Record<string, string> = {};
   const resolver = ResolverFactory.createResolver({
     fileSystem: new CachedInputFileSystem(
@@ -90,6 +89,7 @@ export async function resolveReactAlias(reactVersion: number, isSSR: boolean) {
     alias,
     conditionNames: isSSR ? ['...'] : ['browser', '...'],
   });
+
   await Promise.all(
     libPaths.map(async lib => {
       try {

--- a/packages/core/src/runtime/csrClientEntry.tsx
+++ b/packages/core/src/runtime/csrClientEntry.tsx
@@ -1,15 +1,5 @@
+import { createRoot } from 'react-dom/client';
 import { ClientApp } from './ClientApp';
 
-async function renderInBrowser() {
-  const container = document.getElementById('root')!;
-
-  if (process.env.__REACT_GTE_18__) {
-    const { createRoot } = await import('react-dom/client');
-    createRoot(container).render(<ClientApp />);
-  } else {
-    const ReactDOM = await import('react-dom');
-    ReactDOM.render(<ClientApp />, container);
-  }
-}
-
-renderInBrowser();
+const container = document.getElementById('root')!;
+createRoot(container).render(<ClientApp />);

--- a/packages/core/src/runtime/ssrClientEntry.tsx
+++ b/packages/core/src/runtime/ssrClientEntry.tsx
@@ -1,3 +1,4 @@
+import { hydrateRoot } from 'react-dom/client';
 import { ClientApp } from './ClientApp';
 import { initPageData } from './initPageData';
 
@@ -8,17 +9,7 @@ import { initPageData } from './initPageData';
 async function renderInBrowser() {
   const container = document.getElementById('root')!;
   const initialPageData = await initPageData(window.location.pathname);
-
-  if (process.env.__REACT_GTE_18__) {
-    const { hydrateRoot } = await import('react-dom/client');
-    hydrateRoot(container, <ClientApp initialPageData={initialPageData} />);
-  } else {
-    const ReactDOM = await import('react-dom');
-    ReactDOM.hydrate(
-      <ClientApp initialPageData={initialPageData} />,
-      container,
-    );
-  }
+  hydrateRoot(container, <ClientApp initialPageData={initialPageData} />);
 }
 
 renderInBrowser();

--- a/packages/runtime/src/Content.tsx
+++ b/packages/runtime/src/Content.tsx
@@ -24,12 +24,6 @@ export const Content = ({ fallback = <></> }: { fallback?: ReactNode }) => {
     return <div></div>;
   }
   const routesElement = matched.element;
-
-  // React 17 Suspense SSR is not supported
-  if (!process.env.__REACT_GTE_18__ && process.env.__SSR__) {
-    return routesElement;
-  }
-
   return (
     <Suspense fallback={fallback}>
       <TransitionContent el={routesElement} />


### PR DESCRIPTION
## Summary

This PR removes React 17 compatibility code from Rspress.

Rspress 2.0 uses React 19 by default, and the minimum supported React version is 18, which means React 17 will no longer be supported.

## Related Issue

- https://github.com/web-infra-dev/rspress/discussions/1891#discussioncomment-12475395

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
