### PR TITLE
fix(ssg): better format of mdx compile time error in SSG

### DIFF
--- a/packages/core/src/node/mdx/loader.ts
+++ b/packages/core/src/node/mdx/loader.ts
@@ -1,5 +1,4 @@
-import type { Rspack } from '@rsbuild/core';
-import { logger } from '@rspress/shared/logger';
+import { type Rspack, logger } from '@rsbuild/core';
 
 import { compile, compileWithCrossCompilerCache } from './processor';
 import type { MdxLoaderOptions } from './types';
@@ -45,9 +44,11 @@ export default async function mdxLoader(
     }
   } catch (e) {
     if (e instanceof Error) {
-      logger.error(`MDX compile error: ${e.message} in ${filepath}`);
       logger.debug(e);
-      callback({ message: e.message, name: `${filepath} compile error` });
+      callback({
+        message: `MDX compile error: ${e.message} in ${filepath}`,
+        name: `${filepath} compile error`,
+      });
     }
   }
 }

--- a/packages/core/src/node/mdx/processor.ts
+++ b/packages/core/src/node/mdx/processor.ts
@@ -1,7 +1,6 @@
 import path from 'node:path';
 import { createProcessor } from '@mdx-js/mdx';
 import type { Header, UserConfig } from '@rspress/shared';
-import { logger } from '@rspress/shared/logger';
 import { extractTextAndId, loadFrontMatter } from '@rspress/shared/node-utils';
 
 import type { PluginDriver } from '../PluginDriver';
@@ -106,7 +105,6 @@ MDXContent.__RSPRESS_PAGE_META["${encodeURIComponent(
     if (e instanceof Error) {
       throw e;
     }
-    logger.error(`MDX compile error: ${e} in ${filepath}`);
     throw new Error(`MDX compile error: ${e} in ${filepath}`);
   }
 }

--- a/packages/core/src/node/ssg/rsbuildPluginSSG.ts
+++ b/packages/core/src/node/ssg/rsbuildPluginSSG.ts
@@ -65,6 +65,13 @@ export const rsbuildPluginSSG = ({
             hasError = true;
             return;
           }
+
+          // If user has encountered a compile time error at the web/node output, user needs to first debug the error in this stage.
+          // we will not do ssg for better debugging
+          if (hasError) {
+            return;
+          }
+
           const distPath = environment.distPath;
           const ssgFolderPath = join(distPath, NODE_SSG_BUNDLE_FOLDER);
           const mainCjsAbsolutePath = join(ssgFolderPath, NODE_SSG_BUNDLE_NAME);
@@ -95,18 +102,14 @@ export const rsbuildPluginSSG = ({
 
           await indexHtmlEmittedInWeb;
 
-          // If user has encountered a compile time error at the web/node output, user needs to first debug the error in this stage.
-          // we will not do ssg for better debugging
-          if (!hasError) {
-            await renderPages(
-              routeService,
-              config,
-              pluginDriver,
-              mainCjsAbsolutePath,
-              htmlTemplate,
-              emitAsset,
-            );
-          }
+          await renderPages(
+            routeService,
+            config,
+            pluginDriver,
+            mainCjsAbsolutePath,
+            htmlTemplate,
+            emitAsset,
+          );
 
           if (!isDebugMode()) {
             await rm(ssgFolderPath, { recursive: true });


### PR DESCRIPTION
## Summary

If an error has already been generated during the compile-time process, we will not execute ssg rendering. 

This will cause the error stack to appear during compilation, rather than in the process of ssg.

### before

<img width="877" alt="image" src="https://github.com/user-attachments/assets/ab1d92d6-4b6f-4b94-b79d-6c476f035ad0" />


### after

<img width="877" alt="image" src="https://github.com/user-attachments/assets/1f91bcc0-395a-425b-8be8-973f941e9e74" />

## Related Issue


close https://github.com/web-infra-dev/rspress/issues/2316

close #2329 
<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
