### PR TITLE
fix(theme): aside should not cover the top buttons

### DIFF
--- a/packages/theme-default/src/layout/DocLayout/index.module.scss
+++ b/packages/theme-default/src/layout/DocLayout/index.module.scss
@@ -2,7 +2,6 @@
   position: sticky;
   display: none;
   top: 0;
-  margin-top: calc(-1 * var(--rp-content-padding-y));
   padding-top: var(--rp-content-padding-y);
   overflow-x: hidden;
   overflow-y: auto;


### PR DESCRIPTION
## Summary

<img width="681" height="584" alt="image" src="https://github.com/user-attachments/assets/662a0c0a-fd6f-4750-ae07-134ab34f5713" />

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
