### PR TITLE
fix: incorrect types for `shiki-transformers` entry

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,7 @@
       "default": "./theme.ts"
     },
     "./shiki-transformers": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/shiki-transformers.d.ts",
       "default": "./dist/shiki-transformers.js"
     },
     "./runtime": {


### PR DESCRIPTION
## Summary

incorrect types for `shiki-transformers` entry

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
