### PR TITLE
refactor(ssg): use react18 api onRecoverableError and reduce the difference between SSR and CSR bundle

### DIFF
--- a/packages/core/src/node/route/RouteService.test.ts
+++ b/packages/core/src/node/route/RouteService.test.ts
@@ -18,10 +18,7 @@ async function initRouteService(config: UserConfig) {
   const { routeData } = routeService;
 
   const routeMeta = routeService.getRoutes();
-  const routeCode = routeService.generateRoutesCodeByRouteMeta(
-    routeMeta,
-    false,
-  );
+  const routeCode = routeService.generateRoutesCodeByRouteMeta(routeMeta);
 
   return {
     routeData,

--- a/packages/core/src/node/runtimeModule/routeList.ts
+++ b/packages/core/src/node/runtimeModule/routeList.ts
@@ -5,10 +5,8 @@ export const routeListVMPlugin: VirtualModulePlugin = context => {
   const { routeService } = context;
 
   return {
-    [RuntimeModuleID.Routes]: ({ environment }) => {
-      return environment.name === 'node'
-        ? routeService.generateRoutesCode(true)
-        : routeService.generateRoutesCode(false);
+    [RuntimeModuleID.Routes]: () => {
+      return routeService.generateRoutesCode();
     },
   };
 };

--- a/packages/core/src/runtime/ssrClientEntry.tsx
+++ b/packages/core/src/runtime/ssrClientEntry.tsx
@@ -5,11 +5,18 @@ import { initPageData } from './initPageData';
 // difference from csrClientEntry.tsx
 // 1. use hydrate instead of createRoot().render()
 // 2. initPageData() should already be inited when hydrateRoot()
+// 3. add onRecoverableError
 
 async function renderInBrowser() {
   const container = document.getElementById('root')!;
   const initialPageData = await initPageData(window.location.pathname);
-  hydrateRoot(container, <ClientApp initialPageData={initialPageData} />);
+  hydrateRoot(container, <ClientApp initialPageData={initialPageData} />, {
+    onRecoverableError(error, errorInfo) {
+      if (error instanceof Error) {
+        console.warn('hydrateRoot recoverable error:', error, errorInfo);
+      }
+    },
+  });
 }
 
 renderInBrowser();

--- a/packages/core/src/runtime/ssrServerEntry.tsx
+++ b/packages/core/src/runtime/ssrServerEntry.tsx
@@ -1,4 +1,8 @@
-import { DataContext, ThemeContext } from '@rspress/runtime';
+import {
+  DataContext,
+  ThemeContext,
+  pathnameToRouteService,
+} from '@rspress/runtime';
 import { StaticRouter } from '@rspress/runtime/server';
 import type { PageData } from '@rspress/shared';
 import { type Unhead, UnheadProvider } from '@unhead/react/server';
@@ -11,6 +15,11 @@ import { App } from './App';
 import { initPageData } from './initPageData';
 
 const DEFAULT_THEME = 'light';
+
+async function preloadRoute(pathname: string) {
+  const route = pathnameToRouteService(pathname);
+  await route?.preload();
+}
 
 function renderToHtml(app: ReactNode): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -32,6 +41,7 @@ export async function render(
   head: Unhead,
 ): Promise<{ appHtml: string; pageData: PageData }> {
   const initialPageData = await initPageData(pagePath);
+  await preloadRoute(pagePath);
 
   const appHtml = await renderToHtml(
     <ThemeContext.Provider value={{ theme: DEFAULT_THEME }}>

--- a/packages/runtime/src/Content.tsx
+++ b/packages/runtime/src/Content.tsx
@@ -1,17 +1,10 @@
-import { inBrowser } from '@rspress/shared';
-import {
-  type ReactElement,
-  type ReactNode,
-  Suspense,
-  memo,
-  useMemo,
-} from 'react';
+import { type ReactNode, Suspense, memo, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import siteData from 'virtual-site-data';
 import { useViewTransition } from './hooks';
 import { pathnameToRouteService } from './route';
 
-function TransitionContentImpl(props: { el: ReactElement }) {
+function TransitionContentImpl(props: { el: ReactNode }) {
   let element = props.el;
   if (siteData?.themeConfig?.enableContentAnimation) {
     element = useViewTransition(props.el);
@@ -31,17 +24,6 @@ export const Content = ({ fallback = <></> }: { fallback?: ReactNode }) => {
     const route = pathnameToRouteService(pathname);
     return route?.element;
   }, [pathname]);
-
-  if (!matchedElement) {
-    return <div></div>;
-  }
-
-  // why no Suspense during SSG?
-  // 1. Suspense will hide the error
-  // 2. during SSG, we use sync component instead of async component via `React.lazy`, so we do not need Suspense
-  if (!inBrowser()) {
-    return <TransitionContent el={matchedElement} />;
-  }
 
   return (
     <Suspense fallback={fallback}>

--- a/packages/runtime/src/hooks.ts
+++ b/packages/runtime/src/hooks.ts
@@ -1,6 +1,6 @@
 import type { PageData } from '@rspress/shared';
 import {
-  type ReactElement,
+  type ReactNode,
   createContext,
   useCallback,
   useContext,
@@ -56,7 +56,7 @@ export function useI18n<T = Record<string, Record<string, string>>>() {
   return useCallback((key: keyof T) => i18nTextData[key][lang], [lang]);
 }
 
-export function useViewTransition(dom: ReactElement) {
+export function useViewTransition(dom: ReactNode) {
   /**
    * use a pseudo element to hold the actual JSX element so we can schedule the
    * update later in sync


### PR DESCRIPTION
## Summary

refactor(ssg): use react18 api onRecoverableError and reduce the difference between SSR and CSR bundle


some benefits


#### 1. fix a hydration error of suspense

before

<img width="400" alt="image" src="https://github.com/user-attachments/assets/91c7b6a0-c2b3-4339-bac8-b4e3bf238f1d" />

after

<img width="400" alt="image" src="https://github.com/user-attachments/assets/ecc17e5c-f25d-427a-bcde-4072d0016ef1" />


#### 2. error message optimization

1. compile time ssr error message:


<img width="400" alt="image" src="https://github.com/user-attachments/assets/78337c5d-143e-457e-84bd-961cf3000b41" />


2. hydration error message:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/c64f265d-13c0-41ba-b667-08591e108b4f" />





## Related Issue

https://github.com/web-infra-dev/rspress/issues/2229

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
