### PR TITLE
fix(plugin-api-docgen): too much apiDocMap clone in pageData cause performance issue in runtime

### DIFF
--- a/packages/plugin-api-docgen/index.d.ts
+++ b/packages/plugin-api-docgen/index.d.ts
@@ -1,8 +1,0 @@
-declare module '@rspress/core' {
-  interface PageIndexInfo {
-    apiDocMap?: Record<string, string>;
-  }
-}
-
-
-export * from './dist'

--- a/packages/plugin-api-docgen/package.json
+++ b/packages/plugin-api-docgen/package.json
@@ -19,8 +19,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
-    "static",
-    "index.d.ts"
+    "static"
   ],
   "scripts": {
     "build": "rslib build",

--- a/packages/plugin-api-docgen/src/index.ts
+++ b/packages/plugin-api-docgen/src/index.ts
@@ -1,5 +1,3 @@
-/// <reference path="../index.d.ts" />
-
 import fs from 'node:fs';
 import path from 'node:path';
 import type { RspressPlugin } from '@rspress/core';
@@ -41,6 +39,12 @@ export function pluginApiDocgen(options?: PluginOptions): RspressPlugin {
         parseToolOptions,
         isProd,
       });
+      config.builderConfig = config.builderConfig || {};
+      config.builderConfig.source = config.builderConfig.source || {};
+      config.builderConfig.source.define = {
+        ...config.builderConfig.source.define,
+        RSPRESS_PLUGIN_API_DOCGEN_MAP: JSON.stringify(apiDocMap),
+      };
     },
     async modifySearchIndexData(pages) {
       // Update the search index of module doc which includes `<API moduleName="foo" />` and `<API moduleName="foo" ></API>
@@ -72,9 +76,6 @@ export function pluginApiDocgen(options?: PluginOptions): RspressPlugin {
           page.content = content;
         }),
       );
-    },
-    extendPageData(pageData) {
-      pageData.apiDocMap = { ...apiDocMap };
     },
     markdown: {
       globalComponents: [

--- a/packages/plugin-api-docgen/static/global-components/API.tsx
+++ b/packages/plugin-api-docgen/static/global-components/API.tsx
@@ -1,17 +1,19 @@
-/// <reference path="../../index.d.ts" />
-
-import { useLang, usePageData } from '@rspress/core/runtime';
+import { useLang } from '@rspress/core/runtime';
 // @ts-expect-error @theme is overridden by alias in @rspress/core
 import { getCustomMDXComponent } from '@theme';
+import GithubSlugger from 'github-slugger';
+import type { Content, Element, Root } from 'hast';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import './API.css';
-import GithubSlugger from 'github-slugger';
-import type { Content, Element, Root } from 'hast';
 // biome-ignore lint/style/useImportType: <exact>
 import React from 'react';
 import type { Plugin } from 'unified';
 import { visit } from 'unist-util-visit';
+
+declare global {
+  var RSPRESS_PLUGIN_API_DOCGEN_MAP: Record<string, string>;
+}
 
 function headingRank(node: Root | Content): number | null {
   const name =
@@ -98,12 +100,11 @@ const collectHeaderText = (node: Element): string => {
   return text;
 };
 
-export default (props: { moduleName: string }) => {
+const API = (props: { moduleName: string }) => {
   const lang = useLang();
-  const { page } = usePageData();
   const { moduleName } = props;
   // some api doc have two languages.
-  const apiDocMap = page.apiDocMap;
+  const apiDocMap = RSPRESS_PLUGIN_API_DOCGEN_MAP;
   // avoid error when no page data
   const apiDoc =
     apiDocMap?.[moduleName] || apiDocMap?.[`${moduleName}-${lang}`] || '';
@@ -122,3 +123,5 @@ export default (props: { moduleName: string }) => {
     </div>
   );
 };
+
+export default API;


### PR DESCRIPTION
## Summary

fix(plugin-api-docgen): too much apiDocMap clone in pageData cause performance issue in runtime

https://github.com/web-infra-dev/rspress/pull/2523

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
