### PR TITLE
fix(theme/style): Tabs wrong margin

### DIFF
--- a/packages/theme-default/src/components/Tabs/index.module.scss
+++ b/packages/theme-default/src/components/Tabs/index.module.scss
@@ -4,14 +4,14 @@
   border-radius: var(--rp-radius);
   margin: 1rem 0;
 
-  :global(div[class^='language-']) {
-    margin: 0 -0.5rem;
-    border-radius: 0;
-    font-size: 13px;
+  :global(div[class*='language-']) {
+    margin: 0 -0.5rem !important;
+    border-radius: 0 !important;
+    font-size: 13px !important;
   }
 
   :global(.rspress-code-title) {
-    padding: 8px 16px;
+    padding: 8px 16px !important;
   }
 }
 

--- a/packages/theme-default/src/components/Tabs/index.module.scss
+++ b/packages/theme-default/src/components/Tabs/index.module.scss
@@ -4,7 +4,7 @@
   border-radius: var(--rp-radius);
   margin: 1rem 0;
 
-  :global(div[class*='language-']) {
+  :global(div[class^='language-']) {
     margin: 0 -0.5rem;
     border-radius: 0;
     font-size: 13px;


### PR DESCRIPTION
## Summary

CSS should rely on selector priority rather than import order.

before

<img width="400" alt="image" src="https://github.com/user-attachments/assets/58f8a441-a2a5-4569-8556-d1f935e3bf12" />


after

<img width="400" alt="image" src="https://github.com/user-attachments/assets/e50959fa-1028-4d9c-ba8c-a39d4588ef04" />



## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
