### PR TITLE
refactor(virtual-module): migrate rspress plugin.addRuntimeModules to rsbuild-plugin-virtual-module

### DIFF
--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -31,7 +31,10 @@ import {
 import { hintThemeBreakingChange } from './logger/hint';
 import type { RouteService } from './route/RouteService';
 import { initRouteService } from './route/init';
-import { rsbuildPluginDocVM } from './runtimeModule';
+import {
+  getVirtualModulesFromPlugins,
+  rsbuildPluginDocVM,
+} from './runtimeModule';
 import { globalStylesVMPlugin } from './runtimeModule/globalStyles';
 import { globalUIComponentsVMPlugin } from './runtimeModule/globalUIComponents';
 import { i18nVMPlugin } from './runtimeModule/i18n';
@@ -141,6 +144,10 @@ async function createInternalBuildConfig(
            * Generate route list for client and server runtime
            */
           ...routeListVMPlugin(context),
+          /**
+           *  Get virtual modules from plugins
+           */
+          ...(await getVirtualModulesFromPlugins(pluginDriver)),
         },
       }),
       ...(enableSSG

--- a/packages/shared/src/types/Plugin.ts
+++ b/packages/shared/src/types/Plugin.ts
@@ -73,6 +73,7 @@ export interface RspressPlugin {
   ) => AdditionalPage[] | Promise<AdditionalPage[]>;
   /**
    * Add runtime modules
+   * @deprecated use [rsbuild-plugin-virtual-module](https://github.com/rspack-contrib/rsbuild-plugin-virtual-module) instead.
    */
   addRuntimeModules?: (
     config: UserConfig,


### PR DESCRIPTION
## Summary

refactor(virtual-module): migrate rspress plugin.addRuntimeModules to rsbuild-plugin-virtual-module

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
