### PR TITLE
fix: command using object fully customize don't call normalize

### DIFF
--- a/packages/theme-default/src/components/PackageManagerTabs/index.tsx
+++ b/packages/theme-default/src/components/PackageManagerTabs/index.tsx
@@ -96,14 +96,14 @@ export function PackageManagerTabs({
     additionalTabs.forEach(tab => {
       commandInfo[tab.tool] = `${tab.tool} ${command}`;
     });
+    // Normalize yarn/pnpm/bun command
+    commandInfo.yarn && (commandInfo.yarn = normalizeCommand(commandInfo.yarn));
+    commandInfo.pnpm && (commandInfo.pnpm = normalizeCommand(commandInfo.pnpm));
+    commandInfo.bun && (commandInfo.bun = normalizeCommand(commandInfo.bun));
   } else {
+    // when using { "yarn": "", "pnpm": "", "bun": "" } as command we don't normalize anything
     commandInfo = command;
   }
-
-  // Normalize yarn/pnpm/bun command
-  commandInfo.yarn && (commandInfo.yarn = normalizeCommand(commandInfo.yarn));
-  commandInfo.pnpm && (commandInfo.pnpm = normalizeCommand(commandInfo.pnpm));
-  commandInfo.bun && (commandInfo.bun = normalizeCommand(commandInfo.bun));
 
   return (
     <Tabs

--- a/packages/theme-default/src/components/PackageManagerTabs/index.tsx
+++ b/packages/theme-default/src/components/PackageManagerTabs/index.tsx
@@ -97,11 +97,11 @@ export function PackageManagerTabs({
       commandInfo[tab.tool] = `${tab.tool} ${command}`;
     });
     // Normalize yarn/pnpm/bun command
-    commandInfo.yarn && (commandInfo.yarn = normalizeCommand(commandInfo.yarn));
-    commandInfo.pnpm && (commandInfo.pnpm = normalizeCommand(commandInfo.pnpm));
-    commandInfo.bun && (commandInfo.bun = normalizeCommand(commandInfo.bun));
+    commandInfo.yarn = normalizeCommand(commandInfo.yarn);
+    commandInfo.pnpm = normalizeCommand(commandInfo.pnpm);
+    commandInfo.bun = normalizeCommand(commandInfo.bun);
   } else {
-    // when using { "yarn": "", "pnpm": "", "bun": "" } as command we don't normalize anything
+    // When using { "yarn": "", "pnpm": "", "bun": "" } as command we don't normalize anything
     commandInfo = command;
   }
 


### PR DESCRIPTION
This pull request makes a small adjustment to the logic for handling package manager commands in the `PackageManagerTabs` component. The change ensures that when the `command` prop is already an object (with keys like `"yarn"`, `"pnpm"`, `"bun"`), the commands are not normalized, preserving any intentionally empty or custom values.

* Updated the `PackageManagerTabs` component to avoid normalizing commands when the `command` prop is an object with package manager keys, ensuring custom or empty commands are left unchanged.## Summary

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
