### PR TITLE
test: enable e2e to persistent cache after rspack 1.4

### DIFF
--- a/e2e/utils/runCommands.ts
+++ b/e2e/utils/runCommands.ts
@@ -97,8 +97,6 @@ export async function runDevCommand(
       PORT: port.toString(),
       // This is an escape hatch for playwright test, playwright does not support lazyCompilation
       RSPRESS_LAZY_COMPILATION: 'false',
-      // FIXME: Rspack's buildDependencies should collected the dependencies of rspress.config.ts, plugins change can not trigger the cache invalidate now
-      RSPRESS_PERSISTENT_CACHE: 'false',
     },
   });
 }


### PR DESCRIPTION
## Summary

test: enable e2e to persistent cache after rspack 1.4

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
