### PR TITLE
fix: use SocialLinks & SwitchAppearance components from theme

### DIFF
--- a/packages/theme-default/src/components/Nav/index.tsx
+++ b/packages/theme-default/src/components/Nav/index.tsx
@@ -1,12 +1,10 @@
 import { useLocation, usePageData, useWindowSize } from '@rspress/runtime';
 import type { NavItem } from '@rspress/shared';
-import { Search } from '@theme';
+import { Search, SocialLinks, SwitchAppearance } from '@theme';
 import { base } from 'virtual-runtime-config';
 import { useHiddenNav } from '../../logic/useHiddenNav';
 import { useNavData } from '../../logic/useNav';
 import { NavHamburger } from '../NavHamburger';
-import { SocialLinks } from '../SocialLinks';
-import { SwitchAppearance } from '../SwitchAppearance';
 import { NavBarTitle } from './NavBarTitle';
 import { NavMenuGroup } from './NavMenuGroup';
 import { NavMenuSingleItem } from './NavMenuSingleItem';

--- a/packages/theme-default/src/components/NavScreen/index.tsx
+++ b/packages/theme-default/src/components/NavScreen/index.tsx
@@ -1,6 +1,7 @@
 import { NoSSR } from '@rspress/runtime';
 import type { DefaultThemeConfig, NavItem } from '@rspress/shared';
 import type { SiteData } from '@rspress/shared';
+import { SocialLinks, SwitchAppearance } from '@theme';
 import { clearAllBodyScrollLocks, disableBodyScroll } from 'body-scroll-lock';
 import { useEffect, useRef } from 'react';
 import { base } from 'virtual-runtime-config';
@@ -10,8 +11,6 @@ import {
   useTranslationMenuData,
   useVersionMenuData,
 } from '../Nav/menuDataHooks';
-import { SocialLinks } from '../SocialLinks';
-import { SwitchAppearance } from '../SwitchAppearance';
 import { NavScreenMenuGroup } from './NavScreenMenuGroup';
 import * as styles from './index.module.scss';
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where it was impossible to override the default components in Navigation, namely `SocialLinks` & `SwitchAppearance`. By changing the imports to `from @theme` it is now possible to override those components with custom implementation that will show up in default Nav components

## Related Issue

n/a

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
