### PR TITLE
fix(core): delete the duplicated "MDX compile error" error log and delete the "SSG rendering error" error log

### DIFF
--- a/packages/core/src/node/mdx/loader.ts
+++ b/packages/core/src/node/mdx/loader.ts
@@ -45,7 +45,9 @@ export default async function mdxLoader(
     }
   } catch (e) {
     if (e instanceof Error) {
-      logger.error(`MDX compile error: ${e.message} in ${filepath}`);
+      if (!e.message.includes('Dead link found')) {
+        logger.error(`MDX compile error: ${e.message} in ${filepath}`);
+      }
       logger.debug(e);
       callback({ message: e.message, name: `${filepath} compile error` });
     }

--- a/packages/core/src/node/ssg/renderPages.ts
+++ b/packages/core/src/node/ssg/renderPages.ts
@@ -95,9 +95,6 @@ export async function renderPages(
             ({ appHtml } = await render(routePath, head));
           } catch (e) {
             if (e instanceof Error) {
-              logger.error(
-                `Page "${picocolors.yellow(routePath)}" SSG rendering failed.\n    ${picocolors.gray(e.toString())}`,
-              );
               throw e;
             }
           }


### PR DESCRIPTION
## Summary

- Render Pages Optimization :
Removed redundant "SSG rendering failed" error log in `renderPages` since the error is already captured and logged by the outer error handling mechanism.
- MDX Loader Error Filtering :
Added error message filtering in `mdxLoader` to skip logging "Dead link found" errors, preventing duplicate error reporting between the remark plugin and loader.

## Related Issue

close: https://github.com/web-infra-dev/rspress/issues/2316

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
