### PR TITLE
docs: add npm icon to social links in theme config documentation

### DIFF
--- a/packages/document/docs/en/api/config/config-theme.mdx
+++ b/packages/document/docs/en/api/config/config-theme.mdx
@@ -463,6 +463,7 @@ export type SocialLinkIcon =
   | 'gitlab'
   | 'X'
   | 'bluesky'
+  | 'npm'
   | { svg: string };
 ```
 

--- a/packages/document/docs/zh/api/config/config-theme.mdx
+++ b/packages/document/docs/zh/api/config/config-theme.mdx
@@ -449,6 +449,7 @@ export type SocialLinkIcon =
   | 'gitlab'
   | 'X'
   | 'bluesky'
+  | 'npm'
   | { svg: string };
 ```
 


### PR DESCRIPTION
## Summary
Added npm icon option to the social links configuration in theme documentation.

## Related PR

https://github.com/web-infra-dev/rspress/pull/2441

<!--- Provide link of related issues -->

## Checklist
Please let me know if there are any additional documents that need to be added! 🙂

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
