### PR TITLE
fix: export `usePage` to replace deprecated `usePageData`

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -18,6 +18,7 @@ export { useI18n } from './hooks/useI18n';
 export { useLang } from './hooks/useLang';
 export { useLocaleSiteData } from './hooks/useLocaleSiteData';
 export { useNav } from './hooks/useNav';
+export { usePage } from './hooks/usePage';
 export { DataContext, usePageData } from './hooks/usePageData';
 export { getSidebarDataGroup, useSidebar } from './hooks/useSidebar';
 export { useSite as useSiteData } from './hooks/useSite';


### PR DESCRIPTION
## Summary

export `usePage` to replace deprecated `usePageData`

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
