### PR TITLE
refactor: use regexp to replace location.pathname instead

### DIFF
--- a/packages/theme-default/src/layout/NotFountLayout/index.tsx
+++ b/packages/theme-default/src/layout/NotFountLayout/index.tsx
@@ -7,14 +7,13 @@ export function NotFoundLayout() {
   // Consider the existing sites include the defaultLang in some links, such as '/zh/guide/quick-start'
   // We need to redirect them to '/guide/quick-start'
   // In the meanwhile, we will not show the 404 page for the user experience
-  if (
-    defaultLang &&
-    typeof window !== 'undefined' &&
-    new RegExp(`/${defaultLang}(\\/|$)`).test(location.pathname)
-  ) {
-    const redirectUrl = location.pathname.replace(`/${defaultLang}`, '');
-    window.location.replace(redirectUrl || '/');
-    return <></>;
+  if (defaultLang && typeof window !== 'undefined') {
+    const regexp = new RegExp(`/${defaultLang}(\\/|$)`);
+    if (regexp.test(location.pathname)) {
+      const redirectUrl = location.pathname.replace(regexp, '');
+      window.location.replace(redirectUrl || '/');
+      return null;
+    }
   }
 
   let root = '/';


### PR DESCRIPTION
## Summary

## Related Issue

<!--- Provide link of related issues -->

Ensure url parts like `/${defaultLang}-xyz` won't be replaced unexpectedly

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
