### PR TITLE
fix: exclude `.rspress-toc-exclude` ancestor nodes in dynamic TOC

### DIFF
--- a/packages/theme-default/src/components/Aside/useDynamicToc.ts
+++ b/packages/theme-default/src/components/Aside/useDynamicToc.ts
@@ -66,7 +66,7 @@ function updateHeaders(target: Element) {
     '.rspress-doc h2.rspress-doc-outline, h3.rspress-doc-outline, h4.rspress-doc-outline',
   );
   elements?.forEach(el => {
-    if (el && isElementVisible(el)) {
+    if (!el.closest('.rspress-toc-exclude') && isElementVisible(el)) {
       collectedHeaders.push({
         id: el.id,
         text: processTitleElement(el).innerHTML,


### PR DESCRIPTION
## Summary

exclude `.rspress-toc-exclude` ancestor nodes in dynamic TOC

## Related Issue

<!--- Provide link of related issues -->

related #2136

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
