### PR TITLE
chore(core): add hint for react and react-dom are different versions.

### DIFF
--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -301,7 +301,6 @@ async function createInternalBuildConfig(
         resolve: {
           alias: {
             ...reactCSRAlias,
-            // FIXME: currently in Rspress we only support ^6.29.0
             ...reactRouterDomAlias,
           },
         },
@@ -327,7 +326,6 @@ async function createInternalBuildConfig(
               resolve: {
                 alias: {
                   ...reactSSRAlias,
-                  // FIXME: currently in Rspress we only support react-router-dom ^6.29.0
                   ...reactRouterDomAlias,
                 },
               },

--- a/packages/core/src/node/logger/hint.ts
+++ b/packages/core/src/node/logger/hint.ts
@@ -9,7 +9,6 @@ const THEME_DEFAULT_EXPORT_PATTERN = /export\s+default\s+\{/;
 /**
  * breaking change hint of theme
  * @see https://github.com/web-infra-dev/rspress/discussions/1891#discussioncomment-12422737
- *
  */
 export async function hintThemeBreakingChange(customThemeDir: string) {
   const fileList = ['index.ts', 'index.tsx', 'index.js', 'index.mjs'];
@@ -44,12 +43,24 @@ export async function hintThemeBreakingChange(customThemeDir: string) {
   }
 }
 
+/**
+ * Possible reasons for printing "ssg: false" and some troubleshooting guidelines for users.
+ */
 export function hintSSGFailed() {
   logger.info(`[Rspress v2] \`ssg: true\` requires the source code to support SSR. If the code is not compatible to SSR, the build process will fail. You can try:
     1. Fix code to make it SSR-compatible.
     2. Set \`ssg: false\`, but the SSG feature will be lost.`);
 }
 
+/**
+ * Print "ssg: false" explicitly to give users a clear perception.
+ */
 export function hintSSGFalse() {
   logger.info('`ssg: false` detected, SSG will be disabled.');
+}
+
+export function hintReactVersion() {
+  logger.info(
+    '[Rspress v2] Rspress support React 18 and 19, please confirm that both react and react-dom are installed in package.json with the same version. ',
+  );
 }

--- a/packages/core/src/node/utils/detectReactVersion.ts
+++ b/packages/core/src/node/utils/detectReactVersion.ts
@@ -2,7 +2,9 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { logger } from '@rspress/shared/logger';
 import enhancedResolve from 'enhanced-resolve';
+import picocolors from 'picocolors';
 import { PACKAGE_ROOT } from '../constants';
+import { hintReactVersion } from '../logger/hint';
 import { pathExists, readJson } from './fs';
 
 // TODO: replace enhanced-resolve with this.getResolver
@@ -29,6 +31,7 @@ export async function detectReactVersion(): Promise<number> {
   return (await detectPackageMajorVersion('react')) ?? DEFAULT_REACT_VERSION;
 }
 
+// FIXME: currently in Rspress we only support react-router-dom ^6.29.0
 export async function resolveReactRouterDomAlias(): Promise<
   Record<string, string>
 > {
@@ -108,7 +111,12 @@ export async function resolveReactAlias(reactVersion: number, isSSR: boolean) {
           );
         });
       } catch (e) {
-        logger.warn(`${lib} not found: \n`, e);
+        if (e instanceof Error) {
+          logger.warn(
+            `${lib} not found: \n    ${picocolors.gray(e.toString())}`,
+          );
+          hintReactVersion();
+        }
       }
     }),
   );

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -372,7 +372,7 @@ export type LocalSearchOptions = SearchHooks & {
   versioned?: boolean;
   /**
    * If enabled, the search index will include code block content, which allows users to search code blocks.
-   * @default false
+   * @default true
    */
   codeBlocks?: boolean;
 };


### PR DESCRIPTION
## Summary

1. comment "@default true"

2. chore: add hint for react and react-dom are different versions.

## Related Issue

<!--- Provide link of related issues -->

close #2234

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
