### PR TITLE
fix(plugin-typedoc): skip patch raw links

### DIFF
--- a/e2e/fixtures/plugin-typedoc/index.test.ts
+++ b/e2e/fixtures/plugin-typedoc/index.test.ts
@@ -64,10 +64,24 @@ test.describe('plugin-typedoc multi entries', async () => {
     expect(sidebarTexts.join(',')).toEqual(
       [
         '@rspress-fixture/rspress-plugin-typedoc-multi',
-        'FunctionsFunction: createMiddlewareFunction: mergeMiddlewares',
-        'ModulesModule: middleware',
+        'FunctionsFunction: createMiddlewareFunction: mergeMiddlewaresFunction: getRspressUrl',
+        'ModulesModule: middlewareModule: raw-link',
         'TypesType alias: Middleware',
       ].join(','),
     );
+  });
+
+  test('Should render raw link correctly', async ({ page }) => {
+    await page.goto(
+      `http://localhost:${appPort}/api/functions/raw_link.getRspressUrl.html`,
+      {
+        waitUntil: 'networkidle',
+      },
+    );
+    const rspressUrl = await page.$eval(
+      'a[href="https://rspress.rs"]',
+      el => el.textContent,
+    );
+    expect(rspressUrl).toBe('Rspress site');
   });
 });

--- a/e2e/fixtures/plugin-typedoc/multi/rspress.config.ts
+++ b/e2e/fixtures/plugin-typedoc/multi/rspress.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       entryPoints: [
         path.join('./src/index.ts'),
         path.join('./src/middleware.ts'),
+        path.join('./src/raw-link.ts'),
       ],
     }),
   ],

--- a/e2e/fixtures/plugin-typedoc/multi/src/raw-link.ts
+++ b/e2e/fixtures/plugin-typedoc/multi/src/raw-link.ts
@@ -1,0 +1,8 @@
+/**
+ * Get the Rspress site URL.
+ *
+ * @returns The [Rspress site](https://rspress.rs) URL.
+ */
+export function getRspressUrl() {
+  return 'https://rspress.rs';
+}

--- a/packages/plugin-typedoc/src/patch.ts
+++ b/packages/plugin-typedoc/src/patch.ts
@@ -7,14 +7,20 @@ async function patchLinks(outputDir: string) {
   // replace
   // 1. [foo](bar) -> [foo](./bar)
   // 2. [foo](./bar) -> [foo](./bar) no change
+  // 3. [foo](http(s)://...) -> [foo](http(s)://...) no change
   const normalizeLinksInFile = async (filePath: string) => {
     const content = await fs.readFile(filePath, 'utf-8');
     // 1. [foo](bar) -> [foo](./bar)
     const newContent = content.replace(
       /\[([^\]]+)\]\(([^)]+)\)/g,
       (_match, p1, p2) => {
-        // 2. [foo](./bar) -> [foo](./bar) no change
-        if (['/', '.'].includes(p2[0])) {
+        if (
+          // 2. [foo](./bar) -> [foo](./bar) no change
+          ['/', '.'].includes(p2[0]) ||
+          // 3. [foo](http(s)://...) -> [foo](http(s)://...) no change
+          p2.startsWith('http://') ||
+          p2.startsWith('https://')
+        ) {
           return `[${p1}](${p2})`;
         }
         return `[${p1}](./${p2})`;


### PR DESCRIPTION
## Summary

`@rspress/plugin-typedoc` replacing raw external links like `https://exmaple.com` with `./https://example.com`, this pull request fixes to keep no change when raw link detected.

## Related Issue

--

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
