### PR TITLE
fix: `children` should be unavailable for `CodeBlockRuntime`

### DIFF
--- a/packages/theme-default/src/components/CodeBlockRuntime/index.tsx
+++ b/packages/theme-default/src/components/CodeBlockRuntime/index.tsx
@@ -6,7 +6,8 @@ import {
   type PreWithCodeButtonGroupProps,
 } from '../../layout/DocLayout/docComponents/pre';
 
-export interface CodeBlockRuntimeProps extends PreWithCodeButtonGroupProps {
+export interface CodeBlockRuntimeProps
+  extends Omit<PreWithCodeButtonGroupProps, 'children'> {
   lang: string;
   code: string;
 }


### PR DESCRIPTION
## Summary

<img width="985" alt="image" src="https://github.com/user-attachments/assets/6e2225ac-3af3-4148-a302-539f6a726ad2" />

## Related Issue

<!--- Provide link of related issues -->

related #2190

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
