### PR TITLE
fix(plugin-shiki/style): for force wrap style

### DIFF
--- a/packages/plugin-shiki/src/shiki.scss
+++ b/packages/plugin-shiki/src/shiki.scss
@@ -38,8 +38,9 @@ html.rp-dark {
   --shiki-token-inserted: #36c47f;
 }
 
-.rspress-doc span.line {
+.shiki span.line {
   padding: 0 1.25rem;
+  display: inline-block;
 }
 
 .diff,


### PR DESCRIPTION
## Summary


before

<img width="500" alt="image" src="https://github.com/user-attachments/assets/fd7cf7e5-2083-4fe3-a6c9-52c782e1d3e1" />

after

<img width="525" alt="image" src="https://github.com/user-attachments/assets/b19989e1-d89a-4df6-a453-f9525aaca9f5" />


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
