### PR TITLE
fix(theme-default): improve redirect URL handling in NotFoundLayout

### DIFF
--- a/packages/theme-default/src/layout/NotFountLayout/index.tsx
+++ b/packages/theme-default/src/layout/NotFountLayout/index.tsx
@@ -12,10 +12,7 @@ export function NotFoundLayout() {
     typeof window !== 'undefined' &&
     new RegExp(`^/${defaultLang}(\\/|$)`).test(location.pathname)
   ) {
-    const redirectUrl = location.pathname.replace(
-      new RegExp(`^/${defaultLang}`),
-      '',
-    );
+    const redirectUrl = location.pathname.replace(`/${defaultLang}`, '');
     window.location.replace(redirectUrl || '/');
     return <></>;
   }

--- a/packages/theme-default/src/layout/NotFountLayout/index.tsx
+++ b/packages/theme-default/src/layout/NotFountLayout/index.tsx
@@ -10,10 +10,13 @@ export function NotFoundLayout() {
   if (
     defaultLang &&
     typeof window !== 'undefined' &&
-    location.pathname.includes(`/${defaultLang}/`)
+    new RegExp(`^/${defaultLang}(\\/|$)`).test(location.pathname)
   ) {
-    const redirectUrl = location.pathname.replace(`/${defaultLang}/`, '/');
-    window.location.replace(redirectUrl);
+    const redirectUrl = location.pathname.replace(
+      new RegExp(`^/${defaultLang}`),
+      '',
+    );
+    window.location.replace(redirectUrl || '/');
     return <></>;
   }
 


### PR DESCRIPTION
## Summary
### improve default language redirect handling

- Use a more precise regular expression to match paths with the default language, ensuring accurate detection of patterns like `/en` and `/en/`
- Improve redirect URL generation to handle edge cases, especially avoiding empty path outputs after replacement
- Ensures better user experience by preventing unnecessary 404 pages for default language paths

## Related Issue

#2173

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
