### PR TITLE
fix: empty blockquote crash the compiler

### DIFF
--- a/.changeset/better-eels-tap.md
+++ b/.changeset/better-eels-tap.md
@@ -1,0 +1,5 @@
+---
+'@rspress/plugin-container-syntax': minor
+---
+
+fix empty blockquote crash

--- a/packages/plugin-container-syntax/src/remarkPlugin.ts
+++ b/packages/plugin-container-syntax/src/remarkPlugin.ts
@@ -156,7 +156,10 @@ function transformer(tree: Parent) {
          * </div>
          */
         node.type === 'blockquote' &&
+        node.children[0] &&
         node.children[0].type === 'paragraph' &&
+        node.children[0].children &&
+        node.children[0].children[0] &&
         'value' in node.children[0].children[0]
       ) {
         const initiatorTag = node.children[0].children[0].value;

--- a/packages/plugin-container-syntax/src/remarkPlugin.ts
+++ b/packages/plugin-container-syntax/src/remarkPlugin.ts
@@ -156,10 +156,8 @@ function transformer(tree: Parent) {
          * </div>
          */
         node.type === 'blockquote' &&
-        node.children[0] &&
-        node.children[0].type === 'paragraph' &&
-        node.children[0].children &&
-        node.children[0].children[0] &&
+        node.children[0]?.type === 'paragraph' &&
+        node.children[0].children?.[0] &&
         'value' in node.children[0].children[0]
       ) {
         const initiatorTag = node.children[0].children[0].value;

--- a/packages/plugin-container-syntax/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-container-syntax/tests/__snapshots__/index.test.ts.snap
@@ -54,6 +54,11 @@ exports[`remark-container > details 1`] = `
 This is a details block.</p></div></details>"
 `;
 
+exports[`remark-container > empty blockquote 1`] = `
+"<blockquote>
+</blockquote>"
+`;
+
 exports[`remark-container > end with a link 1`] = `"<div class="rspress-directive tip"><div class="rspress-directive-title">TIP</div><div class="rspress-directive-content"><p>Line 1.</p><p>Line 2 with <a href="http://example.com">link</a>.</p></div></div>"`;
 
 exports[`remark-container > end with a link 2`] = `

--- a/packages/plugin-container-syntax/tests/index.test.ts
+++ b/packages/plugin-container-syntax/tests/index.test.ts
@@ -380,4 +380,13 @@ Line 2 with [link](http://example.com).
 
     expect(resultWithoutDirective.value).toMatchSnapshot();
   });
+
+  test('empty blockquote', () => {
+    const result = processor.processSync(`
+
+>
+
+  `);
+    expect(result.value).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
## Summary

Fixing the bug #2220 by adding undefined protection to a part of logic in **plugin-container-syntax**.

## Related Issue

#2220 

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
