### PR TITLE
docs: update community plugins links to point to the correct repository

### DIFF
--- a/packages/document/docs/en/plugin/community-plugins/overview.mdx
+++ b/packages/document/docs/en/plugin/community-plugins/overview.mdx
@@ -8,18 +8,18 @@ Community plugins include:
 - [rspress-plugin-translate](https://github.com/byteHulk/rspress-plugin-translate): A plugin that integrates LLM for document translation.
 - [rspress-plugin-font-open-sans](https://github.com/rspack-contrib/rspress-plugin-font-open-sans): Use Open Sans as the default font in your Rspress website.
   Rspress website.
-- [rspress-plugin-align-image](https://github.com/linbudu599/rspress-plugins/tree/main/packages/rspress-plugin-align-image): Rspress plugin to align images in markdown.
-- [rspress-plugin-directives](https://github.com/linbudu599/rspress-plugins/tree/main/packages/rspress-plugin-directives): Rspress plugin for custom directives support.
-- [rspress-plugin-file-tree](https://github.com/linbudu599/rspress-plugins/tree/main/packages/rspress-plugin-file-tree): Rspress plugin that add tree view for file structure display.
-- [rspress-plugin-gh-pages](https://github.com/linbudu599/rspress-plugins/tree/main/packages/rspress-plugin-gh-pages): Rspress plugin to add support for automatic deployment to GitHub Pages.
-- [rspress-plugin-google-analytics](https://github.com/linbudu599/rspress-plugins/tree/main/packages/rspress-plugin-google-analytics): Rspress plugin for Google Analytics integration.
-- [rspress-plugin-vercel-analytics](https://github.com/linbudu599/rspress-plugins/tree/main/packages/rspress-plugin-vercel-analytics): Rspress plugin for Vercel Analytics integration.
-- [rspress-plugin-katex](https://github.com/linbudu599/rspress-plugins/tree/main/packages/rspress-plugin-katex): Rspress plugin to add support for rendering math equations using [KaTeX](https://katex.org/).
-- [rspress-plugin-live2d](https://github.com/linbudu599/rspress-plugins/tree/main/packages/rspress-plugin-live2d): Rspress plugin for live2d, powered by [on-my-live2d](https://oml2d.com/).
-- [rspress-plugin-mermaid](https://github.com/linbudu599/rspress-plugins/tree/main/packages/rspress-plugin-mermaid): Rspress plugin to render [Mermaid](https://mermaid.js.org/#/) diagrams in markdown files.
-- [rspress-plugin-reading-time](https://github.com/linbudu599/rspress-plugins/tree/main/packages/rspress-plugin-reading-time): Rspress plugin to display reading time for your document pages.
-- [rspress-plugin-supersub](https://github.com/linbudu599/rspress-plugins/tree/main/packages/rspress-plugin-supersub): Rspress plugin to add superscript(`<super></super>`) and subscript(`<sub></sub>`) support.
-- [rspress-plugin-toc](https://github.com/linbudu599/rspress-plugins/tree/main/packages/rspress-plugin-toc): Rspress plugin that injects a table of contents into the page.
+- [rspress-plugin-align-image](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-align-image): Rspress plugin to align images in markdown.
+- [rspress-plugin-directives](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-directives): Rspress plugin for custom directives support.
+- [rspress-plugin-file-tree](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-file-tree): Rspress plugin that add tree view for file structure display.
+- [rspress-plugin-gh-pages](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-gh-pages): Rspress plugin to add support for automatic deployment to GitHub Pages.
+- [rspress-plugin-google-analytics](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-google-analytics): Rspress plugin for Google Analytics integration.
+- [rspress-plugin-vercel-analytics](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-vercel-analytics): Rspress plugin for Vercel Analytics integration.
+- [rspress-plugin-katex](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-katex): Rspress plugin to add support for rendering math equations using [KaTeX](https://katex.org/).
+- [rspress-plugin-live2d](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-live2d): Rspress plugin for live2d, powered by [on-my-live2d](https://oml2d.com/).
+- [rspress-plugin-mermaid](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-mermaid): Rspress plugin to render [Mermaid](https://mermaid.js.org/#/) diagrams in markdown files.
+- [rspress-plugin-reading-time](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-reading-time): Rspress plugin to display reading time for your document pages.
+- [rspress-plugin-supersub](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-supersub): Rspress plugin to add superscript(`<super></super>`) and subscript(`<sub></sub>`) support.
+- [rspress-plugin-toc](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-toc): Rspress plugin that injects a table of contents into the page.
 
 You can check out the Rspress plugins provided by the community at [awesome-rspack - Rspress Plugins](https://github.com/web-infra-dev/awesome-rspack?tab=readme-ov-file#rspress-plugins).
 

--- a/packages/document/docs/zh/plugin/community-plugins/overview.mdx
+++ b/packages/document/docs/zh/plugin/community-plugins/overview.mdx
@@ -7,18 +7,18 @@
 - [rspress-plugin-sitemap](https://github.com/jl917/rspress-plugin-sitemap)：自动生成用于 SEO 的站点地图。
 - [rspress-plugin-translate](https://github.com/byteHulk/rspress-plugin-translate)：集成 LLM 进行文档翻译的插件。
 - [rspress-plugin-font-open-sans](https://github.com/rspack-contrib/rspress-plugin-font-open-sans): 使用 Open Sans 作为 Rspress 网站中的默认字体。
-- [rspress-plugin-align-image](https://github.com/linbudu599/rspress-plugins/tree/main/packages/rspress-plugin-align-image): 让 markdown 中的图片居中展示.
-- [rspress-plugin-directives](https://github.com/linbudu599/rspress-plugins/tree/main/packages/rspress-plugin-directives): 支持自定义的指令到全局组件转换逻辑.
-- [rspress-plugin-file-tree](https://github.com/linbudu599/rspress-plugins/tree/main/packages/rspress-plugin-file-tree): 支持文件树的可视化展示.
-- [rspress-plugin-gh-pages](https://github.com/linbudu599/rspress-plugins/tree/main/packages/rspress-plugin-gh-pages): 自动部署到 GitHub Pages.
-- [rspress-plugin-google-analytics](https://github.com/linbudu599/rspress-plugins/tree/main/packages/rspress-plugin-google-analytics): 为 Rspress 站点集成 Google Analytics.
-- [rspress-plugin-vercel-analytics](https://github.com/linbudu599/rspress-plugins/tree/main/packages/rspress-plugin-vercel-analytics): 为 Rspress 站点集成 Vercel Analytics.
-- [rspress-plugin-katex](https://github.com/linbudu599/rspress-plugins/tree/main/packages/rspress-plugin-katex): 支持在 markdown 中编写数学公式，并使用 [KaTeX](https://katex.org/) 渲染.
-- [rspress-plugin-live2d](https://github.com/linbudu599/rspress-plugins/tree/main/packages/rspress-plugin-live2d): 为你的 Rspress 站点添加看板娘，基于 [on-my-live2d](https://oml2d.com/).
-- [rspress-plugin-mermaid](https://github.com/linbudu599/rspress-plugins/tree/main/packages/rspress-plugin-mermaid): 为 Rspress 支持基于 [Mermaid](https://mermaid.js.org/#/) 的流程图、时序图等.
-- [rspress-plugin-reading-time](https://github.com/linbudu599/rspress-plugins/tree/main/packages/rspress-plugin-reading-time): 计算每一页文档的预计阅读时间，并在文档的正上方展示.
-- [rspress-plugin-supersub](https://github.com/linbudu599/rspress-plugins/tree/main/packages/rspress-plugin-supersub): 为 Rspress 支持 上标(`<super></super>`) 与 下标(`<sub></sub>`) 语法.
-- [rspress-plugin-toc](https://github.com/linbudu599/rspress-plugins/tree/main/packages/rspress-plugin-toc): 自动为你的文档页面生成内容导航。
+- [rspress-plugin-align-image](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-align-image): 让 markdown 中的图片居中展示.
+- [rspress-plugin-directives](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-directives): 支持自定义的指令到全局组件转换逻辑.
+- [rspress-plugin-file-tree](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-file-tree): 支持文件树的可视化展示.
+- [rspress-plugin-gh-pages](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-gh-pages): 自动部署到 GitHub Pages.
+- [rspress-plugin-google-analytics](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-google-analytics): 为 Rspress 站点集成 Google Analytics.
+- [rspress-plugin-vercel-analytics](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-vercel-analytics): 为 Rspress 站点集成 Vercel Analytics.
+- [rspress-plugin-katex](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-katex): 支持在 markdown 中编写数学公式，并使用 [KaTeX](https://katex.org/) 渲染.
+- [rspress-plugin-live2d](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-live2d): 为你的 Rspress 站点添加看板娘，基于 [on-my-live2d](https://oml2d.com/).
+- [rspress-plugin-mermaid](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-mermaid): 为 Rspress 支持基于 [Mermaid](https://mermaid.js.org/#/) 的流程图、时序图等.
+- [rspress-plugin-reading-time](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-reading-time): 计算每一页文档的预计阅读时间，并在文档的正上方展示.
+- [rspress-plugin-supersub](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-supersub): 为 Rspress 支持 上标(`<super></super>`) 与 下标(`<sub></sub>`) 语法.
+- [rspress-plugin-toc](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-toc): 自动为你的文档页面生成内容导航。
 
 你可以在 [awesome-rspack - Rspress Plugins](https://github.com/web-infra-dev/awesome-rspack?tab=readme-ov-file#rspress-plugins) 中查看社区提供的 Rspress 插件。
 


### PR DESCRIPTION
## Summary

Update community plugins links to point to the correct repository.

## Related Issue

https://github.com/rspack-contrib/rspress-plugins

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
