### PR TITLE
fix: use `withBase` from runtime

### DIFF
--- a/packages/theme-default/src/components/HomeFeature/index.tsx
+++ b/packages/theme-default/src/components/HomeFeature/index.tsx
@@ -1,5 +1,5 @@
-import { normalizeHrefInRuntime } from '@rspress/runtime';
-import { isExternalUrl, withBase } from '@rspress/shared';
+import { normalizeHrefInRuntime, withBase } from '@rspress/runtime';
+import { isExternalUrl } from '@rspress/shared';
 import type { Feature, FrontMatterMeta } from '@rspress/shared';
 
 import { renderHtmlOrText } from '../../logic/utils';
@@ -25,7 +25,6 @@ const getGridClass = (feature: Feature): string => {
 
 export function HomeFeature({
   frontmatter,
-  routePath,
 }: {
   frontmatter: FrontMatterMeta;
   routePath: string;
@@ -41,7 +40,7 @@ export function HomeFeature({
         if (rawLink) {
           link = isExternalUrl(rawLink)
             ? rawLink
-            : normalizeHrefInRuntime(withBase(rawLink, routePath));
+            : normalizeHrefInRuntime(withBase(rawLink));
         }
 
         return (

--- a/packages/theme-default/src/components/HomeHero/index.tsx
+++ b/packages/theme-default/src/components/HomeHero/index.tsx
@@ -1,5 +1,9 @@
-import { normalizeHrefInRuntime, normalizeImagePath } from '@rspress/runtime';
-import { isExternalUrl, withBase } from '@rspress/shared';
+import {
+  normalizeHrefInRuntime,
+  normalizeImagePath,
+  withBase,
+} from '@rspress/runtime';
+import { isExternalUrl } from '@rspress/shared';
 import type { FrontMatterMeta } from '@rspress/shared';
 import { Button } from '@theme';
 
@@ -25,7 +29,6 @@ function HomeHero({
   beforeHeroActions,
   afterHeroActions,
   frontmatter,
-  routePath,
 }: HomeHeroProps) {
   const hero = frontmatter?.hero || DEFAULT_HERO;
   const hasImage = hero.image !== undefined;
@@ -77,7 +80,7 @@ function HomeHero({
               {hero.actions.map(action => {
                 const link = isExternalUrl(action.link)
                   ? action.link
-                  : normalizeHrefInRuntime(withBase(action.link, routePath));
+                  : normalizeHrefInRuntime(withBase(action.link));
                 return (
                   <div className="rp-flex rp-flex-shrink-0 rp-p-1" key={link}>
                     <Button


### PR DESCRIPTION
## Summary

This PR fixes an issue where links on the landing page don't include the the basepath (set with `base` option in config). 

`routePath` passed to `HomeHero` & `HomeFeature` components never includes the base so using `withBase` from `@rspress/shared` instead of `@rspress/runtime` will cause the base to be skipped. 

## Related Issue

n/a

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
