### PR TITLE
chore: remove types reference to fix tsc circular issue

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -99,7 +99,6 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.52.8",
     "@rslib/core": "0.10.6",
-    "@rspress-dev/plugin-preview": "link:../plugin-preview",
     "@rspress/config": "workspace:*",
     "@types/hast": "^3.0.4",
     "@types/html-to-text": "^9.0.4",

--- a/packages/core/src/node/runtimeModule/siteData/index.ts
+++ b/packages/core/src/node/runtimeModule/siteData/index.ts
@@ -1,5 +1,3 @@
-/// <reference types="@rspress-dev/plugin-preview" />
-
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { SEARCH_INDEX_NAME, type SiteData } from '@rspress/shared';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -844,9 +844,6 @@ importers:
       '@rslib/core':
         specifier: 0.10.6
         version: 0.10.6(@microsoft/api-extractor@7.52.8(@types/node@22.10.2))(typescript@5.8.2)
-      '@rspress-dev/plugin-preview':
-        specifier: link:../plugin-preview
-        version: link:../plugin-preview
       '@rspress/config':
         specifier: workspace:*
         version: link:../../scripts/config


### PR DESCRIPTION
## Summary

<img width="1530" height="1000" alt="image" src="https://github.com/user-attachments/assets/12db190a-ceb0-45d1-ba2c-2b0c5c55f2cf" />

remove types reference of plugin-preview to fix tsc circular issue.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
