### PR TITLE
fix(tab-list): Fix tabs scrolling when not overflowing

### DIFF
--- a/packages/theme-default/src/components/Tabs/index.module.scss
+++ b/packages/theme-default/src/components/Tabs/index.module.scss
@@ -20,7 +20,7 @@
   padding-top: 4px;
   display: flex;
   min-width: 100%;
-  overflow-x: scroll;
+  overflow: scroll hidden;
 }
 
 .tab {


### PR DESCRIPTION
## Summary

Disabled vertical scrolling on the tabs to fix a bug where they would try to scroll vertically when there's nothing to scroll

To reproduce:
- Navigate to https://rspress.rs/guide/default-theme/components#tabtabs
- Hover the mouse over one of the tab links like the blue "Tab 1"
- Scroll down with the mouse wheel
- Current behavior: nothing happens
- New behavior: page scrolls down

This bug is caused by the `margin-bottom: -1px;` on the `tab` style which causes them to overflow their container. Setting the vertical scroll on `tab-list` to `hidden` fixes it