### PR TITLE
fix: directive node should have `name` field

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -110,6 +110,7 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "execa": "8.0.1",
+    "mdast-util-directive": "^3.1.0",
     "mdast-util-mdx-expression": "^2.0.1",
     "memfs": "^4.17.2",
     "p-map": "^7.0.3",

--- a/packages/core/src/node/mdx/remarkPlugins/containerSyntax.ts
+++ b/packages/core/src/node/mdx/remarkPlugins/containerSyntax.ts
@@ -12,7 +12,6 @@
  * So the plugin is used to solve the problem and support both syntaxes in above cases.
  */
 /// <reference types="mdast-util-mdx-expression" />
-/// <reference types="remark-directive" />
 import type {
   BlockContent,
   Literal,
@@ -22,6 +21,7 @@ import type {
   Root,
   RootContent,
 } from 'mdast';
+import type { ContainerDirective } from 'mdast-util-directive';
 import type { Plugin } from 'unified';
 
 export const DIRECTIVE_TYPES = [
@@ -72,7 +72,7 @@ const createContainer = (
   type: DirectiveType | string,
   title: string | undefined,
   children: (BlockContent | PhrasingContent)[],
-): Parent => {
+): ContainerDirective => {
   const isDetails = type === 'details';
 
   const rootHName = isDetails ? 'details' : 'div';
@@ -80,6 +80,7 @@ const createContainer = (
 
   return {
     type: 'containerDirective',
+    name: type,
     data: {
       hName: rootHName,
       hProperties: {
@@ -90,7 +91,6 @@ const createContainer = (
       {
         type: 'paragraph',
         data: {
-          // @ts-ignore
           hName: titleHName,
           hProperties: {
             class: 'rspress-directive-title',
@@ -101,7 +101,6 @@ const createContainer = (
       {
         type: 'paragraph',
         data: {
-          // @ts-ignore
           hName: 'div',
           hProperties: { class: 'rspress-directive-content' },
         },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -877,6 +877,9 @@ importers:
       execa:
         specifier: 8.0.1
         version: 8.0.1
+      mdast-util-directive:
+        specifier: ^3.1.0
+        version: 3.1.0
       mdast-util-mdx-expression:
         specifier: ^2.0.1
         version: 2.0.1


### PR DESCRIPTION
## Summary

directive node should have `name` field

https://github.com/syntax-tree/mdast-util-directive/blob/a683327fafc4e48f81caf8d09d15fef8dd42a627/index.d.ts#L51-L54

## Related Issue

<!--- Provide link of related issues -->

N/A

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
