### PR TITLE
style(theme): update primary text color for better contrast

### DIFF
--- a/packages/theme-default/src/styles/vars.css
+++ b/packages/theme-default/src/styles/vars.css
@@ -30,7 +30,7 @@
   --rp-c-divider: rgba(60, 60, 60, 0.29);
   --rp-c-divider-light: rgba(60, 60, 60, 0.1);
 
-  --rp-c-text-1: #213547;
+  --rp-c-text-1: #242424;
   --rp-c-text-2: rgba(60, 60, 60, 0.66);
   --rp-c-text-3: rgba(60, 60, 60, 0.33);
   --rp-c-text-4: rgba(60, 60, 60, 0.18);


### PR DESCRIPTION
## Summary

The previous main text color was slightly blue, so I referenced [Medium](https://medium.com/)’s text color and changed it from`#213547` to `#242424` .

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
