### PR TITLE
feat(theme): Save user preferred language and optimize navigation (#1912)

### DIFF
--- a/packages/document/docs/en/api/config/config-theme.mdx
+++ b/packages/document/docs/en/api/config/config-theme.mdx
@@ -767,3 +767,20 @@ export default defineConfig({
   },
 });
 ```
+
+## saveUserPreferredLanguage
+
+- Type: `'auto' | 'never' | 'only-home-page'`
+- Default: `'auto'`
+
+Whether to redirect to the user's previously selected language when visiting the site. The default is `auto`, which means always redirect, `never` means no redirection, and `only-home-page` means redirection only occurs when accessing the homepage ( `pageType === 'home'` ). For example:
+
+```ts title="rspress.config.ts"
+import { defineConfig } from 'rspress/config';
+
+export default defineConfig({
+  themeConfig: {
+    saveUserPreferredLanguage: 'never',
+  },
+});
+```

--- a/packages/document/docs/zh/api/config/config-theme.mdx
+++ b/packages/document/docs/zh/api/config/config-theme.mdx
@@ -753,3 +753,20 @@ export default defineConfig({
   },
 });
 ```
+
+## saveUserPreferredLanguage
+
+- Type: `'auto' | 'never' | 'only-home-page'`
+- Default: `'auto'`
+
+是否在访问网站时重定向到用户上一次切换的语言，默认为 `auto` 表示始终将重定向，`never` 表示不重定向，`only-home-page` 表示仅在访问首页时 ( `pageType === 'home'` ) 重定向。比如:
+
+```ts title="rspress.config.ts"
+import { defineConfig } from 'rspress/config';
+
+export default defineConfig({
+  themeConfig: {
+    saveUserPreferredLanguage: 'never',
+  },
+});
+```

--- a/packages/shared/src/types/defaultTheme.ts
+++ b/packages/shared/src/types/defaultTheme.ts
@@ -120,6 +120,11 @@ export interface Config {
    * @default true
    */
   fallbackHeadingTitle?: boolean;
+  /**
+   * Whether to save the language when user switch the language
+   * @default 'auto'
+   */
+  saveUserPreferredLanguage?: 'auto' | 'never' | 'only-home-page';
 }
 
 /**
@@ -176,6 +181,7 @@ export type NavItemWithLink = {
   tag?: string;
   activeMatch?: string;
   position?: 'left' | 'right';
+  onClick?: () => void;
 };
 
 export interface NavItemWithChildren {

--- a/packages/theme-default/src/components/Nav/NavMenuGroup.tsx
+++ b/packages/theme-default/src/components/Nav/NavMenuGroup.tsx
@@ -43,7 +43,11 @@ function ActiveGroupItem({ item }: { item: NavItemWithLink }) {
 
 function NormalGroupItem({ item }: { item: NavItemWithLink }) {
   return (
-    <div key={item.link} className="rp-font-medium rp-my-1">
+    <div
+      key={item.link}
+      className="rp-font-medium rp-my-1"
+      onClick={item?.onClick}
+    >
       <Link href={item.link}>
         <div
           className="rp-rounded-2xl hover:rp-bg-mute"

--- a/packages/theme-default/src/components/Nav/menuDataHooks.tsx
+++ b/packages/theme-default/src/components/Nav/menuDataHooks.tsx
@@ -1,6 +1,7 @@
 import { useLocation, usePageData, useVersion } from '@rspress/runtime';
 import { replaceLang, replaceVersion } from '@rspress/shared';
 import Translator from '@theme-assets/translator';
+import { usePreferredLanguage } from '../../logic/usePreferredLanguage';
 import { SvgWrapper } from '../SvgWrapper';
 import type { NavMenuGroupItem } from './NavMenuGroup';
 
@@ -17,6 +18,8 @@ export function useTranslationMenuData(): NavMenuGroupItem {
   const hasMultiLanguage = localeLanguages.length > 1;
   const { lang: currentLang, pageType } = page;
   const { base } = siteData;
+
+  const { setPreferredLanguage } = usePreferredLanguage();
 
   const translationMenuData = hasMultiLanguage
     ? {
@@ -46,6 +49,9 @@ export function useTranslationMenuData(): NavMenuGroupItem {
             cleanUrls,
             pageType === '404',
           ),
+          onClick: () => {
+            setPreferredLanguage(item.lang);
+          },
         })),
         activeValue: localeLanguages.find(item => currentLang === item.lang)
           ?.label,

--- a/packages/theme-default/src/logic/usePreferredLanguage.ts
+++ b/packages/theme-default/src/logic/usePreferredLanguage.ts
@@ -6,7 +6,6 @@ import {
 } from '@rspress/runtime';
 import { replaceLang } from '@rspress/shared';
 import { useEffect } from 'react';
-import { useStorageValue } from './useStorageValue';
 
 /**
  * Redirect to preferred locale
@@ -25,39 +24,41 @@ export function usePreferredLanguage() {
   const defaultVersion = siteData.multiVersion.default || '';
   const { base } = siteData;
   const PREFERRED_LANG_KEY = 'rspress-preferred-language';
-  const [preferredLang, setLang] = useStorageValue<string>(
-    PREFERRED_LANG_KEY,
-    '',
-  );
 
   const saveUserPreferredLanguage =
     siteData.themeConfig.saveUserPreferredLanguage ?? 'auto';
 
-  const botRegex = /bot|spider|crawl|lighthouse/i;
-
-  const disableStorage =
-    saveUserPreferredLanguage === 'never' ||
-    !hasMultiLanguage ||
-    // If the request is coming from a bot or crawler, do not redirect.
-    // this ensures that Google's search crawler can work as expected.
-    botRegex.test(window.navigator.userAgent);
+  const checkDisableStorage = () => {
+    const botRegex = /bot|spider|crawl|lighthouse/i;
+    return (
+      saveUserPreferredLanguage === 'never' ||
+      !hasMultiLanguage ||
+      // If the request is coming from a bot or crawler, do not redirect.
+      // this ensures that Google's search crawler can work as expected.
+      botRegex.test(window.navigator.userAgent)
+    );
+  };
+  const getPreferredLanguage = () => {
+    return localStorage.getItem(PREFERRED_LANG_KEY);
+  };
 
   const setPreferredLanguage = (lang: string) => {
-    if (!lang || lang === preferredLang || disableStorage) {
+    const preferredLang = getPreferredLanguage();
+    if (!lang || lang === preferredLang || checkDisableStorage()) {
       return;
     }
-    setLang(lang);
+    localStorage.setItem(PREFERRED_LANG_KEY, lang);
   };
 
   useEffect(() => {
     if (
-      disableStorage ||
+      checkDisableStorage() ||
       (saveUserPreferredLanguage === 'only-home-page' && pageType !== 'home') // only redirect in home page
     ) {
       //  no need to redirect
       return;
     }
-
+    const preferredLang = getPreferredLanguage();
     if (preferredLang && preferredLang !== currentLang) {
       const cleanUrls = siteData.route?.cleanUrls || false;
       const newPath = replaceLang(
@@ -80,7 +81,7 @@ export function usePreferredLanguage() {
   }, []);
 
   return {
-    preferredLang,
+    getPreferredLanguage,
     setPreferredLanguage,
   } as const;
 }

--- a/packages/theme-default/src/logic/usePreferredLanguage.ts
+++ b/packages/theme-default/src/logic/usePreferredLanguage.ts
@@ -1,0 +1,86 @@
+import {
+  useLocation,
+  useNavigate,
+  usePageData,
+  useVersion,
+} from '@rspress/runtime';
+import { replaceLang } from '@rspress/shared';
+import { useEffect } from 'react';
+import { useStorageValue } from './useStorageValue';
+
+/**
+ * Redirect to preferred locale
+ */
+export function usePreferredLanguage() {
+  const { siteData, page } = usePageData();
+  const currentVersion = useVersion();
+  const defaultLang = siteData.lang || '';
+  const localeLanguages = Object.values(
+    siteData.locales || siteData.themeConfig.locales || {},
+  );
+  const hasMultiLanguage = localeLanguages.length > 1;
+  const { pathname, search } = useLocation();
+  const navigate = useNavigate();
+  const { lang: currentLang, pageType } = page;
+  const defaultVersion = siteData.multiVersion.default || '';
+  const { base } = siteData;
+  const PREFERRED_LANG_KEY = 'rspress-preferred-language';
+  const [preferredLang, setLang] = useStorageValue<string>(
+    PREFERRED_LANG_KEY,
+    '',
+  );
+
+  const saveUserPreferredLanguage =
+    siteData.themeConfig.saveUserPreferredLanguage ?? 'auto';
+
+  const botRegex = /bot|spider|crawl|lighthouse/i;
+
+  const disableStorage =
+    saveUserPreferredLanguage === 'never' ||
+    !hasMultiLanguage ||
+    // If the request is coming from a bot or crawler, do not redirect.
+    // this ensures that Google's search crawler can work as expected.
+    botRegex.test(window.navigator.userAgent);
+
+  const setPreferredLanguage = (lang: string) => {
+    if (!lang || lang === preferredLang || disableStorage) {
+      return;
+    }
+    setLang(lang);
+  };
+
+  useEffect(() => {
+    if (
+      disableStorage ||
+      (saveUserPreferredLanguage === 'only-home-page' && pageType !== 'home') // only redirect in home page
+    ) {
+      //  no need to redirect
+      return;
+    }
+
+    if (preferredLang && preferredLang !== currentLang) {
+      const cleanUrls = siteData.route?.cleanUrls || false;
+      const newPath = replaceLang(
+        pathname + search,
+        {
+          current: currentLang,
+          target: preferredLang,
+          default: defaultLang,
+        },
+        {
+          current: currentVersion,
+          default: defaultVersion,
+        },
+        base,
+        cleanUrls,
+        pageType === '404',
+      );
+      navigate(newPath);
+    }
+  }, []);
+
+  return {
+    preferredLang,
+    setPreferredLanguage,
+  } as const;
+}


### PR DESCRIPTION
## Summary
- Add `saveUserPreferredLanguage` property to Config interface to control whether to save user switched language
- Update navigation component to add click event handling for language switching
- Add description for `saveUserPreferredLanguage` configuration

![image](https://github.com/user-attachments/assets/19e4929f-df17-43a5-9c45-9a1874d76295)

## Related Issue
- #1912
<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
