### PR TITLE
test: remove leftover `node:path` module from e2e tests

### DIFF
--- a/e2e/fixtures/auto-nav-sidebar-dir-convention/index.test.ts
+++ b/e2e/fixtures/auto-nav-sidebar-dir-convention/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getSidebar, getSidebarTexts } from '../../utils/getSideBar';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';

--- a/e2e/fixtures/auto-nav-sidebar-issue-1682/index.test.ts
+++ b/e2e/fixtures/auto-nav-sidebar-issue-1682/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getSidebarTexts } from '../../utils/getSideBar';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';

--- a/e2e/fixtures/auto-nav-sidebar-no-meta/index.test.ts
+++ b/e2e/fixtures/auto-nav-sidebar-no-meta/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getSidebarTexts } from '../../utils/getSideBar';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';

--- a/e2e/fixtures/auto-nav-sidebar/index.test.ts
+++ b/e2e/fixtures/auto-nav-sidebar/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { type ElementHandle, expect, test } from '@playwright/test';
 import { getNavbar, getSidebar } from '../../utils/getSideBar';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';

--- a/e2e/fixtures/basic/index.test.ts
+++ b/e2e/fixtures/basic/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/client-redirects/index.test.ts
+++ b/e2e/fixtures/client-redirects/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/code-block-runtime/index.test.ts
+++ b/e2e/fixtures/code-block-runtime/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/custom-headers/index.test.ts
+++ b/e2e/fixtures/custom-headers/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import {
   getPort,

--- a/e2e/fixtures/custom-home-footer/index.test.ts
+++ b/e2e/fixtures/custom-home-footer/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/custom-icon/index.test.ts
+++ b/e2e/fixtures/custom-icon/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/custom-layout-ui-switch/index.test.ts
+++ b/e2e/fixtures/custom-layout-ui-switch/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/custom-plugin/index.test.ts
+++ b/e2e/fixtures/custom-plugin/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/github-alert-mdxjs/index.test.ts
+++ b/e2e/fixtures/github-alert-mdxjs/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/heading-title/index.test.ts
+++ b/e2e/fixtures/heading-title/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/hide-nav-bar/index.test.ts
+++ b/e2e/fixtures/hide-nav-bar/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { type Page, expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/i18n/index.test.ts
+++ b/e2e/fixtures/i18n/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/icon-file-url/index.test.ts
+++ b/e2e/fixtures/icon-file-url/index.test.ts
@@ -1,4 +1,4 @@
-import { access, readFile } from 'node:fs/promises';
+import { access } from 'node:fs/promises';
 import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { runBuildCommand } from '../../utils/runCommands';

--- a/e2e/fixtures/inline-markdown/index.test.ts
+++ b/e2e/fixtures/inline-markdown/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getSidebar } from '../../utils/getSideBar';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';

--- a/e2e/fixtures/issue-1309/index.test.ts
+++ b/e2e/fixtures/issue-1309/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getNavbar, getSidebar } from '../../utils/getSideBar';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';

--- a/e2e/fixtures/markdown-link/index.test.ts
+++ b/e2e/fixtures/markdown-link/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/multi-version/index.test.ts
+++ b/e2e/fixtures/multi-version/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/nav-link-item-with-hash/index.test.ts
+++ b/e2e/fixtures/nav-link-item-with-hash/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/nav-link-items-without-suffix/index.test.ts
+++ b/e2e/fixtures/nav-link-items-without-suffix/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/nav-link-items/index.test.ts
+++ b/e2e/fixtures/nav-link-items/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/nav-link/index.test.ts
+++ b/e2e/fixtures/nav-link/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/nested-overview/index.test.ts
+++ b/e2e/fixtures/nested-overview/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/no-config-root/index.test.ts
+++ b/e2e/fixtures/no-config-root/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import {
   getPort,

--- a/e2e/fixtures/package-manager-tabs/index.test.ts
+++ b/e2e/fixtures/package-manager-tabs/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/page-type-home/index.test.ts
+++ b/e2e/fixtures/page-type-home/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/plugin-api-docgen/index.test.ts
+++ b/e2e/fixtures/plugin-api-docgen/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 import { searchInPage } from '../../utils/search';

--- a/e2e/fixtures/plugin-playground/index.test.ts
+++ b/e2e/fixtures/plugin-playground/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/plugin-preview-custom-entry/index.test.ts
+++ b/e2e/fixtures/plugin-preview-custom-entry/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/plugin-preview/index.test.ts
+++ b/e2e/fixtures/plugin-preview/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/plugin-rss/index.test.ts
+++ b/e2e/fixtures/plugin-rss/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import {
   getPort,

--- a/e2e/fixtures/plugin-shiki/index.test.ts
+++ b/e2e/fixtures/plugin-shiki/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import {
   getPort,

--- a/e2e/fixtures/production/index.test.ts
+++ b/e2e/fixtures/production/index.test.ts
@@ -1,10 +1,8 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import {
   getPort,
   killProcess,
   runBuildCommand,
-  runDevCommand,
   runPreviewCommand,
 } from '../../utils/runCommands';
 

--- a/e2e/fixtures/react-19/index.test.ts
+++ b/e2e/fixtures/react-19/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/replace-rules/index.test.ts
+++ b/e2e/fixtures/replace-rules/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/search-algolia/index.test.ts
+++ b/e2e/fixtures/search-algolia/index.test.ts
@@ -1,5 +1,4 @@
 import assert from 'node:assert';
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/search-code-blocks/index.test.ts
+++ b/e2e/fixtures/search-code-blocks/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 import { searchInPage } from '../../utils/search';

--- a/e2e/fixtures/search-i18n/index.test.ts
+++ b/e2e/fixtures/search-i18n/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 import { searchInPage } from '../../utils/search';

--- a/e2e/fixtures/ssg-fail-strict/index.test.ts
+++ b/e2e/fixtures/ssg-fail-strict/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { runBuildCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/tabs-component/index.test.ts
+++ b/e2e/fixtures/tabs-component/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/theme-css/index.test.ts
+++ b/e2e/fixtures/theme-css/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/title-number/index.test.ts
+++ b/e2e/fixtures/title-number/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/view-transition/index.test.ts
+++ b/e2e/fixtures/view-transition/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 

--- a/e2e/fixtures/with-base/index.test.ts
+++ b/e2e/fixtures/with-base/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 


### PR DESCRIPTION
## Summary

Remove leftover references to the Node-specific `node:path` module from all end-to-end test fixtures and standardize on the built-in `path` import.

Enhancements:
- Clean up test code by using the standard `path` module import

Tests:
- Drop `node:path` imports from every e2e fixture’s index.test.ts file

## Related Issue or Pull Request

The most of `node:path` was unnecessary when moved all the test files to its fixture folder at #2247.

> [!TIP]
> You can remove unused imports using [noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports/) rule in [Biome](https://biomejs.dev/).
> ```diff
>       "correctness": {
>         "useExhaustiveDependencies": "off",
> +       "noUnusedImports": "error"
>       },



## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
