### PR TITLE
refactor(theme-default): refactor mediumZoom as <ImgZoom /> in getCustomMDXComponent

### DIFF
--- a/packages/theme-default/package.json
+++ b/packages/theme-default/package.json
@@ -47,6 +47,7 @@
     "github-slugger": "^2.0.0",
     "hast-util-to-jsx-runtime": "^2.3.6",
     "lodash-es": "^4.17.21",
+    "medium-zoom": "1.1.0",
     "nprogress": "^0.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/packages/theme-default/src/layout/DocLayout/docComponents/img.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/img.tsx
@@ -1,6 +1,42 @@
 import { normalizeImagePath } from '@rspress/runtime';
+import mediumZoom from 'medium-zoom';
+import type React from 'react';
 import type { ComponentProps } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 export const Img = (props: ComponentProps<'img'>) => {
   return <img {...props} src={normalizeImagePath(props.src || '')} />;
+};
+
+export const ImgZoom = ({
+  ref: refProp,
+  ...props
+}: ComponentProps<'img'> & { ref?: React.Ref<HTMLImageElement> }) => {
+  const imgRef = useRef<HTMLImageElement>(null);
+  const combinedRef = useCallback(
+    (node: HTMLImageElement) => {
+      if (refProp) {
+        if (typeof refProp === 'function') {
+          refProp(node);
+        } else {
+          refProp.current = node;
+        }
+      }
+      imgRef.current = node;
+    },
+    [refProp],
+  );
+
+  useEffect(() => {
+    if (!imgRef.current) return;
+    const zoom = mediumZoom(imgRef.current, {
+      background: 'var(--rp-c-bg)',
+    });
+
+    return () => {
+      zoom.detach();
+    };
+  }, []);
+
+  return <img ref={combinedRef} {...props} />;
 };

--- a/packages/theme-default/src/layout/DocLayout/docComponents/index.module.scss
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/index.module.scss
@@ -63,6 +63,11 @@
   }
 }
 
+.medium-zoom-overlay,
+.medium-zoom-image--opened {
+  z-index: 999;
+}
+
 :global(.header-anchor) {
   color: var(--rp-c-brand);
 }

--- a/packages/theme-default/src/layout/DocLayout/docComponents/index.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/index.tsx
@@ -1,7 +1,7 @@
 import { A } from './a';
 import { Code } from './code';
 import { Hr } from './hr';
-import { Img } from './img';
+import { Img, ImgZoom } from './img';
 import { Li, Ol, Ul } from './list';
 import { Blockquote, P, Strong } from './paragraph';
 import { PreWithCodeButtonGroup } from './pre';
@@ -31,5 +31,6 @@ export function getCustomMDXComponent() {
     code: Code,
     pre: PreWithCodeButtonGroup,
     img: Img,
+    imgZoom: ImgZoom,
   };
 }


### PR DESCRIPTION
## Summary

refactor the `plugin-medium-zoom`  to `ImgZoom` in `getCustomMDXComponent` with React 19 Compatibility.

This PR refactors the image component implementation by:

1. Keeping the original component `Img` and add a new component `ImgZoom` to make the image zoomable.
2. Ensuring proper theme integration with CSS variables for background colors.
3. Maintaining full backward compatibility while improving component modularity

The ImgZoom component maintains all previous zoom functionality using medium-zoom library, with enhanced ref forwarding capabilities and proper cleanup logic to prevent memory leaks. Both components are properly exported and registered in the MDX component map for immediate use in documentation.

To add a click-to-zoom image in MDX, use the following:
`<ImgZoom src="./example.png" alt="An image that can be zoomed" />`

## Related Issue

close: https://github.com/web-infra-dev/rspress/issues/2325

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
