### PR TITLE
feat!: expose type `RspressPlugin` from "rspress/core", "@rspress/shared" which is a private package should not be installed by users

### DIFF
--- a/packages/cli/core.ts
+++ b/packages/cli/core.ts
@@ -1,0 +1,5 @@
+export * from '@rspress/core';
+
+export type { RspressPlugin } from '@rspress/shared';
+
+export { logger } from '@rspress/shared/logger';

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,6 +20,9 @@
     },
     "./config": {
       "default": "./config.ts"
+    },
+    "./core": {
+      "default": "./core.ts"
     }
   },
   "main": "./dist/index.js",
@@ -33,7 +36,8 @@
     "dist",
     "runtime.ts",
     "theme.ts",
-    "config.ts"
+    "config.ts",
+    "core.ts"
   ],
   "scripts": {
     "build": "rslib build",

--- a/packages/plugin-shiki/package.json
+++ b/packages/plugin-shiki/package.json
@@ -29,7 +29,6 @@
     "reset": "rimraf ./**/node_modules"
   },
   "dependencies": {
-    "@rspress/shared": "workspace:*",
     "hast-util-from-html": "^1.0.2",
     "shiki": "^0.14.7",
     "unist-util-visit": "^4.1.2"
@@ -45,6 +44,9 @@
     "react": "^18.3.1",
     "typescript": "^5.5.3",
     "unified": "^10.1.2"
+  },
+  "peerDependencies": {
+    "rspress": "workspace:^1.44.0"
   },
   "engines": {
     "node": ">=14.17.6"

--- a/packages/plugin-shiki/src/shiki/pluginShiki.ts
+++ b/packages/plugin-shiki/src/shiki/pluginShiki.ts
@@ -11,7 +11,7 @@ import {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-import type { RspressPlugin } from '@rspress/shared';
+import type { RspressPlugin } from 'rspress/core';
 import type { Lang, Theme as shikiTheme } from 'shiki';
 import type { ITransformer } from './types';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1476,12 +1476,12 @@ importers:
 
   packages/plugin-shiki:
     dependencies:
-      '@rspress/shared':
-        specifier: workspace:*
-        version: link:../shared
       hast-util-from-html:
         specifier: ^1.0.2
         version: 1.0.2
+      rspress:
+        specifier: workspace:^1.44.0
+        version: link:../cli
       shiki:
         specifier: ^0.14.7
         version: 0.14.7


### PR DESCRIPTION
## Summary

port #2360 to 1.x for 1.x plugin compatibility

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
