### PR TITLE
perf(ssg): add `ssg.experimentalWorker` based on tinypool to speed up ssg process

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -91,6 +91,7 @@
     "rspack-plugin-virtual-module": "1.0.1",
     "shiki": "^3.4.2",
     "tinyglobby": "^0.2.14",
+    "tinypool": "^1.1.1",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0",
     "unist-util-visit-children": "^3.0.0"

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -26,6 +26,15 @@ export default defineConfig({
     generateEntry('./src/theme.ts'),
     {
       format: 'esm',
+      syntax: 'es2022',
+      source: {
+        entry: {
+          renderPageWorker: './src/node/ssg/renderPageWorker.ts',
+        },
+      },
+    },
+    {
+      format: 'esm',
       dts: {
         bundle: true,
       },

--- a/packages/core/src/node/build.ts
+++ b/packages/core/src/node/build.ts
@@ -48,7 +48,7 @@ export async function build(options: BuildOptions) {
   await pluginDriver.init();
   const modifiedConfig = await pluginDriver.modifyConfig();
 
-  const ssgConfig = modifiedConfig.ssg ?? true;
+  const ssgConfig = Boolean(modifiedConfig.ssg ?? true);
 
   // empty temp dir before build
   await emptyDir(TEMP_DIR);

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -234,12 +234,13 @@ async function createInternalBuildConfig(
       ...(process.env.RSPRESS_PERSISTENT_CACHE !== 'false'
         ? {
             buildCache: {
+              // 1. config file: rspress.config.ts
               buildDependencies: [pluginDriver.getConfigFilePath()],
               cacheDigest: [
-                // other configuration files which are not included in rspress.config.ts should be added to cacheDigest
-                // 1. routeService glob
+                // 2.other configuration files which are not included in rspress.config.ts should be added to cacheDigest
+                // 2.1 routeService glob
                 routeService.generateRoutesCode(),
-                // 2. auto-nav-sidebar _nav.json or _meta.json
+                // 2.2. auto-nav-sidebar _nav.json or _meta.json
                 JSON.stringify(
                   config.themeConfig?.locales?.map(i => ({
                     nav: i.nav,
@@ -249,6 +250,12 @@ async function createInternalBuildConfig(
                     sidebar: config.themeConfig?.sidebar,
                   },
                 ),
+                // TODO: remove the configuration track after rspack upgrading the import analysis of rspress.config.ts
+                JSON.stringify({
+                  base: config.base,
+                  ssg: config.ssg,
+                  pluginLength: config.plugins?.length ?? 0,
+                }),
               ],
             },
           }

--- a/packages/core/src/node/runtimeModule/runtimeConfig.ts
+++ b/packages/core/src/node/runtimeModule/runtimeConfig.ts
@@ -14,7 +14,8 @@ export const runtimeConfigVMPlugin: VirtualModulePlugin = context => {
       // TODO: base can be normalized in compile time side in an earlier stage
       const normalizedBase = normalizeSlash(base ?? '/');
       // Use named export for better tree-shaking support
-      return `export const base = ${JSON.stringify(normalizedBase)};`;
+      return `export const base = ${JSON.stringify(normalizedBase)};
+export const ssg = ${JSON.stringify(config.ssg ?? true)};`;
     },
   };
 };

--- a/packages/core/src/node/runtimeModule/siteData/index.ts
+++ b/packages/core/src/node/runtimeModule/siteData/index.ts
@@ -116,7 +116,6 @@ export async function siteDataVMPlugin(context: FactoryContext) {
     locales: userConfig?.locales || userConfig.themeConfig?.locales || [],
     logo: userConfig?.logo || '',
     logoText: userConfig?.logoText || '',
-    ssg: Boolean(userConfig?.ssg ?? true),
     multiVersion: {
       default: userConfig?.multiVersion?.default || '',
       versions: userConfig?.multiVersion?.versions || [],

--- a/packages/core/src/node/ssg/renderHtmlTemplate.ts
+++ b/packages/core/src/node/ssg/renderHtmlTemplate.ts
@@ -8,13 +8,13 @@ import {
 } from '../constants';
 
 async function renderConfigHead(
-  config: UserConfig,
+  head: UserConfig['head'],
   route: RouteMeta,
 ): Promise<string> {
   if (!isRouteMeta(route)) return '';
-  if (!config.head || config.head.length === 0) return '';
+  if (!head || head.length === 0) return '';
 
-  return config.head
+  return head
     .map(head => {
       if (typeof head === 'string') return head;
       if (typeof head === 'function') {
@@ -30,7 +30,7 @@ async function renderConfigHead(
 
 export async function renderHtmlTemplate(
   htmlTemplate: string,
-  config: UserConfig,
+  head: UserConfig['head'],
   route: RouteMeta,
   appHtml: string = '',
 ) {
@@ -42,7 +42,7 @@ export async function renderHtmlTemplate(
       META_GENERATOR,
       () => `<meta name="generator" content="Rspress v${RSPRESS_VERSION}">`,
     )
-    .replace(HEAD_MARKER, [await renderConfigHead(config, route)].join(''));
+    .replace(HEAD_MARKER, [await renderConfigHead(head, route)].join(''));
   return replacedHtmlTemplate;
 }
 

--- a/packages/core/src/node/ssg/renderPage.ts
+++ b/packages/core/src/node/ssg/renderPage.ts
@@ -23,7 +23,7 @@ interface SSRBundleExports {
 export async function renderPage(
   route: RouteMeta,
   htmlTemplate: string,
-  config: UserConfig,
+  configHead: UserConfig['head'],
   ssrBundlePath: string,
 ) {
   let render: SSRBundleExports['render'];
@@ -60,7 +60,7 @@ export async function renderPage(
 
   const replacedHtmlTemplate = await renderHtmlTemplate(
     htmlTemplate,
-    config,
+    configHead,
     route,
     appHtml,
   );

--- a/packages/core/src/node/ssg/renderPageWorker.ts
+++ b/packages/core/src/node/ssg/renderPageWorker.ts
@@ -1,0 +1,18 @@
+import type { RouteMeta, UserConfig } from '@rspress/shared';
+import { renderPage } from './renderPage';
+
+const exportWorkerGlueFn = ({
+  head,
+  htmlTemplate,
+  route,
+  ssrBundlePath,
+}: {
+  route: RouteMeta;
+  htmlTemplate: string;
+  head: UserConfig['head'];
+  ssrBundlePath: string;
+}) => {
+  return renderPage(route, htmlTemplate, head, ssrBundlePath);
+};
+
+export default exportWorkerGlueFn;

--- a/packages/core/src/node/ssg/renderPageWorker.ts
+++ b/packages/core/src/node/ssg/renderPageWorker.ts
@@ -1,18 +1,31 @@
+import { workerData } from 'node:worker_threads';
 import type { RouteMeta, UserConfig } from '@rspress/shared';
+import pMap from 'p-map';
 import { renderPage } from './renderPage';
 
-const exportWorkerGlueFn = ({
-  head,
-  htmlTemplate,
-  route,
-  ssrBundlePath,
-}: {
-  route: RouteMeta;
+interface Args {
+  routes: RouteMeta[];
   htmlTemplate: string;
   head: UserConfig['head'];
   ssrBundlePath: string;
-}) => {
-  return renderPage(route, htmlTemplate, head, ssrBundlePath);
+}
+
+const params = workerData?.[1]?.params as Omit<Args, 'route'>;
+if (!params) {
+  throw new Error('SSG Worker Thread workerData params missing');
+}
+
+const { htmlTemplate, head, ssrBundlePath } = params;
+
+const exportWorkerGlueFn = async ({ routes }: Args): Promise<string[]> => {
+  return pMap(
+    routes,
+    async route => {
+      const html = await renderPage(route, htmlTemplate, head, ssrBundlePath);
+      return html;
+    },
+    { concurrency: 10 },
+  );
 };
 
 export default exportWorkerGlueFn;

--- a/packages/core/src/node/ssg/renderPages.ts
+++ b/packages/core/src/node/ssg/renderPages.ts
@@ -1,12 +1,13 @@
 import type { UserConfig } from '@rspress/shared';
 import { logger } from '@rspress/shared/logger';
-import pMap from 'p-map';
+// import pMap from 'p-map';
 import picocolors from 'picocolors';
+import Tinypool from 'tinypool';
 
 import { hintSSGFailed } from '../logger/hint';
 import type { RouteService } from '../route/RouteService';
 import { renderHtmlTemplate } from './renderHtmlTemplate';
-import { renderPage } from './renderPage';
+// import { renderPage } from './renderPage';
 
 const routePath2HtmlFileName = (routePath: string) => {
   let fileName = routePath;
@@ -24,7 +25,7 @@ export async function renderPages(
   config: UserConfig,
   ssrBundlePath: string,
   htmlTemplate: string,
-  emitAsset: (assetName: string, content: string) => void,
+  emitAsset: (assetName: string, content: string | Buffer) => void,
 ) {
   logger.info('Rendering pages...');
   const startTime = Date.now();
@@ -35,28 +36,45 @@ export async function renderPages(
       // @ts-expect-error 404 page has no absolutePath attribute, so it is special
       routes.push({ routePath: '/404' });
     }
-    await pMap(
-      routes,
-      async route => {
-        const html = await renderPage(
+    // await pMap(
+    //   routes,
+    //   async route => {
+    //     const html = await renderPage(
+    //       route,
+    //       htmlTemplate,
+    //       config.head,
+    //       ssrBundlePath,
+    //     );
+
+    //     const fileName = routePath2HtmlFileName(route.routePath);
+    //     emitAsset(fileName, html);
+    //   },
+    //   // https://github.com/facebook/docusaurus/blob/45065e8d2b5831117b8d69fec1be28f5520cf105/packages/docusaurus/src/ssg/ssgEnv.ts#L11
+    //   {
+    //     concurrency: process.env.RSPRESS_SSG_CONCURRENCY
+    //       ? Number.parseInt(process.env.RSPRESS_SSG_CONCURRENCY, 10)
+    //       : // Not easy to define a reasonable option default
+    //         // Will still be better than Infinity
+    //         // See also https://github.com/sindresorhus/p-map/issues/24
+    //         32,
+    //   },
+    // );
+
+    const pool = new Tinypool({
+      filename: new URL('./renderPageWorker.js', import.meta.url).href,
+    });
+
+    await Promise.all(
+      routes.map(async route => {
+        const html = await pool.run({
           route,
           htmlTemplate,
-          config,
+          head: config.head,
           ssrBundlePath,
-        );
-
+        });
         const fileName = routePath2HtmlFileName(route.routePath);
         emitAsset(fileName, html);
-      },
-      // https://github.com/facebook/docusaurus/blob/45065e8d2b5831117b8d69fec1be28f5520cf105/packages/docusaurus/src/ssg/ssgEnv.ts#L11
-      {
-        concurrency: process.env.RSPRESS_SSG_CONCURRENCY
-          ? Number.parseInt(process.env.RSPRESS_SSG_CONCURRENCY, 10)
-          : // Not easy to define a reasonable option default
-            // Will still be better than Infinity
-            // See also https://github.com/sindresorhus/p-map/issues/24
-            32,
-      },
+      }),
     );
 
     const totalTime = Date.now() - startTime;
@@ -75,7 +93,7 @@ export async function renderCSRPages(
   routeService: RouteService,
   config: UserConfig,
   htmlTemplate: string,
-  emitAsset: (assetName: string, content: string) => void,
+  emitAsset: (assetName: string, content: string | Buffer) => void,
 ) {
   const routes = routeService.getRoutes();
   if (!routeService.isExistRoute('/404')) {
@@ -85,7 +103,12 @@ export async function renderCSRPages(
 
   await Promise.all(
     routes.map(async route => {
-      const html = await renderHtmlTemplate(htmlTemplate, config, route, '');
+      const html = await renderHtmlTemplate(
+        htmlTemplate,
+        config.head,
+        route,
+        '',
+      );
       const fileName = routePath2HtmlFileName(route.routePath);
       emitAsset(fileName, html);
     }),

--- a/packages/core/src/node/ssg/renderPages.ts
+++ b/packages/core/src/node/ssg/renderPages.ts
@@ -1,8 +1,8 @@
 import type { UserConfig } from '@rspress/shared';
 import { logger } from '@rspress/shared/logger';
+import { chunk } from 'lodash-es';
 import pMap from 'p-map';
 import picocolors from 'picocolors';
-import Tinypool from 'tinypool';
 
 import { hintSSGFailed } from '../logger/hint';
 import type { RouteService } from '../route/RouteService';
@@ -19,6 +19,19 @@ const routePath2HtmlFileName = (routePath: string) => {
 
   return fileName.replace(/^\/+/, '');
 };
+
+function getConcurrencyNum() {
+  /**
+   * https://github.com/facebook/docusaurus/blob/45065e8d2b5831117b8d69fec1be28f5520cf105/packages/docusaurus/src/ssg/ssgEnv.ts#L11
+   *
+   */
+  return process.env.RSPRESS_SSG_CONCURRENCY
+    ? Number.parseInt(process.env.RSPRESS_SSG_CONCURRENCY, 10)
+    : // Not easy to define a reasonable option default
+      // Will still be better than Infinity
+      // See also https://github.com/sindresorhus/p-map/issues/24
+      32;
+}
 
 export async function renderPages(
   routeService: RouteService,
@@ -38,22 +51,39 @@ export async function renderPages(
     }
 
     if (typeof config.ssg === 'object' && config.ssg?.experimentalWorker) {
+      const Tinypool = await import('tinypool').then(m => m.default);
       const pool = new Tinypool({
         filename: new URL('./renderPageWorker.js', import.meta.url).href,
-      });
-
-      await Promise.all(
-        routes.map(async route => {
-          const html = await pool.run({
-            route,
+        // chunk tasks manually
+        concurrentTasksPerWorker: 1,
+        /**
+         * https://github.com/facebook/docusaurus/blob/0306d182407bb98f140cd5ec7481fa9608fe0297/packages/docusaurus/src/ssg/ssgExecutor.ts#L123
+         * @license MIT
+         */
+        maxMemoryLimitBeforeRecycle: 1_000_000_000,
+        isolateWorkers: false,
+        workerData: {
+          params: {
             htmlTemplate,
             head: config.head,
             ssrBundlePath,
-          });
-          const fileName = routePath2HtmlFileName(route.routePath);
-          emitAsset(fileName, html);
+          },
+        },
+      });
+
+      await Promise.all(
+        chunk(routes, 10).map(async routes => {
+          const htmlList = await pool.run({ routes });
+          for (let i = 0; i < routes.length; i++) {
+            const route = routes[i];
+            const html = htmlList[i];
+            const fileName = routePath2HtmlFileName(route.routePath);
+            emitAsset(fileName, html);
+          }
         }),
       );
+
+      await pool.destroy();
     } else {
       await pMap(
         routes,
@@ -68,14 +98,8 @@ export async function renderPages(
           const fileName = routePath2HtmlFileName(route.routePath);
           emitAsset(fileName, html);
         },
-        // https://github.com/facebook/docusaurus/blob/45065e8d2b5831117b8d69fec1be28f5520cf105/packages/docusaurus/src/ssg/ssgEnv.ts#L11
         {
-          concurrency: process.env.RSPRESS_SSG_CONCURRENCY
-            ? Number.parseInt(process.env.RSPRESS_SSG_CONCURRENCY, 10)
-            : // Not easy to define a reasonable option default
-              // Will still be better than Infinity
-              // See also https://github.com/sindresorhus/p-map/issues/24
-              32,
+          concurrency: getConcurrencyNum(),
         },
       );
     }

--- a/packages/core/src/node/ssg/renderPages.ts
+++ b/packages/core/src/node/ssg/renderPages.ts
@@ -1,13 +1,13 @@
 import type { UserConfig } from '@rspress/shared';
 import { logger } from '@rspress/shared/logger';
-// import pMap from 'p-map';
+import pMap from 'p-map';
 import picocolors from 'picocolors';
 import Tinypool from 'tinypool';
 
 import { hintSSGFailed } from '../logger/hint';
 import type { RouteService } from '../route/RouteService';
 import { renderHtmlTemplate } from './renderHtmlTemplate';
-// import { renderPage } from './renderPage';
+import { renderPage } from './renderPage';
 
 const routePath2HtmlFileName = (routePath: string) => {
   let fileName = routePath;
@@ -36,46 +36,49 @@ export async function renderPages(
       // @ts-expect-error 404 page has no absolutePath attribute, so it is special
       routes.push({ routePath: '/404' });
     }
-    // await pMap(
-    //   routes,
-    //   async route => {
-    //     const html = await renderPage(
-    //       route,
-    //       htmlTemplate,
-    //       config.head,
-    //       ssrBundlePath,
-    //     );
 
-    //     const fileName = routePath2HtmlFileName(route.routePath);
-    //     emitAsset(fileName, html);
-    //   },
-    //   // https://github.com/facebook/docusaurus/blob/45065e8d2b5831117b8d69fec1be28f5520cf105/packages/docusaurus/src/ssg/ssgEnv.ts#L11
-    //   {
-    //     concurrency: process.env.RSPRESS_SSG_CONCURRENCY
-    //       ? Number.parseInt(process.env.RSPRESS_SSG_CONCURRENCY, 10)
-    //       : // Not easy to define a reasonable option default
-    //         // Will still be better than Infinity
-    //         // See also https://github.com/sindresorhus/p-map/issues/24
-    //         32,
-    //   },
-    // );
+    if (typeof config.ssg === 'object' && config.ssg?.experimentalWorker) {
+      const pool = new Tinypool({
+        filename: new URL('./renderPageWorker.js', import.meta.url).href,
+      });
 
-    const pool = new Tinypool({
-      filename: new URL('./renderPageWorker.js', import.meta.url).href,
-    });
+      await Promise.all(
+        routes.map(async route => {
+          const html = await pool.run({
+            route,
+            htmlTemplate,
+            head: config.head,
+            ssrBundlePath,
+          });
+          const fileName = routePath2HtmlFileName(route.routePath);
+          emitAsset(fileName, html);
+        }),
+      );
+    } else {
+      await pMap(
+        routes,
+        async route => {
+          const html = await renderPage(
+            route,
+            htmlTemplate,
+            config.head,
+            ssrBundlePath,
+          );
 
-    await Promise.all(
-      routes.map(async route => {
-        const html = await pool.run({
-          route,
-          htmlTemplate,
-          head: config.head,
-          ssrBundlePath,
-        });
-        const fileName = routePath2HtmlFileName(route.routePath);
-        emitAsset(fileName, html);
-      }),
-    );
+          const fileName = routePath2HtmlFileName(route.routePath);
+          emitAsset(fileName, html);
+        },
+        // https://github.com/facebook/docusaurus/blob/45065e8d2b5831117b8d69fec1be28f5520cf105/packages/docusaurus/src/ssg/ssgEnv.ts#L11
+        {
+          concurrency: process.env.RSPRESS_SSG_CONCURRENCY
+            ? Number.parseInt(process.env.RSPRESS_SSG_CONCURRENCY, 10)
+            : // Not easy to define a reasonable option default
+              // Will still be better than Infinity
+              // See also https://github.com/sindresorhus/p-map/issues/24
+              32,
+        },
+      );
+    }
 
     const totalTime = Date.now() - startTime;
     logger.success(`Pages rendered in ${picocolors.yellow(totalTime)} ms.`);

--- a/packages/core/src/node/ssg/rsbuildPluginCSR.ts
+++ b/packages/core/src/node/ssg/rsbuildPluginCSR.ts
@@ -20,10 +20,10 @@ export const rsbuildPluginCSR = ({
             return;
           }
 
-          const emitAsset: (assetName: string, content: string) => void = (
+          const emitAsset = (
             assetName: string,
-            content: string,
-          ) => {
+            content: string | Buffer,
+          ): void => {
             compilation.emitAsset(
               assetName,
               new compiler.webpack.sources.RawSource(content),

--- a/packages/core/src/node/ssg/rsbuildPluginSSG.ts
+++ b/packages/core/src/node/ssg/rsbuildPluginSSG.ts
@@ -63,10 +63,10 @@ export const rsbuildPluginSSG = ({
             return;
           }
 
-          const emitAsset: (assetName: string, content: string) => void = (
+          const emitAsset = (
             assetName: string,
-            content: string,
-          ) => {
+            content: string | Buffer,
+          ): void => {
             compilation.emitAsset(
               assetName,
               new compiler.webpack.sources.RawSource(content),

--- a/packages/core/src/runtime/env.d.ts
+++ b/packages/core/src/runtime/env.d.ts
@@ -49,4 +49,5 @@ declare module 'virtual-runtime-config' {
   import type { NormalizedRuntimeConfig } from '@rspress/shared';
 
   export const base: NormalizedRuntimeConfig['base'];
+  export const ssg: NormalizedRuntimeConfig['ssg'];
 }

--- a/packages/core/src/runtime/ssrServerEntry.tsx
+++ b/packages/core/src/runtime/ssrServerEntry.tsx
@@ -12,7 +12,7 @@ import { renderToPipeableStream } from 'react-dom/server';
 import { PassThrough } from 'node:stream';
 import { text } from 'node:stream/consumers';
 import type { ReactNode } from 'react';
-import { base } from 'virtual-runtime-config';
+import { base, ssg } from 'virtual-runtime-config';
 import { App } from './App';
 import { initPageData } from './initPageData';
 
@@ -28,6 +28,9 @@ function renderToHtml(app: ReactNode): Promise<string> {
     const passThrough = new PassThrough();
     const { pipe } = renderToPipeableStream(app, {
       onError(error) {
+        if (typeof ssg === 'object' && ssg.experimentalLoose) {
+          return;
+        }
         reject(error);
       },
       onAllReady() {

--- a/packages/document/docs/en/api/config/config-basic.mdx
+++ b/packages/document/docs/en/api/config/config-basic.mdx
@@ -505,7 +505,7 @@ After enabled, you can use Worker to speed up the SSG process. It is suitable fo
 - Type: `boolean`
 - Default: `false`
 
-After enabled, some errors in the SSG process will be ignored and other pages will continue to be generated, but the SSG of some pages will be missing. It is suitable for SSG errors that are used by large document sites to bypass a small number of pages. It is not recommended to actively open them.
+After enabled, some errors in the SSG process will be ignored and other pages will continue to be generated, but the SSG of some pages will be missing. It is suitable for SSG errors that are used by large document sites to bypass a small number of pages. It is not recommended to actively enable them.
 
 ## replaceRules
 

--- a/packages/document/docs/en/api/config/config-basic.mdx
+++ b/packages/document/docs/en/api/config/config-basic.mdx
@@ -468,7 +468,7 @@ export default defineConfig({
 
 ## ssg
 
-- Type: `boolean`
+- Type: `boolean | { experimentalWorker?: boolean; experimentalLoose?: boolean; }`
 - Default: `true`
 
 Whether to enable static site generation. Rspress enable it by default to generate CSR outputs and SSG outputs.
@@ -492,6 +492,20 @@ SSG requires the source code to support SSR. If the code is not compatible to SS
 2. Set `ssg: false`, but the SSG feature will be lost.
 
 :::
+
+### experimentalWorker
+
+- Type: `boolean`
+- Default: `false`
+
+After enabled, you can use Worker to speed up the SSG process. It is suitable for large document sites and is based on [tinypool](https://github.com/tinylibs/tinypool).
+
+### experimentalLoose
+
+- Type: `boolean`
+- Default: `false`
+
+After enabled, some errors in the SSG process will be ignored and other pages will continue to be generated, but the SSG of some pages will be missing. It is suitable for SSG errors that are used by large document sites to bypass a small number of pages. It is not recommended to actively open them.
 
 ## replaceRules
 

--- a/packages/document/docs/en/api/config/config-basic.mdx
+++ b/packages/document/docs/en/api/config/config-basic.mdx
@@ -498,7 +498,7 @@ SSG requires the source code to support SSR. If the code is not compatible to SS
 - Type: `boolean`
 - Default: `false`
 
-After enabled, you can use Worker to speed up the SSG process. It is suitable for large document sites and is based on [tinypool](https://github.com/tinylibs/tinypool).
+After enabled, you can use worker to accelerate the SSG process and reduce memory usage. It is suitable for large document sites and is based on [tinypool](https://github.com/tinylibs/tinypool).
 
 ### experimentalLoose
 

--- a/packages/document/docs/zh/api/config/config-basic.mdx
+++ b/packages/document/docs/zh/api/config/config-basic.mdx
@@ -467,7 +467,7 @@ export default defineConfig({
 
 ## ssg
 
-- Type: `boolean`
+- Type: `boolean | { experimentalWorker?: boolean; experimentalLoose?: boolean; }`
 - Default: `true`
 
 是否开启静态站点生成。Rspress 默认开启该功能，生成 SSG 产物。
@@ -491,6 +491,20 @@ SSG 要求源码支持在 SSR 下编译，如果使用了不兼容 SSR 场景下
 2. 设置 `ssg` 为 `false`，但是会失去 SSG 功能。
 
 :::
+
+### experimentalWorker
+
+- Type: `boolean`
+- Default: `false`
+
+开启后可以使用 Worker 来加速 SSG 过程，适合大型文档站点，底层基于 [tinypool](https://github.com/tinylibs/tinypool)。
+
+### experimentalLoose
+
+- Type: `boolean`
+- Default: `false`
+
+开启后将忽略一些 SSG 过程中的错误，继续生成其他页面，但部分页面的 SSG 会缺失，适合用于大型文档站点绕过一小部分页面的 SSG 错误，不建议主动开启。
 
 ## replaceRules
 

--- a/packages/document/docs/zh/api/config/config-basic.mdx
+++ b/packages/document/docs/zh/api/config/config-basic.mdx
@@ -497,7 +497,7 @@ SSG 要求源码支持在 SSR 下编译，如果使用了不兼容 SSR 场景下
 - Type: `boolean`
 - Default: `false`
 
-开启后可以使用 Worker 来加速 SSG 过程，适合大型文档站点，底层基于 [tinypool](https://github.com/tinylibs/tinypool)。
+开启后可以使用 Worker 来加速 SSG 过程并降低内存占用，适合大型文档站点，底层基于 [tinypool](https://github.com/tinylibs/tinypool)。
 
 ### experimentalLoose
 

--- a/packages/document/rspress.config.ts
+++ b/packages/document/rspress.config.ts
@@ -79,9 +79,6 @@ export default defineConfig({
         },
       }),
     ],
-    output: {
-      cleanDistPath: false,
-    },
   },
   route: {
     cleanUrls: true,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -154,8 +154,17 @@ export interface UserConfig<ThemeConfig = DefaultThemeConfig> {
   search?: SearchOptions;
   /**
    * Whether to enable ssg, default is true
+   * @default true
    */
-  ssg?: boolean;
+  ssg?:
+    | boolean
+    | {
+        /**
+         * Using tinypool to perform ssg rendering in parallel can significantly reduce memory usage and build time in large document sites.
+         * @default false
+         */
+        experimentalWorker?: boolean;
+      };
   /**
    * Whether to enable medium-zoom, default is true
    */

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -164,6 +164,11 @@ export interface UserConfig<ThemeConfig = DefaultThemeConfig> {
          * @default false
          */
         experimentalWorker?: boolean;
+        /**
+         * ignore some error via Suspense
+         * @default false
+         */
+        experimentalLoose?: boolean;
       };
   /**
    * Whether to enable medium-zoom, default is true
@@ -230,7 +235,6 @@ export interface SiteData<ThemeConfig = NormalizedDefaultThemeConfig> {
   logoText: string;
   pages: BaseRuntimePageInfo[];
   search: SearchOptions;
-  ssg: boolean;
   markdown: {
     showLineNumbers: boolean;
     defaultWrapCode: boolean;
@@ -245,6 +249,7 @@ export interface SiteData<ThemeConfig = NormalizedDefaultThemeConfig> {
 // TODO: migrate more SiteData to NormalizedRuntimeConfig, and rename "SiteData" to "PageData" or "Pages"
 export interface NormalizedRuntimeConfig {
   base: string;
+  ssg: boolean | { experimentalWorker?: boolean; experimentalLoose?: boolean };
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -825,6 +825,9 @@ importers:
       tinyglobby:
         specifier: ^0.2.14
         version: 0.2.14
+      tinypool:
+        specifier: ^1.1.1
+        version: 1.1.1
       unified:
         specifier: ^11.0.5
         version: 11.0.5
@@ -6318,8 +6321,8 @@ packages:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.0.1:
-    resolution: {integrity: sha512-URZYihUbRPcGv95En+sz6MfghfIc2OJ1sv/RmhWZLouPY0/8Vo80viwPvg3dlaS9fuq7fQMEfgRRK7BBZThBEA==}
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@1.2.0:
@@ -12423,7 +12426,7 @@ snapshots:
       fdir: 6.4.4(picomatch@4.0.2)
       picomatch: 4.0.2
 
-  tinypool@1.0.1: {}
+  tinypool@1.1.1: {}
 
   tinyrainbow@1.2.0: {}
 
@@ -12741,7 +12744,7 @@ snapshots:
       std-env: 3.8.0
       tinybench: 2.9.0
       tinyexec: 0.3.1
-      tinypool: 1.0.1
+      tinypool: 1.1.1
       tinyrainbow: 1.2.0
       vite: 5.4.0(@types/node@22.10.2)(sass-embedded@1.89.2)(terser@5.31.6)
       vite-node: 2.1.9(@types/node@22.10.2)(sass-embedded@1.89.2)(terser@5.31.6)


### PR DESCRIPTION
## Summary


## ssg

- Type: `boolean | { experimentalWorker?: boolean; experimentalLoose?: boolean; }`
- Default: `true`

Whether to enable static site generation. Rspress enable it by default to generate CSR outputs and SSG outputs.

If your document site is only required to be used in CSR scenarios, you can set `ssg` to `false`, and Rspress will only generate CSR outputs.

```ts title="rspress.config.ts"
import { defineConfig } from '@rspress/core';

export default defineConfig({
  ssg: false,
});
```

### experimentalWorker

- Type: `boolean`
- Default: `false`

After enabled, you can use Worker to speed up the SSG process. It is suitable for large document sites and is based on [tinypool](https://github.com/tinylibs/tinypool).

### experimentalLoose

- Type: `boolean`
- Default: `false`

After enabled, some errors in the SSG process will be ignored and other pages will continue to be generated, but the SSG of some pages will be missing. It is suitable for SSG errors that are used by large document sites to bypass a small number of pages. It is not recommended to actively enable them.



## Related Issue

close https://github.com/web-infra-dev/rspress/issues/2272

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
