### PR TITLE
feat(mdx): add `markdown.crossCompilerCache` for speed up build process

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -43,10 +43,35 @@ export default defineConfig({
         distPath: {
           root: './dist',
         },
+        externals: {
+          './processor': 'module ./processor.js',
+        },
       },
       source: {
         entry: {
           loader: './src/node/mdx/loader.ts',
+        },
+      },
+    },
+    {
+      format: 'esm',
+      syntax: 'es2022',
+      dts: {
+        bundle: true,
+      },
+      shims: {
+        esm: {
+          require: true,
+        },
+      },
+      output: {
+        distPath: {
+          root: './dist',
+        },
+      },
+      source: {
+        entry: {
+          processor: './src/node/mdx/processor.ts',
         },
       },
     },

--- a/packages/core/src/node/mdx/loader.ts
+++ b/packages/core/src/node/mdx/loader.ts
@@ -1,37 +1,11 @@
-import path from 'node:path';
-import { createProcessor } from '@mdx-js/mdx';
 import type { Rspack } from '@rsbuild/core';
-import type { FrontMatterMeta, Header, UserConfig } from '@rspress/shared';
 import { logger } from '@rspress/shared/logger';
-import { extractTextAndId, loadFrontMatter } from '@rspress/shared/node-utils';
 
-import type { PluginDriver } from '../PluginDriver';
-import type { RouteService } from '../route/RouteService';
-import {
-  applyReplaceRules,
-  escapeMarkdownHeadingIds,
-  normalizePath,
-} from '../utils';
-import { createMDXOptions } from './options';
-import type { TocItem } from './remarkPlugins/toc';
-
-interface LoaderOptions {
-  config: UserConfig;
-  docDirectory: string;
-  checkDeadLinks: boolean;
-  routeService: RouteService;
-  pluginDriver: PluginDriver;
-}
-
-export interface PageMeta {
-  toc: TocItem[];
-  title: string;
-  headingTitle: string;
-  frontmatter?: FrontMatterMeta;
-}
+import { compile, compileWithCrossCompilerCache } from './processor';
+import type { MdxLoaderOptions } from './types';
 
 export default async function mdxLoader(
-  this: Rspack.LoaderContext<LoaderOptions>,
+  this: Rspack.LoaderContext<MdxLoaderOptions>,
   source: string,
 ) {
   this.cacheable(true);
@@ -42,72 +16,34 @@ export default async function mdxLoader(
   const { config, docDirectory, checkDeadLinks, routeService, pluginDriver } =
     options;
 
-  // Separate frontmatter and content in MDX source
-  const { frontmatter, emptyLinesSource } = loadFrontMatter(
-    source,
-    filepath,
-    docDirectory,
-    true,
-  );
-
-  // For loader error stack, so we use the source with frontmatter @see https://github.com/web-infra-dev/rspress/issues/2010
-  const replacedSource = applyReplaceRules(
-    emptyLinesSource,
-    config.replaceRules,
-  );
-
-  // Support custom id like `#hello world {#custom-id}`.
-  // TODO > issue: `#hello world {#custom-id}` will also be replaced.
-  const preprocessedContent = escapeMarkdownHeadingIds(replacedSource);
+  const crossCompilerCache = config?.markdown?.crossCompilerCache ?? true;
 
   try {
-    let pageMeta: PageMeta = {
-      title: '',
-      toc: [] as TocItem[],
-      headingTitle: '',
-    };
-
-    const frontmatterTitle = extractTextAndId(frontmatter.title)[0];
-
-    const mdxOptions = await createMDXOptions(
-      docDirectory,
-      config,
-      checkDeadLinks,
-      routeService,
-      filepath,
-      pluginDriver,
-    );
-    const compiler = createProcessor(mdxOptions);
-
-    compiler.data('pageMeta' as any, { toc: [], title: '' });
-    const vFile = await compiler.process({
-      value: preprocessedContent,
-      path: filepath,
-    });
-
-    const compileResult = String(vFile);
-    const compilationMeta = compiler.data('pageMeta' as any) as {
-      toc: Header[];
-      title: string;
-    };
-    const headingTitle = extractTextAndId(compilationMeta.title)[0];
-    pageMeta = {
-      ...compilationMeta,
-      title: frontmatterTitle || headingTitle,
-      headingTitle,
-      frontmatter,
-    } as PageMeta;
-
-    const result = `const frontmatter = ${JSON.stringify(frontmatter)};
-${compileResult}
-MDXContent.__RSPRESS_PAGE_META = {};
-
-MDXContent.__RSPRESS_PAGE_META["${encodeURIComponent(
-      normalizePath(path.relative(docDirectory, filepath)),
-    )}"] = ${JSON.stringify(pageMeta)};
-`;
-    callback(null, result);
-  } catch (e: unknown) {
+    // TODO wrong but good enough for now (example: "build --watch")
+    if (crossCompilerCache && process.env.NODE_ENV === 'production') {
+      const compileResult = await compileWithCrossCompilerCache({
+        source,
+        filepath,
+        docDirectory,
+        checkDeadLinks,
+        config,
+        pluginDriver,
+        routeService,
+      });
+      callback(null, compileResult);
+    } else {
+      const compileResult = await compile({
+        source,
+        filepath,
+        docDirectory,
+        checkDeadLinks,
+        config,
+        pluginDriver,
+        routeService,
+      });
+      callback(null, compileResult);
+    }
+  } catch (e) {
     if (e instanceof Error) {
       logger.error(`MDX compile error: ${e.message} in ${filepath}`);
       logger.debug(e);

--- a/packages/core/src/node/mdx/options.ts
+++ b/packages/core/src/node/mdx/options.ts
@@ -16,14 +16,22 @@ import type { PluginDriver } from '../PluginDriver';
 import type { RouteService } from '../route/RouteService';
 import { rehypeCodeMeta } from './rehypePlugins/codeMeta';
 
-export async function createMDXOptions(
-  docDirectory: string,
-  config: UserConfig,
-  checkDeadLinks: boolean,
-  routeService: RouteService,
-  filepath: string,
-  pluginDriver: PluginDriver,
-): Promise<ProcessorOptions> {
+export async function createMDXOptions(options: {
+  docDirectory: string;
+  config: UserConfig;
+  checkDeadLinks: boolean;
+  routeService: RouteService;
+  filepath: string;
+  pluginDriver: PluginDriver;
+}): Promise<ProcessorOptions> {
+  const {
+    docDirectory,
+    config,
+    checkDeadLinks,
+    routeService,
+    filepath,
+    pluginDriver,
+  } = options;
   const format = path.extname(filepath).slice(1) as 'mdx' | 'md';
   const cleanUrls = config?.route?.cleanUrls ?? false;
   const {

--- a/packages/core/src/node/mdx/processor.ts
+++ b/packages/core/src/node/mdx/processor.ts
@@ -1,0 +1,134 @@
+import path from 'node:path';
+import { createProcessor } from '@mdx-js/mdx';
+import type { Header, UserConfig } from '@rspress/shared';
+import { logger } from '@rspress/shared/logger';
+import { extractTextAndId, loadFrontMatter } from '@rspress/shared/node-utils';
+
+import type { PluginDriver } from '../PluginDriver';
+import type { RouteService } from '../route/RouteService';
+import {
+  applyReplaceRules,
+  escapeMarkdownHeadingIds,
+  normalizePath,
+} from '../utils';
+import { createMDXOptions } from './options';
+import type { TocItem } from './remarkPlugins/toc';
+import type { PageMeta } from './types';
+
+interface CompileOptions {
+  source: string;
+  filepath: string;
+  checkDeadLinks: boolean;
+
+  // assume that the below instances are singleton, it will not change.
+  docDirectory: string;
+  config: UserConfig;
+  routeService: RouteService;
+  pluginDriver: PluginDriver;
+}
+
+async function compile(options: CompileOptions): Promise<string> {
+  const {
+    source,
+    filepath,
+    docDirectory,
+    checkDeadLinks,
+    config,
+    routeService,
+    pluginDriver,
+  } = options;
+
+  config.root;
+
+  const mdxOptions = await createMDXOptions({
+    checkDeadLinks,
+    config,
+    docDirectory,
+    filepath,
+    pluginDriver,
+    routeService,
+  });
+  // Separate frontmatter and content in MDX source
+  const { frontmatter, emptyLinesSource } = loadFrontMatter(
+    source,
+    filepath,
+    docDirectory,
+    true,
+  );
+
+  // For loader error stack, so we use the source with frontmatter @see https://github.com/web-infra-dev/rspress/issues/2010
+  const replacedSource = applyReplaceRules(
+    emptyLinesSource,
+    config.replaceRules,
+  );
+
+  // Support custom id like `#hello world {#custom-id}`.
+  // TODO > issue: `#hello world {#custom-id}` will also be replaced.
+  const preprocessedContent = escapeMarkdownHeadingIds(replacedSource);
+
+  try {
+    let pageMeta: PageMeta = {
+      title: '',
+      toc: [] as TocItem[],
+      headingTitle: '',
+    };
+
+    const frontmatterTitle = extractTextAndId(frontmatter.title)[0];
+
+    const compiler = createProcessor(mdxOptions);
+
+    compiler.data('pageMeta' as any, { toc: [], title: '' });
+    const vFile = await compiler.process({
+      value: preprocessedContent,
+      path: filepath,
+    });
+
+    const compileResult = String(vFile);
+    const compilationMeta = compiler.data('pageMeta' as any) as {
+      toc: Header[];
+      title: string;
+    };
+
+    const headingTitle = extractTextAndId(compilationMeta.title)[0];
+    pageMeta = {
+      ...compilationMeta,
+      title: frontmatterTitle || headingTitle,
+      headingTitle,
+      frontmatter,
+    } as PageMeta;
+
+    const result = `const frontmatter = ${JSON.stringify(frontmatter)};
+${compileResult}
+MDXContent.__RSPRESS_PAGE_META = {};
+
+MDXContent.__RSPRESS_PAGE_META["${encodeURIComponent(
+      normalizePath(path.relative(docDirectory, filepath)),
+    )}"] = ${JSON.stringify(pageMeta)};
+`;
+    return result;
+  } catch (e: unknown) {
+    if (e instanceof Error) {
+      throw e;
+    }
+    logger.error(`MDX compile error: ${e} in ${filepath}`);
+    throw new Error(`MDX compile error: ${e} in ${filepath}`);
+  }
+}
+
+// TODO: free the memory
+const cache = new Map<string, Promise<string>>();
+
+async function compileWithCrossCompilerCache(
+  options: CompileOptions,
+): Promise<string> {
+  const task = cache.get(options.filepath);
+  if (task) {
+    return task;
+  }
+
+  const promise = compile(options);
+  cache.set(options.filepath, promise);
+  return promise;
+}
+
+export { compile, compileWithCrossCompilerCache };

--- a/packages/core/src/node/mdx/remarkPlugins/toc.ts
+++ b/packages/core/src/node/mdx/remarkPlugins/toc.ts
@@ -3,7 +3,7 @@ import Slugger from 'github-slugger';
 import type { Root } from 'hast';
 import type { Plugin } from 'unified';
 import { visitChildren } from 'unist-util-visit-children';
-import type { PageMeta } from '../loader';
+import type { PageMeta } from '../types';
 
 export interface TocItem {
   id: string;

--- a/packages/core/src/node/mdx/types.ts
+++ b/packages/core/src/node/mdx/types.ts
@@ -1,0 +1,20 @@
+import type { FrontMatterMeta, UserConfig } from '@rspress/shared';
+
+import type { PluginDriver } from '../PluginDriver';
+import type { RouteService } from '../route/RouteService';
+import type { TocItem } from './remarkPlugins/toc';
+
+export interface MdxLoaderOptions {
+  config: UserConfig;
+  docDirectory: string;
+  checkDeadLinks: boolean;
+  routeService: RouteService;
+  pluginDriver: PluginDriver;
+}
+
+export interface PageMeta {
+  toc: TocItem[];
+  title: string;
+  headingTitle: string;
+  frontmatter?: FrontMatterMeta;
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -415,6 +415,12 @@ export interface MarkdownOptions {
    * @type import('@shikijs/rehype').RehypeShikiOptions
    */
   shiki?: Partial<PluginShikiOptions>;
+
+  /**
+   * Speed up build time by caching mdx parsing result in `rspress build`
+   * @default true
+   */
+  crossCompilerCache?: boolean;
 }
 
 export type Config =


### PR DESCRIPTION
## Summary

Reduce 13% time

before

<img width="400" alt="image" src="https://github.com/user-attachments/assets/61962ed1-2ab1-42c9-aaf9-aa58b2b7e9cf" />


after

<img width="400" alt="image" src="https://github.com/user-attachments/assets/222aa542-b468-4a8b-b6a6-28b871f67304" />


## Related Issue

https://github.com/facebook/docusaurus/blob/45065e8d2b5831117b8d69fec1be28f5520cf105/packages/docusaurus-mdx-loader/src/createMDXLoader.ts#L36

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
