### PR TITLE
feat(ssg): add `ssg.experimentalExcludeRoutePaths`

### DIFF
--- a/packages/core/src/node/runtimeModule/runtimeConfig.ts
+++ b/packages/core/src/node/runtimeModule/runtimeConfig.ts
@@ -14,8 +14,7 @@ export const runtimeConfigVMPlugin: VirtualModulePlugin = context => {
       // TODO: base can be normalized in compile time side in an earlier stage
       const normalizedBase = normalizeSlash(base ?? '/');
       // Use named export for better tree-shaking support
-      return `export const base = ${JSON.stringify(normalizedBase)};
-export const ssg = ${JSON.stringify(config.ssg ?? true)};`;
+      return `export const base = ${JSON.stringify(normalizedBase)};`;
     },
   };
 };

--- a/packages/core/src/node/ssg/renderPages.ts
+++ b/packages/core/src/node/ssg/renderPages.ts
@@ -1,4 +1,4 @@
-import type { UserConfig } from '@rspress/shared';
+import type { RouteMeta, UserConfig } from '@rspress/shared';
 import { logger } from '@rspress/shared/logger';
 import { chunk } from 'lodash-es';
 import pMap from 'p-map';
@@ -42,6 +42,7 @@ export async function renderPages(
 ) {
   logger.info('Rendering pages...');
   const startTime = Date.now();
+  const ssg = config.ssg || true;
 
   try {
     const routes = routeService.getRoutes();
@@ -50,7 +51,50 @@ export async function renderPages(
       routes.push({ routePath: '/404' });
     }
 
-    if (typeof config.ssg === 'object' && config.ssg?.experimentalWorker) {
+    if (
+      typeof ssg === 'object' &&
+      Array.isArray(ssg?.experimentalIgnoreRoutePaths) &&
+      ssg.experimentalIgnoreRoutePaths.length > 0
+    ) {
+      const shouldIgnoreRoutePaths: Set<string> = new Set();
+      const shouldIgnoreRoutePathsRegExp: RegExp[] = [];
+
+      for (const path of ssg.experimentalIgnoreRoutePaths) {
+        if (typeof path === 'string') {
+          shouldIgnoreRoutePaths.add(path);
+        } else if (path instanceof RegExp) {
+          shouldIgnoreRoutePathsRegExp.push(path);
+        }
+      }
+
+      const promiseList: Promise<void>[] = [];
+      const csrRoutes: RouteMeta[] = [];
+      const ssgRoutes: RouteMeta[] = [];
+      for (const route of routes) {
+        if (
+          shouldIgnoreRoutePaths.has(route.routePath) ||
+          shouldIgnoreRoutePathsRegExp.some(reg => reg.test(route.routePath))
+        ) {
+          csrRoutes.push(route);
+          promiseList.push(
+            renderCSRPage(config.head, route, htmlTemplate, emitAsset),
+          );
+        } else {
+          ssgRoutes.push(route);
+        }
+      }
+      logger.warn(
+        `Some routes are ignored in SSG and fallback to CSR via \`ssg.experimentalIgnoreRoutePaths\`: ${picocolors.yellow(
+          csrRoutes.map(r => r.routePath).join(', '),
+        )}`,
+      );
+
+      await Promise.all(promiseList);
+      routes.length = 0;
+      routes.push(...ssgRoutes);
+    }
+
+    if (typeof ssg === 'object' && ssg?.experimentalWorker) {
       const Tinypool = await import('tinypool').then(m => m.default);
       const pool = new Tinypool({
         filename: new URL('./renderPageWorker.js', import.meta.url).href,
@@ -116,6 +160,17 @@ export async function renderPages(
   }
 }
 
+async function renderCSRPage(
+  head: UserConfig['head'],
+  route: RouteMeta,
+  htmlTemplate: string,
+  emitAsset: (assetName: string, content: string | Buffer) => void,
+) {
+  const html = await renderHtmlTemplate(htmlTemplate, head, route, '');
+  const fileName = routePath2HtmlFileName(route.routePath);
+  emitAsset(fileName, html);
+}
+
 export async function renderCSRPages(
   routeService: RouteService,
   config: UserConfig,
@@ -124,20 +179,13 @@ export async function renderCSRPages(
 ) {
   const routes = routeService.getRoutes();
   if (!routeService.isExistRoute('/404')) {
-    // @ts-expect-error 404 page
+    // @ts-expect-error 404 page is special
     routes.push({ routePath: '/404' });
   }
 
   await Promise.all(
-    routes.map(async route => {
-      const html = await renderHtmlTemplate(
-        htmlTemplate,
-        config.head,
-        route,
-        '',
-      );
-      const fileName = routePath2HtmlFileName(route.routePath);
-      emitAsset(fileName, html);
+    routes.map(route => {
+      return renderCSRPage(config.head, route, htmlTemplate, emitAsset);
     }),
   );
 }

--- a/packages/core/src/node/ssg/renderPages.ts
+++ b/packages/core/src/node/ssg/renderPages.ts
@@ -53,17 +53,17 @@ export async function renderPages(
 
     if (
       typeof ssg === 'object' &&
-      Array.isArray(ssg?.experimentalIgnoreRoutePaths) &&
-      ssg.experimentalIgnoreRoutePaths.length > 0
+      Array.isArray(ssg?.experimentalExcludeRoutePaths) &&
+      ssg.experimentalExcludeRoutePaths.length > 0
     ) {
       const shouldIgnoreRoutePaths: Set<string> = new Set();
       const shouldIgnoreRoutePathsRegExp: RegExp[] = [];
 
-      for (const path of ssg.experimentalIgnoreRoutePaths) {
-        if (typeof path === 'string') {
-          shouldIgnoreRoutePaths.add(path);
-        } else if (path instanceof RegExp) {
-          shouldIgnoreRoutePathsRegExp.push(path);
+      for (const routePath of ssg.experimentalExcludeRoutePaths) {
+        if (typeof routePath === 'string') {
+          shouldIgnoreRoutePaths.add(routePath);
+        } else if (routePath instanceof RegExp) {
+          shouldIgnoreRoutePathsRegExp.push(routePath);
         }
       }
 
@@ -83,15 +83,16 @@ export async function renderPages(
           ssgRoutes.push(route);
         }
       }
-      logger.warn(
-        `Some routes are ignored in SSG and fallback to CSR via \`ssg.experimentalIgnoreRoutePaths\`: ${picocolors.yellow(
-          csrRoutes.map(r => r.routePath).join(', '),
-        )}`,
-      );
-
-      await Promise.all(promiseList);
-      routes.length = 0;
-      routes.push(...ssgRoutes);
+      if (csrRoutes.length > 0) {
+        logger.warn(
+          `Some routes are ignored in SSG and fallback to CSR via \`ssg.experimentalExcludeRoutePaths\`: ${picocolors.yellow(
+            csrRoutes.map(r => r.routePath).join(', '),
+          )}`,
+        );
+        await Promise.all(promiseList);
+        routes.length = 0;
+        routes.push(...ssgRoutes);
+      }
     }
 
     if (typeof ssg === 'object' && ssg?.experimentalWorker) {

--- a/packages/core/src/node/ssg/ssgEnv.ts
+++ b/packages/core/src/node/ssg/ssgEnv.ts
@@ -73,7 +73,6 @@ function SSGConcurrency() {
 }
 
 export {
-  SSGWorkerThreadCount,
   SSGWorkerThreadRecyclerMaxMemory,
   SSGWorkerThreadTaskSize,
   SSGConcurrency,

--- a/packages/core/src/node/ssg/ssgEnv.ts
+++ b/packages/core/src/node/ssg/ssgEnv.ts
@@ -1,0 +1,81 @@
+/**
+ * these codes are copied from
+ * @link https://github.com/facebook/docusaurus/blob/45065e8d2b5831117b8d69fec1be28f5520cf105/packages/docusaurus/src/ssg/ssgEnv.ts#L11
+ * @license MIT
+ */
+
+import os from 'node:os';
+
+function SSGWorkerThreadTaskSize() {
+  return process.env.RSPRESS_SSG_WORKER_THREAD_TASK_SIZE
+    ? Number.parseInt(process.env.RSPRESS_SSG_WORKER_THREAD_TASK_SIZE, 10)
+    : 10;
+}
+function SSGWorkerThreadRecyclerMaxMemory(): number | undefined {
+  return process.env.RSPRESS_SSG_WORKER_THREAD_RECYCLER_MAX_MEMORY
+    ? Number.parseInt(
+        process.env.RSPRESS_SSG_WORKER_THREAD_RECYCLER_MAX_MEMORY,
+        10,
+      )
+    : // 1 GB is a quite reasonable max value
+      // It should work well even for large sites
+      1_000_000_000;
+}
+
+function inferNumberOfThreads({
+  pageCount,
+  cpuCount,
+  minPagesPerCpu,
+}: {
+  pageCount: number;
+  cpuCount: number;
+  minPagesPerCpu: number;
+}) {
+  // Calculate "ideal" amount of threads based on the number of pages to render
+  const threadsByWorkload = Math.ceil(pageCount / minPagesPerCpu);
+  // Use the smallest of threadsByWorkload or cpuCount, ensuring min=1 thread
+  return Math.max(1, Math.min(threadsByWorkload, cpuCount));
+}
+
+function SSGWorkerThreadCount(): number | undefined {
+  return process.env.RSPRESS_SSG_WORKER_THREAD_COUNT
+    ? Number.parseInt(process.env.RSPRESS_SSG_WORKER_THREAD_COUNT, 10)
+    : undefined;
+}
+
+function getNumberOfThreads(pathnamesLength: number): number {
+  const workerCount = SSGWorkerThreadCount();
+  if (typeof workerCount !== 'undefined') {
+    return workerCount;
+  }
+
+  // See also https://github.com/tinylibs/tinypool/pull/108
+  const cpuCount =
+    typeof os.availableParallelism === 'function'
+      ? os.availableParallelism()
+      : os.cpus().length;
+
+  return inferNumberOfThreads({
+    pageCount: pathnamesLength,
+    cpuCount,
+    // These are "magic value" that we should refine based on user feedback
+    // Local tests show that it's not worth spawning new workers for few pages
+    minPagesPerCpu: 100,
+  });
+}
+function SSGConcurrency() {
+  return process.env.RSPRESS_SSG_CONCURRENCY
+    ? Number.parseInt(process.env.RSPRESS_SSG_CONCURRENCY, 10)
+    : // Not easy to define a reasonable option default
+      // Will still be better than Infinity
+      // See also https://github.com/sindresorhus/p-map/issues/24
+      32;
+}
+
+export {
+  SSGWorkerThreadCount,
+  SSGWorkerThreadRecyclerMaxMemory,
+  SSGWorkerThreadTaskSize,
+  SSGConcurrency,
+  getNumberOfThreads,
+};

--- a/packages/core/src/runtime/ssrServerEntry.tsx
+++ b/packages/core/src/runtime/ssrServerEntry.tsx
@@ -12,7 +12,7 @@ import { renderToPipeableStream } from 'react-dom/server';
 import { PassThrough } from 'node:stream';
 import { text } from 'node:stream/consumers';
 import type { ReactNode } from 'react';
-import { base, ssg } from 'virtual-runtime-config';
+import { base } from 'virtual-runtime-config';
 import { App } from './App';
 import { initPageData } from './initPageData';
 
@@ -28,9 +28,6 @@ function renderToHtml(app: ReactNode): Promise<string> {
     const passThrough = new PassThrough();
     const { pipe } = renderToPipeableStream(app, {
       onError(error) {
-        if (typeof ssg === 'object' && ssg.experimentalLoose) {
-          return;
-        }
         reject(error);
       },
       onAllReady() {

--- a/packages/document/docs/en/api/config/config-basic.mdx
+++ b/packages/document/docs/en/api/config/config-basic.mdx
@@ -500,12 +500,12 @@ SSG requires the source code to support SSR. If the code is not compatible to SS
 
 After enabled, you can use worker to accelerate the SSG process and reduce memory usage. It is suitable for large document sites and is based on [tinypool](https://github.com/tinylibs/tinypool).
 
-### experimentalLoose
+### experimentalIgnoreRoutePaths
 
-- Type: `boolean`
-- Default: `false`
+- Type: `(string | RegExp)[]`
+- Default: `[]`
 
-After enabled, some errors in the SSG process will be ignored and other pages will continue to be generated, but the SSG of some pages will be missing. It is suitable for SSG errors that are used by large document sites to bypass a small number of pages. It is not recommended to actively enable them.
+After enabled, some pages will not be rendered by SSG, and they will directly use html under CSR. This is suitable for SSG errors in large document sites bypassing a small number of pages. It is not recommended to enable this option actively.
 
 ## replaceRules
 

--- a/packages/document/docs/en/api/config/config-basic.mdx
+++ b/packages/document/docs/en/api/config/config-basic.mdx
@@ -500,7 +500,7 @@ SSG requires the source code to support SSR. If the code is not compatible to SS
 
 After enabled, you can use worker to accelerate the SSG process and reduce memory usage. It is suitable for large document sites and is based on [tinypool](https://github.com/tinylibs/tinypool).
 
-### experimentalIgnoreRoutePaths
+### experimentalExcludeRoutePaths
 
 - Type: `(string | RegExp)[]`
 - Default: `[]`

--- a/packages/document/docs/zh/api/config/config-basic.mdx
+++ b/packages/document/docs/zh/api/config/config-basic.mdx
@@ -499,7 +499,7 @@ SSG 要求源码支持在 SSR 下编译，如果使用了不兼容 SSR 场景下
 
 开启后可以使用 Worker 来加速 SSG 过程并降低内存占用，适合大型文档站点，底层基于 [tinypool](https://github.com/tinylibs/tinypool)。
 
-### experimentalIgnoreRoutePaths
+### experimentalExcludeRoutePaths
 
 - Type: `(string | RegExp)[]`
 - Default: `[]`

--- a/packages/document/docs/zh/api/config/config-basic.mdx
+++ b/packages/document/docs/zh/api/config/config-basic.mdx
@@ -499,12 +499,12 @@ SSG 要求源码支持在 SSR 下编译，如果使用了不兼容 SSR 场景下
 
 开启后可以使用 Worker 来加速 SSG 过程并降低内存占用，适合大型文档站点，底层基于 [tinypool](https://github.com/tinylibs/tinypool)。
 
-### experimentalLoose
+### experimentalIgnoreRoutePaths
 
-- Type: `boolean`
-- Default: `false`
+- Type: `(string | RegExp)[]`
+- Default: `[]`
 
-开启后将忽略一些 SSG 过程中的错误，继续生成其他页面，但部分页面的 SSG 会缺失，适合用于大型文档站点绕过一小部分页面的 SSG 错误，不建议主动开启。
+开启后一部分页面将不进行 SSG 渲染，直接使用 CSR 下的 html，适合用于大型文档站点绕过一小部分页面的 SSG 错误，不建议主动开启。
 
 ## replaceRules
 

--- a/packages/document/rspress.config.ts
+++ b/packages/document/rspress.config.ts
@@ -85,7 +85,7 @@ export default defineConfig({
     exclude: ['**/fragments/**'],
   },
   themeConfig: {
-    enableAppearanceAnimation: false,
+    lastUpdated: true,
     footer: {
       message: '© 2023-present ByteDance Inc.',
     },

--- a/packages/shared/src/types/defaultTheme.ts
+++ b/packages/shared/src/types/defaultTheme.ts
@@ -103,6 +103,7 @@ export interface Config {
   enableContentAnimation?: boolean;
   /**
    * Whether to enable view transition animation for the theme
+   * @default false
    */
   enableAppearanceAnimation?: boolean;
   /**

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -160,15 +160,15 @@ export interface UserConfig<ThemeConfig = DefaultThemeConfig> {
     | boolean
     | {
         /**
-         * Using tinypool to perform ssg rendering in parallel can significantly reduce memory usage and build time in large document sites.
+         * After enabled, you can use worker to accelerate the SSG process and reduce memory usage. It is suitable for large document sites and is based on [tinypool](https://github.com/tinylibs/tinypool).
          * @default false
          */
         experimentalWorker?: boolean;
         /**
-         * ignore some error via Suspense
+         * After enabled, some errors in the SSG process will be ignored and other pages will continue to be generated, but the SSG of some pages will be missing. It is suitable for SSG errors that are used by large document sites to bypass a small number of pages. It is not recommended to actively enable them.
          * @default false
          */
-        experimentalLoose?: boolean;
+        experimentalIgnoreRoutePaths?: (string | RegExp)[];
       };
   /**
    * Whether to enable medium-zoom, default is true
@@ -249,7 +249,6 @@ export interface SiteData<ThemeConfig = NormalizedDefaultThemeConfig> {
 // TODO: migrate more SiteData to NormalizedRuntimeConfig, and rename "SiteData" to "PageData" or "Pages"
 export interface NormalizedRuntimeConfig {
   base: string;
-  ssg: boolean | { experimentalWorker?: boolean; experimentalLoose?: boolean };
 }
 
 /**

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -153,7 +153,7 @@ export interface UserConfig<ThemeConfig = DefaultThemeConfig> {
    */
   search?: SearchOptions;
   /**
-   * Whether to enable ssg, default is true
+   * Whether to enable ssg
    * @default true
    */
   ssg?:
@@ -165,13 +165,14 @@ export interface UserConfig<ThemeConfig = DefaultThemeConfig> {
          */
         experimentalWorker?: boolean;
         /**
-         * After enabled, some errors in the SSG process will be ignored and other pages will continue to be generated, but the SSG of some pages will be missing. It is suitable for SSG errors that are used by large document sites to bypass a small number of pages. It is not recommended to actively enable them.
-         * @default false
+         * After enabled, some pages will not be rendered by SSG, and they will directly use html under CSR. This is suitable for SSG errors in large document sites bypassing a small number of pages. It is not recommended to enable this option actively.
+         * @default []
          */
         experimentalIgnoreRoutePaths?: (string | RegExp)[];
       };
   /**
-   * Whether to enable medium-zoom, default is true
+   * Whether to enable medium-zoom
+   * @default true
    */
   mediumZoom?:
     | boolean
@@ -366,6 +367,7 @@ export interface RouteOptions {
   exclude?: string[];
   /**
    * use links without .html files
+   * @default false
    */
   cleanUrls?: boolean;
 }
@@ -396,12 +398,14 @@ export interface MarkdownOptions {
   remarkPlugins?: PluggableList;
   rehypePlugins?: PluggableList;
   /**
-   * Whether to enable check dead links, default is false
+   * Whether to enable check dead links
+   * @default false
    */
   checkDeadLinks?: boolean;
   showLineNumbers?: boolean;
   /**
-   * Whether to wrap code by default, default is false
+   * Whether to wrap code by default
+   * @default false
    */
   defaultWrapCode?: boolean;
   /**

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -168,7 +168,7 @@ export interface UserConfig<ThemeConfig = DefaultThemeConfig> {
          * After enabled, some pages will not be rendered by SSG, and they will directly use html under CSR. This is suitable for SSG errors in large document sites bypassing a small number of pages. It is not recommended to enable this option actively.
          * @default []
          */
-        experimentalIgnoreRoutePaths?: (string | RegExp)[];
+        experimentalExcludeRoutePaths?: (string | RegExp)[];
       };
   /**
    * Whether to enable medium-zoom


### PR DESCRIPTION
## Summary

feat(ssg): add `ssg.experimentalExcludeRoutePaths`


### experimentalExcludeRoutePaths

- Type: `(string | RegExp)[]`
- Default: `[]`

After enabled, some pages will not be rendered by SSG, and they will directly use html under CSR. This is suitable for SSG errors in large document sites bypassing a small number of pages. It is not recommended to enable this option actively.
## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
