### PR TITLE
fix(lazyCompilation): use `{ entries: false }` for better DX

### DIFF
--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -173,7 +173,13 @@ async function createInternalBuildConfig(
       },
     },
     dev: {
-      lazyCompilation: process.env.RSPRESS_LAZY_COMPILATION !== 'false', // This is an escape hatch for playwright test, playwright does not support lazyCompilation
+      // This is an escape hatch for playwright test, playwright does not support lazyCompilation
+      lazyCompilation:
+        process.env.RSPRESS_LAZY_COMPILATION === 'false'
+          ? false
+          : {
+              entries: false,
+            },
       progressBar: false,
       // Serve static files
       setupMiddlewares: [

--- a/packages/document/rspress.config.ts
+++ b/packages/document/rspress.config.ts
@@ -45,9 +45,6 @@ export default defineConfig({
     pluginLlms(),
   ],
   builderConfig: {
-    dev: {
-      lazyCompilation: true,
-    },
     plugins: [
       pluginSass(),
       pluginGoogleAnalytics({ id: 'G-66B2Z6KG0J' }),


### PR DESCRIPTION
## Summary

Rspress actually has only one entry, so there is no need for lazy loading. It is the necessary path for rendering.

Currently, we have adopted lazyLoading, which will only load CSS when the developer first opens the page, resulting in a poor experience (large CLS).

This PR may lead to degradation in benchmark data, but these are necessary.

### before

<img width="828" alt="image" src="https://github.com/user-attachments/assets/041bd543-99f0-40ad-a978-fc4bda77c68a" />

### after

This result is actually faster than before because some work has already been done during the time the user opens the browser.

<img width="690" alt="image" src="https://github.com/user-attachments/assets/51ef33d5-9288-4779-9b98-f54896c27f4c" />


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
