### PR TITLE
chore: bump rsbuild-plugin-virtual-module and don't bundle it anymore

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -81,6 +81,7 @@
     "rehype-raw": "^7.0.0",
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.1",
+    "rsbuild-plugin-virtual-module": "0.3.0",
     "rspack-plugin-virtual-module": "1.0.1",
     "shiki": "^3.4.2",
     "tinyglobby": "^0.2.14",
@@ -111,7 +112,6 @@
     "remark-stringify": "^11.0.0",
     "rimraf": "^6.0.1",
     "rsbuild-plugin-publint": "^0.3.2",
-    "rsbuild-plugin-virtual-module": "0.2.0",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.2",
     "vfile": "^6.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -851,6 +851,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      rsbuild-plugin-virtual-module:
+        specifier: 0.3.0
+        version: 0.3.0(@rsbuild/core@1.3.22)
       rspack-plugin-virtual-module:
         specifier: 1.0.1
         version: 1.0.1
@@ -936,9 +939,6 @@ importers:
       rsbuild-plugin-publint:
         specifier: ^0.3.2
         version: 0.3.2(@rsbuild/core@1.3.22)
-      rsbuild-plugin-virtual-module:
-        specifier: 0.2.0
-        version: 0.2.0(@rsbuild/core@1.3.22)
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.17(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.8.2))
@@ -6124,8 +6124,8 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  rsbuild-plugin-virtual-module@0.2.0:
-    resolution: {integrity: sha512-cUmKiwHdttlg7QPBfdVEFBX0GMZIIRkqFC7bNJ7K5Yl9dT7/sRcFl39oZe8246DgEKnk7pBndH3zOzFS7FcJQA==}
+  rsbuild-plugin-virtual-module@0.3.0:
+    resolution: {integrity: sha512-uvFqAUUAdL6ofEhkccTgKARSUCx/w1CbJUe8S2z1OWZ0y0KqPm6FoUMQmPqrQ/9BgLy0WyfuK4V5CIqVJlCZvg==}
     peerDependencies:
       '@rsbuild/core': 1.x
     peerDependenciesMeta:
@@ -12342,7 +12342,7 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 1.4.0-beta.3
 
-  rsbuild-plugin-virtual-module@0.2.0(@rsbuild/core@1.3.22):
+  rsbuild-plugin-virtual-module@0.3.0(@rsbuild/core@1.3.22):
     optionalDependencies:
       '@rsbuild/core': 1.3.22
 


### PR DESCRIPTION
## Summary

bump `rsbuild-plugin-virtual-module` and don't bundle it anymore

## Related Issue

<!--- Provide link of related issues -->

https://github.com/rspack-contrib/rsbuild-plugin-virtual-module/pull/5

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
