### PR TITLE
fix(buildCache): other configuration files besides `rspress.config.ts` should be added to persistent cache deps

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -70,7 +70,7 @@ cli
             eventName === 'unlink' ||
             (eventName === 'change' &&
               (CONFIG_FILES.includes(basename) ||
-                META_FILES.includes(path.basename(filepath))))
+                META_FILES.includes(basename)))
           ) {
             if (isRestarting) {
               return;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,7 +10,7 @@ import { loadConfigFile, resolveDocRoot } from './config/loadConfigFile';
 
 const CONFIG_FILES = ['rspress.config.ts', 'rspress.config.js'];
 
-const META_FILE = '_meta.json';
+const META_FILES = ['_meta.json', '_nav.json'];
 
 const cli = cac('rspress').version(version).help();
 
@@ -64,12 +64,13 @@ cli
           },
         );
         cliWatcher.on('all', async (eventName, filepath) => {
+          const basename = path.basename(filepath);
           if (
             eventName === 'add' ||
             eventName === 'unlink' ||
             (eventName === 'change' &&
-              (CONFIG_FILES.includes(path.basename(filepath)) ||
-                path.basename(filepath) === META_FILE))
+              (CONFIG_FILES.includes(basename) ||
+                META_FILES.includes(path.basename(filepath))))
           ) {
             if (isRestarting) {
               return;

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -235,6 +235,21 @@ async function createInternalBuildConfig(
         ? {
             buildCache: {
               buildDependencies: [pluginDriver.getConfigFilePath()],
+              cacheDigest: [
+                // other configuration files which are not included in rspress.config.ts should be added to cacheDigest
+                // 1. routeService glob
+                routeService
+                  .getRoutes()
+                  .map(i => i.absolutePath + i.routePath)
+                  .join('\n'),
+                // 2. auto-nav-sidebar _nav.json or _meta.json
+                JSON.stringify(
+                  config.themeConfig?.locales ?? {
+                    nav: config.themeConfig?.nav,
+                    sidebar: config.themeConfig?.sidebar,
+                  },
+                ),
+              ],
             },
           }
         : {}),

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -238,13 +238,13 @@ async function createInternalBuildConfig(
               cacheDigest: [
                 // other configuration files which are not included in rspress.config.ts should be added to cacheDigest
                 // 1. routeService glob
-                routeService
-                  .getRoutes()
-                  .map(i => i.absolutePath + i.routePath)
-                  .join('\n'),
+                routeService.generateRoutesCode(),
                 // 2. auto-nav-sidebar _nav.json or _meta.json
                 JSON.stringify(
-                  config.themeConfig?.locales ?? {
+                  config.themeConfig?.locales?.map(i => ({
+                    nav: i.nav,
+                    sidebar: i.sidebar,
+                  })) ?? {
                     nav: config.themeConfig?.nav,
                     sidebar: config.themeConfig?.sidebar,
                   },


### PR DESCRIPTION
## Summary

fix: other configuration except rspress.config.ts should be added to persistent cache deps

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
