### PR TITLE
fix(plugin-preview): preview demo should not include too much css like tailwind for css confliction

### DIFF
--- a/packages/plugin-preview/static/global-styles/entry.css
+++ b/packages/plugin-preview/static/global-styles/entry.css
@@ -1,12 +1,28 @@
-@import url(@rspress/theme-default/bundle.css);
-
 :root {
-  --rp-iframe-bg: var(--rp-code-block-bg);
+  --rp-iframe-bg: #f6f8fa;
+  --rp-iframe-nav-bg: #ffffff;
 }
+
+/* TODO: support dark mode */
+/* .dark {
+  --rp-iframe-bg: #242424;
+  --rp-iframe-nav-bg: #191d24;
+} */
 
 body {
-  background-color: var(--rp-iframe-bg);
+  background-color: var(--rp-iframe-bg) !important;
+  margin: 0px; /* copied from preflight.css */
 }
+
+/* #region copied from preflight.css */
+*,
+::before,
+::after {
+  box-sizing: border-box; /* 1 */
+  border-width: 0; /* 2 */
+  border-style: solid; /* 2 */
+}
+/* #endregion copied from preflight.css */
 
 .preview-nav {
   position: relative;
@@ -14,7 +30,7 @@ body {
   align-items: center;
   justify-content: center;
   height: 56px;
-  background-color: var(--rp-c-bg);
+  background-color: var(--rp-iframe-nav-bg) !important;
   font-weight: 600;
   font-size: 17px;
 }


### PR DESCRIPTION
## Summary

fix(plugin-preview): preview demo should not include too much css like tailwind for css confliction


backport from V2 fix

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
