### PR TITLE
docs: update PackageManagerTabs tips for pnpm

### DIFF
--- a/packages/document/docs/en/fragments/builtin-components.mdx
+++ b/packages/document/docs/en/fragments/builtin-components.mdx
@@ -358,7 +358,7 @@ For the `string` variant of the `command` prop, an optional `exec` prop can be u
 
 :::tip
 
-In the install command, special processing has been done for yarn and bun. If your command is `install some-packages`, the install will be automatically replaced with add in the yarn/bun tab.
+In the install command, special processing has been done for yarn, pnpm and bun. If your command is `install some-packages`, the install will be automatically replaced with add in the yarn/pnpm/bun tab.
 
 :::
 


### PR DESCRIPTION
## Summary

Documentation:
- Mention pnpm alongside yarn and bun for special install→add processing in PackageManagerTabs.

## Related Issue

Follow up #2364.
I forgot to update document.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
