### PR TITLE
feat(theme): Make it possible to mark elements to be excluded when copying

### DIFF
--- a/packages/theme-default/src/layout/DocLayout/docComponents/code/CopyCodeButton.tsx
+++ b/packages/theme-default/src/layout/DocLayout/docComponents/code/CopyCodeButton.tsx
@@ -22,7 +22,10 @@ function copyCode(
   );
   let node = walk.nextNode();
   while (node) {
-    if (!node.parentElement!.classList.contains('linenumber')) {
+    if (
+      !node.parentElement!.classList.contains('linenumber') &&
+      !node.parentElement!.closest('.rp-copy-ignore')
+    ) {
       text += node.nodeValue;
     }
     node = walk.nextNode();


### PR DESCRIPTION
## Summary

To prevent the popup elements added by Twoslash from being copied along with the code, we’ve made it possible to mark elements that should be excluded during copying.

## Related Issue

#574

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
