### PR TITLE
perf(ssg/client): use React 18 startTransition for hydration

### DIFF
--- a/packages/core/src/runtime/ssrClientEntry.tsx
+++ b/packages/core/src/runtime/ssrClientEntry.tsx
@@ -1,3 +1,4 @@
+import { startTransition } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 import { ClientApp } from './ClientApp';
 import { initPageData } from './initPageData';
@@ -10,12 +11,16 @@ import { initPageData } from './initPageData';
 async function renderInBrowser() {
   const container = document.getElementById('root')!;
   const initialPageData = await initPageData(window.location.pathname);
-  hydrateRoot(container, <ClientApp initialPageData={initialPageData} />, {
-    onRecoverableError(error, errorInfo) {
-      if (error instanceof Error) {
-        console.warn('hydrateRoot recoverable error:', error, errorInfo);
-      }
-    },
+  // why startTransition?
+  // https://github.com/facebook/docusaurus/pull/9051
+  startTransition(() => {
+    hydrateRoot(container, <ClientApp initialPageData={initialPageData} />, {
+      onRecoverableError(error, errorInfo) {
+        if (error instanceof Error) {
+          console.warn('hydrateRoot recoverable error:', error, errorInfo);
+        }
+      },
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

perf(ssg): use React 18 startTransition for hydration

## Related Issue

<!--- Provide link of related issues -->

https://github.com/facebook/docusaurus/pull/9051

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
