### PR TITLE
fix(plugin): beforeBuild should be executed before initRsbuild

### DIFF
--- a/packages/core/src/node/PluginDriver.ts
+++ b/packages/core/src/node/PluginDriver.ts
@@ -21,6 +21,8 @@ export class PluginDriver {
   #config: UserConfig;
   #configFilePath: string;
 
+  #isSealed: boolean = false;
+
   #plugins: RspressPlugin[];
 
   #isProd: boolean;
@@ -92,6 +94,9 @@ export class PluginDriver {
   }
 
   async modifyConfig() {
+    if (this.#isSealed) {
+      throw new Error('Config has been sealed, cannot call beforeBuild again.');
+    }
     let config = this.#config;
 
     for (let i = 0; i < this.#plugins.length; i++) {
@@ -116,6 +121,10 @@ export class PluginDriver {
       }
     }
     this.#config = config;
+  }
+
+  sealConfig() {
+    this.#isSealed = true;
     return this.#config;
   }
 

--- a/packages/core/src/node/build.ts
+++ b/packages/core/src/node/build.ts
@@ -19,6 +19,7 @@ export async function bundle(
   enableSSG: boolean,
 ) {
   try {
+    await pluginDriver.beforeBuild(); // This is to prevent some Rspress plugins from modifying the config during beforeBuild.
     // if enableSSG, build both client and server bundle
     // else only build client bundle
     const rsbuild = await initRsbuild(
@@ -28,7 +29,6 @@ export async function bundle(
       enableSSG,
     );
 
-    await pluginDriver.beforeBuild();
     await rsbuild.build();
   } finally {
     await checkLanguageParity(config);
@@ -44,7 +44,9 @@ export async function build(options: BuildOptions) {
   const { docDirectory, config, configFilePath } = options;
   const pluginDriver = new PluginDriver(config, configFilePath, true);
   await pluginDriver.init();
-  const modifiedConfig = await pluginDriver.modifyConfig();
+  await pluginDriver.modifyConfig();
+
+  const modifiedConfig = pluginDriver.sealConfig();
 
   const ssgConfig = Boolean(modifiedConfig.ssg ?? true);
 

--- a/packages/core/src/node/build.ts
+++ b/packages/core/src/node/build.ts
@@ -19,7 +19,9 @@ export async function bundle(
   enableSSG: boolean,
 ) {
   try {
-    await pluginDriver.beforeBuild(); // This is to prevent some Rspress plugins from modifying the config during beforeBuild.
+    // beforeBuild is executed before initRsbuild
+    // This is to prevent some Rspress plugins from modifying the config during beforeBuild.
+    await pluginDriver.beforeBuild();
     // if enableSSG, build both client and server bundle
     // else only build client bundle
     const rsbuild = await initRsbuild(

--- a/packages/core/src/node/dev.ts
+++ b/packages/core/src/node/dev.ts
@@ -21,10 +21,11 @@ export async function dev(options: DevOptions): Promise<ServerInstance> {
   const isProd = false;
   const pluginDriver = new PluginDriver(config, configFilePath, isProd);
   await pluginDriver.init();
-  const modifiedConfig = await pluginDriver.modifyConfig();
+  await pluginDriver.modifyConfig();
 
+  const modifiedConfig = pluginDriver.sealConfig();
   try {
-    // empty temp dir before build
+    await pluginDriver.beforeBuild();
     const rsbuild = await initRsbuild(
       docDirectory,
       modifiedConfig,
@@ -32,7 +33,6 @@ export async function dev(options: DevOptions): Promise<ServerInstance> {
       false,
       extraBuilderConfig,
     );
-    await pluginDriver.beforeBuild();
     rsbuild.onDevCompileDone(async () => {
       await pluginDriver.afterBuild();
     });

--- a/packages/core/src/node/serve.ts
+++ b/packages/core/src/node/serve.ts
@@ -34,7 +34,8 @@ export async function serve(
   const pluginDriver = new PluginDriver(config, configFilePath, true);
   await pluginDriver.init();
 
-  const modifiedConfig = await pluginDriver.modifyConfig();
+  await pluginDriver.modifyConfig();
+  const modifiedConfig = pluginDriver.sealConfig();
 
   const rsbuild = await initRsbuild(
     config.root!,


### PR DESCRIPTION
## Summary

fix(plugin): beforeBuild should be executed before initRsbuild

This is to prevent some Rspress plugins from modifying the config during beforeBuild.


 This is actually an incorrect usage, but we need to be compatible.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
