### PR TITLE
refactor(ssg): use `async-node` target with asyncChunks

### DIFF
--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -298,7 +298,9 @@ async function createInternalBuildConfig(
           .merge({ sideEffects: true });
 
         if (isServer) {
-          chain.output.filename(NODE_SSR_BUNDLE_NAME);
+          chain.output.filename(`ssg/${NODE_SSR_BUNDLE_NAME}`);
+          chain.output.chunkFilename('ssg/[name].cjs');
+          chain.target('async-node');
         }
       },
     },
@@ -337,13 +339,6 @@ async function createInternalBuildConfig(
                 alias: {
                   ...reactSSRAlias,
                   ...reactRouterDomAlias,
-                },
-              },
-              tools: {
-                rspack: {
-                  output: {
-                    asyncChunks: false, // Ensure that only one cjs bundle is generated.
-                  },
                 },
               },
               source: {


### PR DESCRIPTION
## Summary

refactor(ssg): use `async-node` target

Under rough measurement, the performance is about the same. We can view the QoS data.

1. `target: 'node'`

<img width="531" alt="image" src="https://github.com/user-attachments/assets/015510dd-a102-4f69-a3d5-9a7b465bdf98" />

2. `target: 'node'` with 'all-in-one' chunk

<img width="408" alt="image" src="https://github.com/user-attachments/assets/0d55c5e2-026b-480e-a2e7-138699754a2c" />


3. `target: 'async-node'`

<img width="605" alt="image" src="https://github.com/user-attachments/assets/267dea37-8c80-4d40-ab2f-1360061a7373" />


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
