### PR TITLE
fix: add rehype codeMeta plugin back but shiki compatible metastring property instead

### DIFF
--- a/packages/core/src/node/mdx/rehypePlugins/codeMeta.ts
+++ b/packages/core/src/node/mdx/rehypePlugins/codeMeta.ts
@@ -1,0 +1,21 @@
+import type { Root } from 'hast';
+import type { Plugin } from 'unified';
+import { visit } from 'unist-util-visit';
+
+export const rehypeCodeMeta: Plugin<[], Root> = () => {
+  return tree => {
+    visit(tree, 'element', node => {
+      // <pre><code>...</code></pre>
+      // 1. Find pre element
+      if (
+        node.tagName === 'pre' &&
+        node.children[0]?.type === 'element' &&
+        node.children[0].tagName === 'code'
+      ) {
+        const codeNode = node.children[0];
+        // https://github.com/shikijs/shiki/blob/4b8e6331aca7f8cd77e280120e67933525550c36/packages/rehype/src/handlers.ts#L59C46-L59C56
+        codeNode.properties.metastring = codeNode.data?.meta;
+      }
+    });
+  };
+};

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -76,6 +76,7 @@ mdast
 Mdxjs
 mdxrs
 menlo
+metastring
 modularly
 napi
 networkidle


### PR DESCRIPTION
## Summary

add rehype codeMeta plugin back but shiki compatible metastring property instead

## Related Issue

<!--- Provide link of related issues -->

related #2214

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
