### PR TITLE
fix(theme/dynamic-toc): remove comment for props replacing in SSG

### DIFF
--- a/packages/theme-default/src/components/Aside/processTitleElement.ts
+++ b/packages/theme-default/src/components/Aside/processTitleElement.ts
@@ -35,5 +35,14 @@ export function processTitleElement(element: Element): Element {
     anchor.replaceWith(tempContainer);
   });
 
+  // 4. remove <!-- -> elements,
+  // case: `## Title {props.title}` will generate a comment node `<!-- -->` for replace in SSG
+  const commentNodes = elementClone.childNodes;
+  commentNodes.forEach(node => {
+    if (node.nodeType === Node.COMMENT_NODE) {
+      node.remove();
+    }
+  });
+
   return elementClone;
 }


### PR DESCRIPTION
## Summary

This bug will only reappear during `build && preview` with ssg and hydration

<img width="400" alt="image" src="https://github.com/user-attachments/assets/6c6c6e61-a25f-4932-a5bd-d1038a2d58f4" />


<img width="400" alt="image" src="https://github.com/user-attachments/assets/6f0e8ef7-eb44-4816-bd3f-32006424c982" />


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
