### PR TITLE
refactor: frontmatter.head should be rendered by @unhead/react

### DIFF
--- a/e2e/fixtures/custom-headers/doc/index.mdx
+++ b/e2e/fixtures/custom-headers/doc/index.mdx
@@ -6,6 +6,9 @@ head:
   - - meta
     - name: custom-meta-2
       content: custom-meta-content-2
+  - - meta
+    - http-equiv: refresh
+      content: 300
 ---
 
 # Hello world

--- a/e2e/fixtures/custom-headers/index.test.ts
+++ b/e2e/fixtures/custom-headers/index.test.ts
@@ -1,11 +1,6 @@
 import path from 'node:path';
 import { expect, test } from '@playwright/test';
-import {
-  getPort,
-  killProcess,
-  runBuildCommand,
-  runPreviewCommand,
-} from '../../utils/runCommands';
+import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 
 test.describe('custom headers', async () => {
   let appPort;
@@ -13,8 +8,7 @@ test.describe('custom headers', async () => {
   test.beforeAll(async () => {
     const appDir = __dirname;
     appPort = await getPort();
-    await runBuildCommand(appDir);
-    app = await runPreviewCommand(appDir, appPort);
+    app = await runDevCommand(appDir, appPort);
   });
 
   test.afterAll(async () => {
@@ -86,6 +80,12 @@ test.describe('custom headers', async () => {
     );
     expect(customMetaContent2).toEqual('custom-meta-content-2');
 
+    const customHttpEquiv = await page.$eval(
+      'meta[http-equiv="refresh"]',
+      customMeta => customMeta.getAttribute('content'),
+    );
+    expect(customHttpEquiv).toEqual('300');
+
     const htmlContent = await page.content();
     expect(htmlContent).toContain(
       '<meta name="custom-meta" content="custom-meta-content">',
@@ -93,5 +93,6 @@ test.describe('custom headers', async () => {
     expect(htmlContent).toContain(
       '<meta name="custom-meta-2" content="custom-meta-content-2">',
     );
+    expect(htmlContent).toContain('<meta http-equiv="refresh" content="300">');
   });
 });

--- a/e2e/fixtures/custom-headers/index.test.ts
+++ b/e2e/fixtures/custom-headers/index.test.ts
@@ -1,6 +1,11 @@
 import path from 'node:path';
 import { expect, test } from '@playwright/test';
-import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
+import {
+  getPort,
+  killProcess,
+  runBuildCommand,
+  runPreviewCommand,
+} from '../../utils/runCommands';
 
 test.describe('custom headers', async () => {
   let appPort;
@@ -8,7 +13,8 @@ test.describe('custom headers', async () => {
   test.beforeAll(async () => {
     const appDir = __dirname;
     appPort = await getPort();
-    app = await runDevCommand(appDir, appPort);
+    await runBuildCommand(appDir);
+    app = await runPreviewCommand(appDir, appPort);
   });
 
   test.afterAll(async () => {

--- a/packages/core/src/node/ssg/renderHead.ts
+++ b/packages/core/src/node/ssg/renderHead.ts
@@ -1,19 +1,4 @@
-import fs from 'node:fs/promises';
 import type { RouteMeta, UserConfig } from '@rspress/shared';
-import { loadFrontMatter } from '@rspress/shared/node-utils';
-
-export async function renderFrontmatterHead(route: unknown): Promise<string> {
-  if (!isRouteMeta(route)) return '';
-  const content = await fs.readFile(route.absolutePath, {
-    encoding: 'utf-8',
-  });
-  const {
-    frontmatter: { head },
-  } = loadFrontMatter(content, route.absolutePath, '', true);
-  if (!head || head.length === 0) return '';
-
-  return head.map(([tag, attrs]) => `<${tag} ${renderAttrs(attrs)}>`).join('');
-}
 
 export async function renderConfigHead(
   config: UserConfig,

--- a/packages/core/src/node/ssg/renderPages.ts
+++ b/packages/core/src/node/ssg/renderPages.ts
@@ -26,7 +26,7 @@ import {
 
 import { hintSSGFailed } from '../logger/hint';
 import type { RouteService } from '../route/RouteService';
-import { renderConfigHead, renderFrontmatterHead } from './renderHead';
+import { renderConfigHead } from './renderHead';
 
 interface SSRBundleExports {
   render: (
@@ -118,10 +118,7 @@ export async function renderPages(
           )
           .replace(
             HEAD_MARKER,
-            [
-              await renderConfigHead(config, route),
-              await renderFrontmatterHead(route),
-            ].join(''),
+            [await renderConfigHead(config, route)].join(''),
           );
         const html = await transformHtmlTemplate(head, replacedHtmlTemplate);
 

--- a/packages/document/docs/en/api/config/config-frontmatter.mdx
+++ b/packages/document/docs/en/api/config/config-frontmatter.mdx
@@ -103,13 +103,6 @@ The generated head tags are as follows:
 </head>
 ```
 
-::: tip Note
-
-- `head` only works in the production build, Rspress will inject the tags into the SSG generated HTML. You can run `rspress build && rspress preview` to see the effect.
-- Make sure to correctly define the header tag names and their attribute names. For tags and attribute names that contain a hyphen (`-`), use the camelCase format. For example, `http-equiv="refresh"` should be defined as `httpEquiv: refresh`. This is because under the hood, headers are handled by React and `unhead`.
-
-:::
-
 ## hero
 
 - Type: `Object`

--- a/packages/document/docs/zh/api/config/config-frontmatter.mdx
+++ b/packages/document/docs/zh/api/config/config-frontmatter.mdx
@@ -103,13 +103,6 @@ head:
 </head>
 ```
 
-::: tip
-
-- `head` 仅在生产构建时生效，Rspress 会将标签注入到 SSG 生成的 HTML 中。你可以运行 `rspress build && rspress preview` 来查看效果。
-- 请确保为 head 标签和属性名称使用正确的格式。对于包含连字符（-）的标签或属性名，需要采用驼峰式命名法。例如，HTML 中的 `http-equiv="refresh"` 在配置中应写为 `httpEquiv: refresh`。这是因为 Rspress 底层使用 React 和 `unhead` 处理这些 headers。
-
-:::
-
 ## hero
 
 - Type: `Object`

--- a/packages/theme-default/src/layout/Layout/index.tsx
+++ b/packages/theme-default/src/layout/Layout/index.tsx
@@ -53,11 +53,6 @@ const HeadTags = memo(
     lang?: string;
   }) => {
     const { lang, frontmatter, description, title } = props;
-    useHead({
-      htmlAttrs: {
-        lang: lang || 'en',
-      },
-    });
 
     const head = frontmatter.head;
     const frontmatterTags = useMemo(() => {
@@ -66,13 +61,22 @@ const HeadTags = memo(
       });
     }, [head]);
 
-    return (
-      <Head>
-        {title ? <title>{title}</title> : null}
-        {description ? <meta name="description" content={description} /> : null}
-        {frontmatterTags ?? null}
-      </Head>
-    );
+    useHead({
+      htmlAttrs: {
+        lang: lang || 'en',
+      },
+      title: title || undefined,
+      meta: [
+        description
+          ? {
+              name: 'description',
+              content: description,
+            }
+          : undefined,
+      ],
+    });
+
+    return <Head>{frontmatterTags ?? null}</Head>;
   },
 );
 

--- a/packages/theme-default/src/layout/Layout/index.tsx
+++ b/packages/theme-default/src/layout/Layout/index.tsx
@@ -1,4 +1,5 @@
 import { Content, usePageData } from '@rspress/runtime';
+import type { FrontMatterMeta } from '@rspress/shared';
 import {
   HomeLayout as DefaultHomeLayout,
   NotFoundLayout as DefaultNotFoundLayout,
@@ -6,7 +7,8 @@ import {
 } from '@theme';
 import { useHead } from '@unhead/react';
 import { Head } from '@unhead/react';
-import type React from 'react';
+import React, { memo } from 'react';
+import { useMemo } from 'react';
 import type { NavProps } from '../../components/Nav';
 import { useSetup } from '../../logic/sideEffects';
 import { useLocaleSiteData } from '../../logic/useLocaleSiteData';
@@ -42,6 +44,37 @@ const concatTitle = (title: string, suffix?: string) => {
 
   return `${title} ${suffix}`;
 };
+
+const HeadTags = memo(
+  (props: {
+    title: string | undefined;
+    description: string | undefined;
+    frontmatter: FrontMatterMeta;
+    lang?: string;
+  }) => {
+    const { lang, frontmatter, description, title } = props;
+    useHead({
+      htmlAttrs: {
+        lang: lang || 'en',
+      },
+    });
+
+    const head = frontmatter.head;
+    const frontmatterTags = useMemo(() => {
+      return head?.map(([tagName, attrs]) => {
+        return tagName ? React.createElement(tagName, { ...attrs }) : null;
+      });
+    }, [head]);
+
+    return (
+      <Head>
+        {title ? <title>{title}</title> : null}
+        {description ? <meta name="description" content={description} /> : null}
+        {frontmatterTags ?? null}
+      </Head>
+    );
+  },
+);
 
 export function Layout(props: LayoutProps) {
   const {
@@ -154,18 +187,15 @@ export function Layout(props: LayoutProps) {
     }
   };
 
-  useHead({
-    htmlAttrs: {
-      lang: currentLang || 'en',
-    },
-  });
-
   return (
     <>
-      <Head>
-        {title ? <title>{title}</title> : null}
-        {description ? <meta name="description" content={description} /> : null}
-      </Head>
+      <HeadTags
+        lang={currentLang}
+        title={title}
+        description={description}
+        frontmatter={frontmatter}
+      />
+
       {top}
 
       {pageType !== 'blank' && uiSwitch.showNavbar && (


### PR DESCRIPTION
## Summary

refactor: frontmatter.head should be rendered by @unhead/react

1. perf: rerender of \<Head  />

before

![20250616200429_rec_](https://github.com/user-attachments/assets/684aead1-ee27-4dbc-8b5d-78acfaef64b2)

after

![20250616200530_rec_](https://github.com/user-attachments/assets/d4b91191-613e-4930-906d-e8d321214f3e)


2. `frontmatter.head` can be rendered in dev not only in build


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
