### PR TITLE
docs: update copyright year in footer automatically

### DIFF
--- a/packages/document/rspress.config.ts
+++ b/packages/document/rspress.config.ts
@@ -91,7 +91,7 @@ export default defineConfig({
   themeConfig: {
     enableAppearanceAnimation: false,
     footer: {
-      message: '© 2024 Bytedance Inc. All Rights Reserved.',
+      message: `© ${new Date().getFullYear()} Bytedance Inc. All Rights Reserved.`,
     },
     hideNavbar: 'auto',
     socialLinks: [


### PR DESCRIPTION
## Summary

Enhancements:
- Replace the hardcoded footer year with `new Date().getFullYear()` to keep the copyright year current automatically.

## Appearance

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/92487f6e-89ed-4dc5-9158-24225120d60a) | ![after](https://github.com/user-attachments/assets/547dd7d6-e1d7-42a6-afc9-ece509ae0479) | 

## Related Issue

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
