### PR TITLE
feat(rsbuild)!: enable persistent cache by default via `performance.buildCache`

### DIFF
--- a/packages/cli/src/config/loadConfigFile.ts
+++ b/packages/cli/src/config/loadConfigFile.ts
@@ -15,7 +15,7 @@ const findConfig = (basePath: string): string | undefined => {
 
 export async function loadConfigFile(
   customConfigFile?: string,
-): Promise<UserConfig> {
+): Promise<{ config: UserConfig; configFilePath: string }> {
   const baseDir = process.cwd();
   let configFilePath = '';
   if (customConfigFile) {
@@ -29,7 +29,7 @@ export async function loadConfigFile(
   }
   if (!configFilePath) {
     logger.info(`No config file found in ${baseDir}`);
-    return {};
+    return { config: {}, configFilePath: '' };
   }
 
   const { loadConfig } = await import('@rsbuild/core');
@@ -38,7 +38,10 @@ export async function loadConfigFile(
     path: configFilePath,
   });
 
-  return content as UserConfig;
+  return {
+    config: content as UserConfig,
+    configFilePath,
+  };
 }
 
 export function resolveDocRoot(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -40,7 +40,9 @@ cli
       let devServer: Awaited<ReturnType<typeof dev>>;
       const startDevServer = async () => {
         const { port, host } = options || {};
-        const config = await loadConfigFile(options?.config);
+        const { config, configFilePath } = await loadConfigFile(
+          options?.config,
+        );
 
         config.root = resolveDocRoot(cwd, root, config.root);
 
@@ -50,6 +52,7 @@ cli
           appDirectory: cwd,
           docDirectory,
           config,
+          configFilePath,
           extraBuilderConfig: { server: { port, host } },
         });
 
@@ -104,7 +107,7 @@ cli
 cli.command('build [root]').action(async (root, options) => {
   setNodeEnv('production');
   const cwd = process.cwd();
-  const config = await loadConfigFile(options.config);
+  const { config, configFilePath } = await loadConfigFile(options.config);
 
   config.root = resolveDocRoot(cwd, root, config.root);
   const docDirectory = config.root;
@@ -113,6 +116,7 @@ cli.command('build [root]').action(async (root, options) => {
     await build({
       docDirectory,
       config,
+      configFilePath,
     });
   } catch (err) {
     logger.error(err);
@@ -133,7 +137,7 @@ cli
       setNodeEnv('production');
       const cwd = process.cwd();
       const { port, host } = options || {};
-      const config = await loadConfigFile(options?.config);
+      const { config, configFilePath } = await loadConfigFile(options?.config);
 
       config.root = resolveDocRoot(cwd, root, config.root);
 
@@ -141,6 +145,7 @@ cli
         config,
         host,
         port,
+        configFilePath,
       });
     },
   );

--- a/packages/cli/tests/config/config-basic.test.ts
+++ b/packages/cli/tests/config/config-basic.test.ts
@@ -8,7 +8,7 @@ const TEST_TITLE = 'my-title';
 describe('Should load config file', () => {
   test('Load config.cjs', async () => {
     const fixtureDir = path.join(__dirname, 'cjs');
-    const config = await loadConfigFile(
+    const { config } = await loadConfigFile(
       path.join(fixtureDir, 'rspress.config.cjs'),
     );
 
@@ -20,7 +20,7 @@ describe('Should load config file', () => {
 
   test('Load config.mjs', async () => {
     const fixtureDir = path.join(__dirname, 'esm');
-    const config = await loadConfigFile(
+    const { config } = await loadConfigFile(
       path.join(fixtureDir, 'rspress.config.mjs'),
     );
 
@@ -33,7 +33,7 @@ describe('Should load config file', () => {
 
   test('Load config.js/config.ts in cjs project', async () => {
     const fixtureDir = path.join(__dirname, 'cjs');
-    let config = await loadConfigFile(
+    const { config } = await loadConfigFile(
       path.join(fixtureDir, 'rspress.config.js'),
     );
 
@@ -42,8 +42,10 @@ describe('Should load config file', () => {
       title: TEST_TITLE,
     });
 
-    config = await loadConfigFile(path.join(fixtureDir, 'rspress.config.ts'));
-    expect(config).toMatchObject({
+    const { config: config2 } = await loadConfigFile(
+      path.join(fixtureDir, 'rspress.config.ts'),
+    );
+    expect(config2).toMatchObject({
       root: normalizePath(fixtureDir),
       title: TEST_TITLE,
     });
@@ -51,7 +53,7 @@ describe('Should load config file', () => {
 
   test('Load config.js/config.ts in esm project', async () => {
     const fixtureDir = path.join(__dirname, 'esm');
-    let config = await loadConfigFile(
+    const { config } = await loadConfigFile(
       path.join(fixtureDir, 'rspress.config.js'),
     );
 
@@ -61,7 +63,9 @@ describe('Should load config file', () => {
     };
     expect(config).toMatchObject(expectConfig);
 
-    config = await loadConfigFile(path.join(fixtureDir, 'rspress.config.ts'));
-    expect(config).toMatchObject(expectConfig);
+    const { config: config2 } = await loadConfigFile(
+      path.join(fixtureDir, 'rspress.config.ts'),
+    );
+    expect(config2).toMatchObject(expectConfig);
   });
 });

--- a/packages/core/src/node/PluginDriver.ts
+++ b/packages/core/src/node/PluginDriver.ts
@@ -20,15 +20,21 @@ type RspressPluginHookKeys =
 
 export class PluginDriver {
   #config: UserConfig;
+  #configFilePath: string;
 
   #plugins: RspressPlugin[];
 
   #isProd: boolean;
 
-  constructor(config: UserConfig, isProd: boolean) {
+  constructor(config: UserConfig, configFilePath: string, isProd: boolean) {
     this.#config = config;
+    this.#configFilePath = configFilePath;
     this.#isProd = isProd;
     this.#plugins = [];
+  }
+
+  getConfigFilePath() {
+    return this.#configFilePath;
   }
 
   // The init function is used to initialize the doc plugins and will execute before the build process.

--- a/packages/core/src/node/build.ts
+++ b/packages/core/src/node/build.ts
@@ -10,6 +10,7 @@ import { checkLanguageParity } from './utils/checkLanguageParity';
 interface BuildOptions {
   docDirectory: string;
   config: UserConfig;
+  configFilePath: string;
 }
 
 export async function bundle(
@@ -42,8 +43,8 @@ function emptyDir(path: string): Promise<void> {
 }
 
 export async function build(options: BuildOptions) {
-  const { docDirectory, config } = options;
-  const pluginDriver = new PluginDriver(config, true);
+  const { docDirectory, config, configFilePath } = options;
+  const pluginDriver = new PluginDriver(config, configFilePath, true);
   await pluginDriver.init();
   const modifiedConfig = await pluginDriver.modifyConfig();
 

--- a/packages/core/src/node/dev.ts
+++ b/packages/core/src/node/dev.ts
@@ -13,13 +13,14 @@ interface DevOptions {
   appDirectory: string;
   docDirectory: string;
   config: UserConfig;
+  configFilePath: string;
   extraBuilderConfig?: RsbuildConfig;
 }
 
 export async function dev(options: DevOptions): Promise<ServerInstance> {
-  const { docDirectory, config, extraBuilderConfig } = options;
+  const { docDirectory, config, extraBuilderConfig, configFilePath } = options;
   const isProd = false;
-  const pluginDriver = new PluginDriver(config, isProd);
+  const pluginDriver = new PluginDriver(config, configFilePath, isProd);
   await pluginDriver.init();
   const modifiedConfig = await pluginDriver.modifyConfig();
 

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -229,7 +229,9 @@ async function createInternalBuildConfig(
       },
     },
     performance: {
-      buildCache: true,
+      buildCache: {
+        buildDependencies: [pluginDriver.getConfigFilePath()],
+      },
       chunkSplit: {
         override: {
           cacheGroups: {

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -229,6 +229,7 @@ async function createInternalBuildConfig(
       },
     },
     performance: {
+      buildCache: true,
       chunkSplit: {
         override: {
           cacheGroups: {

--- a/packages/core/src/node/route/RouteService.test.ts
+++ b/packages/core/src/node/route/RouteService.test.ts
@@ -12,7 +12,7 @@ async function initRouteService(
 ) {
   const routeService = await RouteService.create({
     config,
-    pluginDriver: new PluginDriver(config, false),
+    pluginDriver: new PluginDriver(config, '', false),
     runtimeTempDir: '.rsbuild',
     scanDir: fixtureDir,
   });

--- a/packages/core/src/node/serve.ts
+++ b/packages/core/src/node/serve.ts
@@ -5,6 +5,7 @@ import { initRsbuild } from './initRsbuild';
 
 interface ServeOptions {
   config: UserConfig;
+  configFilePath: string;
   port?: number;
   host?: string;
 }
@@ -13,7 +14,7 @@ interface ServeOptions {
 export async function serve(
   options: ServeOptions,
 ): Promise<ReturnType<RsbuildInstance['preview']>> {
-  const { config, port: userPort, host: userHost } = options;
+  const { config, port: userPort, host: userHost, configFilePath } = options;
   const envPort = process.env.PORT;
   const envHost = process.env.HOST;
   const { builderConfig } = config;
@@ -30,7 +31,7 @@ export async function serve(
     },
   });
 
-  const pluginDriver = new PluginDriver(config, true);
+  const pluginDriver = new PluginDriver(config, configFilePath, true);
   await pluginDriver.init();
 
   const modifiedConfig = await pluginDriver.modifyConfig();


### PR DESCRIPTION
## Summary

feat(rsbuild)!: enable persistent cache defaultly via `performance.buildCache` push

### rspress build

<img width="751" alt="image" src="https://github.com/user-attachments/assets/e994d9fc-3d3b-48e3-be32-bd80ac9c1ef4" />

<img width="813" alt="image" src="https://github.com/user-attachments/assets/0896261f-57a1-46ac-b12a-398b8922b72a" />

### rspress dev

<img width="827" alt="image" src="https://github.com/user-attachments/assets/5289bf86-8288-4fa7-850e-7519582d1b27" />


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
