### PR TITLE
feat: enable rspack native watcher by default

### DIFF
--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -332,6 +332,7 @@ async function createInternalBuildConfig(
           .end();
 
         chain.experiments({
+          // Enable native watcher by default unless RSPRESS_NATIVE_WATCHER is set to 'false'
           ...chain.toConfig().experiments,
           nativeWatcher: process.env.RSPRESS_NATIVE_WATCHER !== 'false',
         });

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -331,6 +331,11 @@ async function createInternalBuildConfig(
           })
           .end();
 
+        chain.experiments({
+          ...chain.toConfig().experiments,
+          nativeWatcher: process.env.RSPRESS_NATIVE_WATCHER !== 'false',
+        });
+
         if (chain.plugins.has(CHAIN_ID.PLUGIN.REACT_FAST_REFRESH)) {
           chain.plugin(CHAIN_ID.PLUGIN.REACT_FAST_REFRESH).tap(options => {
             options[0] ??= {};

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -333,7 +333,7 @@ async function createInternalBuildConfig(
 
         chain.experiments({
           // Enable native watcher by default unless RSPRESS_NATIVE_WATCHER is set to 'false'
-          ...chain.toConfig().experiments,
+          ...chain.get('experiments'),
           nativeWatcher: process.env.RSPRESS_NATIVE_WATCHER !== 'false',
         });
 


### PR DESCRIPTION
## Summary

Rspack native watcher pass all rspress e2e tests. We can enable rspack native watcher in rspress by default. 

User can disable native watcher by setting RSPRESS_NATIVE_WATCHER as 'false' if we found any problems.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
