### PR TITLE
docs: use escape character to bypass HTML render

### DIFF
--- a/packages/document/docs/en/plugin/official-plugins/preview.mdx
+++ b/packages/document/docs/en/plugin/official-plugins/preview.mdx
@@ -38,7 +38,7 @@ The component code of internal components is declared in the mdx file. You can d
 ````md
 ```tsx
 function App() {
-  return <div>Hello World</div>;
+  return &lt;div>Hello World&lt;/div>;
 }
 
 export default App;
@@ -52,7 +52,7 @@ But if you want to keep the style of the code block instead of rendering it as a
 ````md
 ```tsx pure
 function App() {
-  return <div>Hello World</div>;
+  return &lt;div>Hello World&lt;/div>;
 }
 export default App;
 ```
@@ -63,7 +63,7 @@ If you have set `defaultRenderMode` to `'pure'`, Rspress will not render this co
 ````md
 ```tsx preview
 function App() {
-  return <div>Hello World</div>;
+  return &lt;div>Hello World&lt;/div>;
 }
 export default App;
 ```
@@ -131,7 +131,7 @@ You can also set it for each individual code block:
 ````md title="example.mdx"
 ```tsx iframe
 function App() {
-  return <div>Hello World</div>;
+  return &lt;div>Hello World&lt;/div>;
 }
 export default App;
 ```

--- a/packages/document/docs/zh/plugin/official-plugins/preview.mdx
+++ b/packages/document/docs/zh/plugin/official-plugins/preview.mdx
@@ -36,7 +36,7 @@ export default defineConfig({
 ````md
 ```tsx
 function App() {
-  return <div>Hello World</div>;
+  return &lt;div>Hello World&lt;/div>;
 }
 
 export default App;
@@ -50,7 +50,7 @@ export default App;
 ````md
 ```tsx pure
 function App() {
-  return <div>Hello World</div>;
+  return &lt;div>Hello World&lt;/div>;
 }
 export default App;
 ```
@@ -61,7 +61,7 @@ export default App;
 ````md
 ```tsx preview
 function App() {
-  return <div>Hello World</div>;
+  return &lt;div>Hello World&lt;/div>;
 }
 export default App;
 ```
@@ -129,7 +129,7 @@ interface IframeOptions {
 ````md title="example.mdx"
 ```tsx iframe
 function App() {
-  return <div>Hello World</div>;
+  return &lt;div>Hello World&lt;/div>;
 }
 export default App;
 ```


### PR DESCRIPTION
## Summary

Seems like v2's doc has fixed this issue, this is just a quick fix without investigating why it happens (maybe a renderer bug).

https://rspress.dev/plugin/official-plugins/preview#internal-components

before:

<img width="386" alt="image" src="https://github.com/user-attachments/assets/718af2ec-bd8e-4905-9eb2-46b60945d5c9" />

after:

<img width="447" alt="image" src="https://github.com/user-attachments/assets/26e6fa73-4579-4dae-bde0-ce04dfacec88" />


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
