### PR TITLE
feat(CodeBlockRuntime): add onRendered prop

### DIFF
--- a/packages/theme-default/src/components/CodeBlockRuntime/index.tsx
+++ b/packages/theme-default/src/components/CodeBlockRuntime/index.tsx
@@ -23,6 +23,10 @@ export interface CodeBlockRuntimeProps extends PreWithCodeButtonGroupProps {
     CodeToHastOptions<BundledLanguage, BundledTheme>,
     'lang' | 'theme'
   >;
+  /**
+   * Callback when the code block is rendered.
+   */
+  onRendered?: () => void;
 }
 
 const cssVariablesTheme = createCssVariablesTheme({
@@ -43,9 +47,10 @@ export function CodeBlockRuntime({
   title,
   code,
   shikiOptions,
+  onRendered,
   ...otherProps
 }: CodeBlockRuntimeProps) {
-  const [child, setChild] = useState<ReactNode>('');
+  const [child, setChild] = useState<ReactNode | null>(null);
   const codeRef = useLatest(code);
 
   useEffect(() => {
@@ -93,6 +98,12 @@ export function CodeBlockRuntime({
     };
     void highlightCode();
   }, [lang, code, shikiOptions]);
+
+  useEffect(() => {
+    if (child) {
+      onRendered?.();
+    }
+  }, [child]);
 
   return child;
 }

--- a/packages/theme-default/src/components/CodeBlockRuntime/index.tsx
+++ b/packages/theme-default/src/components/CodeBlockRuntime/index.tsx
@@ -25,6 +25,7 @@ export interface CodeBlockRuntimeProps extends PreWithCodeButtonGroupProps {
   >;
   /**
    * Callback when the code block is rendered.
+   * For some DOM operations, such as scroll operations.
    */
   onRendered?: () => void;
 }


### PR DESCRIPTION
## Summary

`onRendered` prop for scroll operation

Lynx website: 

scroll to first highlight line on rendered

## Related Issue

https://github.com/lynx-family/lynx-website/pull/189

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
