### PR TITLE
feat: support async entry

### DIFF
--- a/.changeset/vast-words-enter.md
+++ b/.changeset/vast-words-enter.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+feat: support async entry

--- a/packages/core/src/node/ssg/renderPages.ts
+++ b/packages/core/src/node/ssg/renderPages.ts
@@ -52,7 +52,7 @@ export async function renderPages(
     const { default: ssrExports } = await import(
       pathToFileURL(ssrBundlePath).toString()
     );
-    ({ render } = ssrExports as SSRBundleExports);
+    render = await ssrExports.render;
   } catch (e) {
     if (e instanceof Error) {
       logger.error(


### PR DESCRIPTION
## Summary
MF will replace the original entry with async entry like below: 

```js
// original entry - ssrEntry.js
export {reder,routes};

// after access mf - bootstrap.js
const entry = import('ssrEntry.js');
const render = entry.then({render}=> (render));
const routes = entry.then({routes}=> (routes));

export {render, router}
```

And the ssrExport.render will be Promise.resolve(render), so need to add `await`

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
