### PR TITLE
fix(infra): bundle size regression after migrating to bundleless dist

### DIFF
--- a/packages/theme-default/index-barrel.js
+++ b/packages/theme-default/index-barrel.js
@@ -1,0 +1,59 @@
+// layout
+export { DocLayout } from './layout/DocLayout';
+export { HomeLayout } from './layout/HomeLayout';
+export { Layout } from './layout/Layout';
+export { NotFoundLayout } from './layout/NotFountLayout';
+export { getCustomMDXComponent } from './layout/DocLayout/docComponents';
+
+// logic
+export { usePrevNextPage } from './logic/usePrevNextPage';
+export { useEditLink } from './logic/useEditLink';
+export { useSidebarData } from './logic/useSidebarData';
+export { useHiddenNav, useEnableNav } from './logic/useHiddenNav';
+export { useLocaleSiteData } from './logic/useLocaleSiteData';
+export {
+  useSetup,
+  useBindingAsideScroll as bindingAsideScroll,
+  scrollToTarget,
+} from './logic/sideEffects';
+export { useFullTextSearch } from './logic/useFullTextSearch';
+export { useRedirect4FirstVisit } from './logic/useRedirect4FirstVisit';
+export { useThemeState } from './logic/useAppearance';
+export {
+  renderHtmlOrText,
+  parseInlineMarkdownText,
+  renderInlineMarkdown,
+} from './logic/utils';
+
+export * from './components/Search/logic/types';
+
+// components
+export { Aside } from './components/Aside';
+export { Toc } from './components/Toc';
+export { Badge } from './components/Badge';
+export { Button } from './components/Button';
+export { Card } from './components/Card';
+export { CodeBlockRuntime } from './components/CodeBlockRuntime';
+export { DocFooter } from './components/DocFooter';
+export { EditLink } from './components/EditLink';
+export { HomeFeature } from './components/HomeFeature';
+export { HomeFooter } from './components/HomeFooter';
+export { HomeHero } from './components/HomeHero';
+export { LastUpdated } from './components/LastUpdated';
+export { Link } from './components/Link';
+export { LinkCard } from './components/LinkCard';
+export { Nav } from './components/Nav';
+export { Overview } from './components/Overview';
+export { PackageManagerTabs } from './components/PackageManagerTabs';
+export { PrevNextPage } from './components/PrevNextPage';
+export { ScrollToTop } from './components/ScrollToTop';
+export { Search } from './components/Search';
+export { SearchButton } from './components/Search/SearchButton';
+export { SearchPanel } from './components/Search/SearchPanel';
+export { Sidebar, SidebarList } from './components/Sidebar';
+export { SocialLinks } from './components/SocialLinks';
+export { SourceCode } from './components/SourceCode';
+export { Steps } from './components/Steps';
+export { SwitchAppearance } from './components/SwitchAppearance';
+export { Tab, Tabs } from './components/Tabs';
+export { Tag } from './components/Tag';

--- a/packages/theme-default/index-barrel.js
+++ b/packages/theme-default/index-barrel.js
@@ -1,9 +1,9 @@
 // layout
-export { DocLayout } from './layout/DocLayout.js';
-export { HomeLayout } from './layout/HomeLayout.js';
-export { Layout } from './layout/Layout.js';
-export { NotFoundLayout } from './layout/NotFountLayout.js';
-export { getCustomMDXComponent } from './layout/DocLayout/docComponents.js';
+export { DocLayout } from './layout/DocLayout/index.js';
+export { HomeLayout } from './layout/HomeLayout/index.js';
+export { Layout } from './layout/Layout/index.js';
+export { NotFoundLayout } from './layout/NotFountLayout/index.js';
+export { getCustomMDXComponent } from './layout/DocLayout/docComponents/index.js';
 
 // logic
 export { usePrevNextPage } from './logic/usePrevNextPage.js';
@@ -28,32 +28,35 @@ export {
 export * from './components/Search/logic/types.js';
 
 // components
-export { Aside } from './components/Aside.js';
-export { Toc } from './components/Toc.js';
-export { Badge } from './components/Badge.js';
-export { Button } from './components/Button.js';
-export { Card } from './components/Card.js';
-export { CodeBlockRuntime } from './components/CodeBlockRuntime.js';
-export { DocFooter } from './components/DocFooter.js';
-export { EditLink } from './components/EditLink.js';
-export { HomeFeature } from './components/HomeFeature.js';
-export { HomeFooter } from './components/HomeFooter.js';
-export { HomeHero } from './components/HomeHero.js';
-export { LastUpdated } from './components/LastUpdated.js';
-export { Link } from './components/Link.js';
-export { LinkCard } from './components/LinkCard.js';
-export { Nav } from './components/Nav.js';
-export { Overview } from './components/Overview.js';
-export { PackageManagerTabs } from './components/PackageManagerTabs.js';
-export { PrevNextPage } from './components/PrevNextPage.js';
-export { ScrollToTop } from './components/ScrollToTop.js';
-export { Search } from './components/Search.js';
+export { Aside } from './components/Aside/index.js';
+export { Toc } from './components/Toc/index.js';
+export { Badge } from './components/Badge/index.js';
+export { Button } from './components/Button/index.js';
+export { Card } from './components/Card/index.js';
+export { CodeBlockRuntime } from './components/CodeBlockRuntime/index.js';
+export { DocFooter } from './components/DocFooter/index.js';
+export { EditLink } from './components/EditLink/index.js';
+export { HomeFeature } from './components/HomeFeature/index.js';
+export { HomeFooter } from './components/HomeFooter/index.js';
+export { HomeHero } from './components/HomeHero/index.js';
+export { LastUpdated } from './components/LastUpdated/index.js';
+export { Link } from './components/Link/index.js';
+export { LinkCard } from './components/LinkCard/index.js';
+export { Nav } from './components/Nav/index.js';
+export { Overview } from './components/Overview/index.js';
+export { PackageManagerTabs } from './components/PackageManagerTabs/index.js';
+export { PrevNextPage } from './components/PrevNextPage/index.js';
+export { ScrollToTop } from './components/ScrollToTop/index.js';
+export { Search } from './components/Search/index.js';
 export { SearchButton } from './components/Search/SearchButton.js';
 export { SearchPanel } from './components/Search/SearchPanel.js';
-export { Sidebar, SidebarList } from './components/Sidebar.js';
-export { SocialLinks } from './components/SocialLinks.js';
-export { SourceCode } from './components/SourceCode.js';
-export { Steps } from './components/Steps.js';
-export { SwitchAppearance } from './components/SwitchAppearance.js';
-export { Tab, Tabs } from './components/Tabs.js';
-export { Tag } from './components/Tag.js';
+export {
+  Sidebar,
+  SidebarList,
+} from './components/Sidebar/index.js';
+export { SocialLinks } from './components/SocialLinks/index.js';
+export { SourceCode } from './components/SourceCode/index.js';
+export { Steps } from './components/Steps/index.js';
+export { SwitchAppearance } from './components/SwitchAppearance/index.js';
+export { Tab, Tabs } from './components/Tabs/index.js';
+export { Tag } from './components/Tag/index.js';

--- a/packages/theme-default/index-barrel.js
+++ b/packages/theme-default/index-barrel.js
@@ -1,59 +1,59 @@
 // layout
-export { DocLayout } from './layout/DocLayout';
-export { HomeLayout } from './layout/HomeLayout';
-export { Layout } from './layout/Layout';
-export { NotFoundLayout } from './layout/NotFountLayout';
-export { getCustomMDXComponent } from './layout/DocLayout/docComponents';
+export { DocLayout } from './layout/DocLayout.js';
+export { HomeLayout } from './layout/HomeLayout.js';
+export { Layout } from './layout/Layout.js';
+export { NotFoundLayout } from './layout/NotFountLayout.js';
+export { getCustomMDXComponent } from './layout/DocLayout/docComponents.js';
 
 // logic
-export { usePrevNextPage } from './logic/usePrevNextPage';
-export { useEditLink } from './logic/useEditLink';
-export { useSidebarData } from './logic/useSidebarData';
-export { useHiddenNav, useEnableNav } from './logic/useHiddenNav';
-export { useLocaleSiteData } from './logic/useLocaleSiteData';
+export { usePrevNextPage } from './logic/usePrevNextPage.js';
+export { useEditLink } from './logic/useEditLink.js';
+export { useSidebarData } from './logic/useSidebarData.js';
+export { useHiddenNav, useEnableNav } from './logic/useHiddenNav.js';
+export { useLocaleSiteData } from './logic/useLocaleSiteData.js';
 export {
   useSetup,
   useBindingAsideScroll as bindingAsideScroll,
   scrollToTarget,
-} from './logic/sideEffects';
-export { useFullTextSearch } from './logic/useFullTextSearch';
-export { useRedirect4FirstVisit } from './logic/useRedirect4FirstVisit';
-export { useThemeState } from './logic/useAppearance';
+} from './logic/sideEffects.js';
+export { useFullTextSearch } from './logic/useFullTextSearch.js';
+export { useRedirect4FirstVisit } from './logic/useRedirect4FirstVisit.js';
+export { useThemeState } from './logic/useAppearance.js';
 export {
   renderHtmlOrText,
   parseInlineMarkdownText,
   renderInlineMarkdown,
-} from './logic/utils';
+} from './logic/utils.js';
 
-export * from './components/Search/logic/types';
+export * from './components/Search/logic/types.js';
 
 // components
-export { Aside } from './components/Aside';
-export { Toc } from './components/Toc';
-export { Badge } from './components/Badge';
-export { Button } from './components/Button';
-export { Card } from './components/Card';
-export { CodeBlockRuntime } from './components/CodeBlockRuntime';
-export { DocFooter } from './components/DocFooter';
-export { EditLink } from './components/EditLink';
-export { HomeFeature } from './components/HomeFeature';
-export { HomeFooter } from './components/HomeFooter';
-export { HomeHero } from './components/HomeHero';
-export { LastUpdated } from './components/LastUpdated';
-export { Link } from './components/Link';
-export { LinkCard } from './components/LinkCard';
-export { Nav } from './components/Nav';
-export { Overview } from './components/Overview';
-export { PackageManagerTabs } from './components/PackageManagerTabs';
-export { PrevNextPage } from './components/PrevNextPage';
-export { ScrollToTop } from './components/ScrollToTop';
-export { Search } from './components/Search';
-export { SearchButton } from './components/Search/SearchButton';
-export { SearchPanel } from './components/Search/SearchPanel';
-export { Sidebar, SidebarList } from './components/Sidebar';
-export { SocialLinks } from './components/SocialLinks';
-export { SourceCode } from './components/SourceCode';
-export { Steps } from './components/Steps';
-export { SwitchAppearance } from './components/SwitchAppearance';
-export { Tab, Tabs } from './components/Tabs';
-export { Tag } from './components/Tag';
+export { Aside } from './components/Aside.js';
+export { Toc } from './components/Toc.js';
+export { Badge } from './components/Badge.js';
+export { Button } from './components/Button.js';
+export { Card } from './components/Card.js';
+export { CodeBlockRuntime } from './components/CodeBlockRuntime.js';
+export { DocFooter } from './components/DocFooter.js';
+export { EditLink } from './components/EditLink.js';
+export { HomeFeature } from './components/HomeFeature.js';
+export { HomeFooter } from './components/HomeFooter.js';
+export { HomeHero } from './components/HomeHero.js';
+export { LastUpdated } from './components/LastUpdated.js';
+export { Link } from './components/Link.js';
+export { LinkCard } from './components/LinkCard.js';
+export { Nav } from './components/Nav.js';
+export { Overview } from './components/Overview.js';
+export { PackageManagerTabs } from './components/PackageManagerTabs.js';
+export { PrevNextPage } from './components/PrevNextPage.js';
+export { ScrollToTop } from './components/ScrollToTop.js';
+export { Search } from './components/Search.js';
+export { SearchButton } from './components/Search/SearchButton.js';
+export { SearchPanel } from './components/Search/SearchPanel.js';
+export { Sidebar, SidebarList } from './components/Sidebar.js';
+export { SocialLinks } from './components/SocialLinks.js';
+export { SourceCode } from './components/SourceCode.js';
+export { Steps } from './components/Steps.js';
+export { SwitchAppearance } from './components/SwitchAppearance.js';
+export { Tab, Tabs } from './components/Tabs.js';
+export { Tag } from './components/Tag.js';

--- a/packages/theme-default/package.json
+++ b/packages/theme-default/package.json
@@ -23,11 +23,11 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
+      "default": "./dist/index-barrel.js"
     },
     "./package.json": "./package.json"
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index-barrel.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/theme-default/package.json
+++ b/packages/theme-default/package.json
@@ -23,11 +23,11 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "default": "./dist/index-barrel.js"
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
-  "main": "./dist/index-barrel.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/theme-default/rslib.config.ts
+++ b/packages/theme-default/rslib.config.ts
@@ -63,8 +63,9 @@ export default defineConfig({
           patterns: [
             {
               from: './index-barrel.js',
-              to: './index-barrel.js',
+              to: './index.js',
               context: __dirname,
+              force: true,
             },
           ],
         },

--- a/packages/theme-default/rslib.config.ts
+++ b/packages/theme-default/rslib.config.ts
@@ -59,6 +59,15 @@ export default defineConfig({
           namedExport: true,
           exportLocalsConvention: 'camelCaseOnly',
         },
+        copy: {
+          patterns: [
+            {
+              from: './index-barrel.js',
+              to: './index-barrel.js',
+              context: __dirname,
+            },
+          ],
+        },
       },
     },
   ],

--- a/packages/theme-default/src/index.ts
+++ b/packages/theme-default/src/index.ts
@@ -1,9 +1,9 @@
 // layout
-export { DocLayout } from './layout/DocLayout';
-export { HomeLayout } from './layout/HomeLayout';
-export { Layout } from './layout/Layout';
-export { NotFoundLayout } from './layout/NotFountLayout';
-export { getCustomMDXComponent } from './layout/DocLayout/docComponents';
+export { DocLayout } from './layout/DocLayout/index';
+export { HomeLayout } from './layout/HomeLayout/index';
+export { Layout } from './layout/Layout/index';
+export { NotFoundLayout } from './layout/NotFountLayout/index';
+export { getCustomMDXComponent } from './layout/DocLayout/docComponents/index';
 export type {
   ShikiPreProps,
   PreWithCodeButtonGroupProps,
@@ -32,29 +32,29 @@ export {
 export * from './components/Search/logic/types';
 
 // components
-export { Aside } from './components/Aside';
-export { Toc } from './components/Toc';
-export { Badge } from './components/Badge';
-export { Button } from './components/Button';
-export { Card } from './components/Card';
+export { Aside } from './components/Aside/index';
+export { Toc } from './components/Toc/index';
+export { Badge } from './components/Badge/index';
+export { Button } from './components/Button/index';
+export { Card } from './components/Card/index';
 export {
   CodeBlockRuntime,
   type CodeBlockRuntimeProps,
-} from './components/CodeBlockRuntime';
-export { DocFooter } from './components/DocFooter';
-export { EditLink } from './components/EditLink';
-export { HomeFeature } from './components/HomeFeature';
-export { HomeFooter } from './components/HomeFooter';
-export { HomeHero, type HomeHeroProps } from './components/HomeHero';
-export { LastUpdated } from './components/LastUpdated';
-export { Link, type LinkProps } from './components/Link';
-export { LinkCard } from './components/LinkCard';
-export { Nav } from './components/Nav';
-export { Overview } from './components/Overview';
-export { PackageManagerTabs } from './components/PackageManagerTabs';
-export { PrevNextPage } from './components/PrevNextPage';
-export { ScrollToTop } from './components/ScrollToTop';
-export { Search } from './components/Search';
+} from './components/CodeBlockRuntime/index';
+export { DocFooter } from './components/DocFooter/index';
+export { EditLink } from './components/EditLink/index';
+export { HomeFeature } from './components/HomeFeature/index';
+export { HomeFooter } from './components/HomeFooter/index';
+export { HomeHero, type HomeHeroProps } from './components/HomeHero/index';
+export { LastUpdated } from './components/LastUpdated/index';
+export { Link, type LinkProps } from './components/Link/index';
+export { LinkCard } from './components/LinkCard/index';
+export { Nav } from './components/Nav/index';
+export { Overview } from './components/Overview/index';
+export { PackageManagerTabs } from './components/PackageManagerTabs/index';
+export { PrevNextPage } from './components/PrevNextPage/index';
+export { ScrollToTop } from './components/ScrollToTop/index';
+export { Search } from './components/Search/index';
 export {
   SearchButton,
   type SearchButtonProps,
@@ -63,10 +63,14 @@ export {
   SearchPanel,
   type SearchPanelProps,
 } from './components/Search/SearchPanel';
-export { Sidebar, SidebarList, type SidebarData } from './components/Sidebar';
-export { SocialLinks } from './components/SocialLinks';
-export { SourceCode } from './components/SourceCode';
-export { Steps } from './components/Steps';
-export { SwitchAppearance } from './components/SwitchAppearance';
-export { Tab, Tabs } from './components/Tabs';
-export { Tag } from './components/Tag';
+export {
+  Sidebar,
+  SidebarList,
+  type SidebarData,
+} from './components/Sidebar/index';
+export { SocialLinks } from './components/SocialLinks/index';
+export { SourceCode } from './components/SourceCode/index';
+export { Steps } from './components/Steps/index';
+export { SwitchAppearance } from './components/SwitchAppearance/index';
+export { Tab, Tabs } from './components/Tabs/index';
+export { Tag } from './components/Tag/index';


### PR DESCRIPTION
## Summary

fix(infra): bundle size regression after migrating to bundleless dist

![image](https://github.com/user-attachments/assets/5114f973-4982-4611-a7f7-b151c3beb3f9)

![image](https://github.com/user-attachments/assets/0186e934-1e2c-42d5-a1fd-30b1fa62a9a6)



## Related Issue

<!--- Provide link of related issues -->

#2216

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
