### PR TITLE
chore: enable trusted publishing for npm packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     name: Release
     if: github.repository == 'web-infra-dev/rspress' && github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    environment: production
+    environment: npm
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -47,15 +47,15 @@ jobs:
           node-version: 22.x
           cache: 'pnpm'
 
-      - name: Install npm v9
-        run: npm install -g npm@9
+      # Update npm to the latest version to enable OIDC
+      - name: Update npm
+        run: |
+          npm install -g npm@latest
+          npm --version
 
       - name: Install Dependencies && Build
         run: pnpm install
 
       - name: Publish to npm
-        env:
-          NPM_TOKEN: ${{ secrets.RSPRESS_NPM_TOKEN }}
         run: |
-          npm config set "//registry.npmjs.org/:_authToken" "${NPM_TOKEN}"
           pnpm -r publish --tag ${{ github.event.inputs.npm_tag }} --publish-branch ${{ github.event.inputs.branch }}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -63,7 +63,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -115,7 +115,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/create-rspress/package.json
+++ b/packages/create-rspress/package.json
@@ -41,7 +41,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -28,7 +28,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/modern-plugin-rspress/package.json
+++ b/packages/modern-plugin-rspress/package.json
@@ -45,7 +45,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/plugin-api-docgen/package.json
+++ b/packages/plugin-api-docgen/package.json
@@ -62,7 +62,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/plugin-auto-nav-sidebar/package.json
+++ b/packages/plugin-auto-nav-sidebar/package.json
@@ -45,7 +45,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/plugin-client-redirects/package.json
+++ b/packages/plugin-client-redirects/package.json
@@ -49,7 +49,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/plugin-container-syntax/package.json
+++ b/packages/plugin-container-syntax/package.json
@@ -49,7 +49,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/plugin-last-updated/package.json
+++ b/packages/plugin-last-updated/package.json
@@ -47,7 +47,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/plugin-medium-zoom/package.json
+++ b/packages/plugin-medium-zoom/package.json
@@ -50,7 +50,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/plugin-playground/package.json
+++ b/packages/plugin-playground/package.json
@@ -71,7 +71,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/plugin-preview/package.json
+++ b/packages/plugin-preview/package.json
@@ -59,7 +59,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/plugin-rss/package.json
+++ b/packages/plugin-rss/package.json
@@ -50,7 +50,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/plugin-shiki/package.json
+++ b/packages/plugin-shiki/package.json
@@ -53,7 +53,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/plugin-typedoc/package.json
+++ b/packages/plugin-typedoc/package.json
@@ -49,7 +49,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -61,7 +61,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -60,7 +60,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/theme-default/package.json
+++ b/packages/theme-default/package.json
@@ -83,7 +83,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
## Summary

Enable OIDC publishing to make it easier and more secure to publish npm packages from CI.

## Related Links

- https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
- https://docs.npmjs.com/trusted-publishers

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
