### PR TITLE
fix(core): allow user can deploy to both `http://a.com/base/` and `http://a.com/base`

### DIFF
--- a/e2e/fixtures/with-base/doc/en/index.md
+++ b/e2e/fixtures/with-base/doc/en/index.md
@@ -1,3 +1,0 @@
-# Index
-
-[click](/guide/quick-start) to go to guide

--- a/e2e/fixtures/with-base/doc/en/index.mdx
+++ b/e2e/fixtures/with-base/doc/en/index.mdx
@@ -1,0 +1,9 @@
+# Index
+
+[click](/guide/quick-start) to go to guide
+
+import { NoSSR } from '@rspress/core/runtime';
+
+<NoSSR>
+  <div id="NoSSR">This is the index page</div>
+</NoSSR>

--- a/e2e/fixtures/with-base/doc/zh/index.md
+++ b/e2e/fixtures/with-base/doc/zh/index.md
@@ -1,3 +1,0 @@
-# 首页
-
-[点击](/guide/quick-start) 跳往指南

--- a/e2e/fixtures/with-base/doc/zh/index.mdx
+++ b/e2e/fixtures/with-base/doc/zh/index.mdx
@@ -1,0 +1,9 @@
+# 首页
+
+[点击](/guide/quick-start) 跳往指南
+
+import { NoSSR } from '@rspress/core/runtime';
+
+<NoSSR>
+  <div id="NoSSR">This is the index page</div>
+</NoSSR>

--- a/e2e/fixtures/with-base/index.test.ts
+++ b/e2e/fixtures/with-base/index.test.ts
@@ -43,4 +43,22 @@ test.describe('plugin test', async () => {
     const href = await page.evaluate(a => a?.getAttribute('href'), a);
     expect(href).toBe('/base/en/guide/install.html');
   });
+
+  test('Should render the homepage - "/base"', async ({ page }) => {
+    await page.goto(`http://localhost:${appPort}/base`, {
+      waitUntil: 'networkidle',
+    });
+    const docContent = await page.$('.rspress-doc');
+    const text = await docContent?.textContent();
+    expect(text?.includes('This is the index page')).toBeTruthy();
+  });
+
+  test('Should render the homepage - "/base/"', async ({ page }) => {
+    await page.goto(`http://localhost:${appPort}/base/`, {
+      waitUntil: 'networkidle',
+    });
+    const docContent = await page.$('.rspress-doc');
+    const text = await docContent?.textContent();
+    expect(text?.includes('This is the index page')).toBeTruthy();
+  });
 });

--- a/packages/core/src/runtime/ClientApp.tsx
+++ b/packages/core/src/runtime/ClientApp.tsx
@@ -1,8 +1,13 @@
-import { BrowserRouter, PageContext, ThemeContext } from '@rspress/runtime';
+import {
+  BrowserRouter,
+  PageContext,
+  removeTrailingSlash,
+  ThemeContext,
+  withBase,
+} from '@rspress/runtime';
 import { useThemeState } from '@theme';
 import { createHead, UnheadProvider } from '@unhead/react/client';
 import { useMemo, useState } from 'react';
-import siteData from 'virtual-site-data';
 import { App } from './App';
 import type { Page } from './initPageData';
 
@@ -30,7 +35,7 @@ export function ClientApp({
             v7_relativeSplatPath: true,
             v7_startTransition: true,
           }}
-          basename={siteData.base}
+          basename={removeTrailingSlash(withBase('/'))}
         >
           <UnheadProvider head={head}>
             <App />

--- a/packages/core/src/runtime/initPageData.ts
+++ b/packages/core/src/runtime/initPageData.ts
@@ -68,7 +68,7 @@ export async function initPageData(routePath: string): Promise<Page> {
   let version = siteData.multiVersion?.default || '';
 
   if (siteData.lang && typeof window !== 'undefined') {
-    const path = location.pathname
+    const path = window.location.pathname
       .replace(siteData.base, '')
       .split('/')
       .slice(0, 2);

--- a/packages/core/src/runtime/ssrServerEntry.tsx
+++ b/packages/core/src/runtime/ssrServerEntry.tsx
@@ -3,6 +3,7 @@ import { text } from 'node:stream/consumers';
 import {
   PageContext,
   pathnameToRouteService,
+  removeTrailingSlash,
   ThemeContext,
   withBase,
 } from '@rspress/runtime';
@@ -10,7 +11,6 @@ import { StaticRouter } from '@rspress/runtime/server';
 import { type Unhead, UnheadProvider } from '@unhead/react/server';
 import type { ReactNode } from 'react';
 import { renderToPipeableStream } from 'react-dom/server';
-import siteData from 'virtual-site-data';
 import { App } from './App';
 import { initPageData } from './initPageData';
 
@@ -46,7 +46,10 @@ export async function render(
   const appHtml = await renderToHtml(
     <ThemeContext.Provider value={{ theme: DEFAULT_THEME }}>
       <PageContext.Provider value={{ data: initialPageData }}>
-        <StaticRouter location={withBase(routePath)} basename={siteData.base}>
+        <StaticRouter
+          location={withBase(routePath)}
+          basename={removeTrailingSlash(withBase('/'))}
+        >
           <UnheadProvider value={head}>
             <App />
           </UnheadProvider>

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -32,7 +32,6 @@ export {
   isProduction,
   normalizeHrefInRuntime,
   normalizeImagePath,
-  normalizeSlash,
   removeBase,
   removeTrailingSlash,
   withBase,

--- a/packages/runtime/src/utils.ts
+++ b/packages/runtime/src/utils.ts
@@ -4,7 +4,6 @@ import {
   isExternalUrl,
   isProduction,
   normalizeHref,
-  normalizeSlash,
   removeBase as rawRemoveBase,
   withBase as rawWithBase,
   removeHash,
@@ -12,22 +11,22 @@ import {
 } from '@rspress/shared';
 import siteData from 'virtual-site-data';
 
-export function withBase(url = '/'): string {
+function withBase(url = '/'): string {
   return rawWithBase(url, siteData.base);
 }
 
-export function removeBase(url: string): string {
+function removeBase(url: string): string {
   return rawRemoveBase(url, siteData.base);
 }
 
-export function isEqualPath(a: string, b: string) {
+function isEqualPath(a: string, b: string) {
   return (
     removeBase(normalizeHref(removeHash(a), true)) ===
     removeBase(normalizeHref(removeHash(b), true))
   );
 }
 
-export function normalizeHrefInRuntime(link: string) {
+function normalizeHrefInRuntime(link: string) {
   const cleanUrls = Boolean(siteData?.route?.cleanUrls);
   return normalizeHref(link, cleanUrls);
 }
@@ -35,14 +34,14 @@ export function normalizeHrefInRuntime(link: string) {
 /**
  * we do cleanUrls in runtime side
  */
-export function cleanUrlByConfig(link: string) {
+function cleanUrlByConfig(link: string) {
   if (siteData?.route?.cleanUrls) {
     return normalizeHref(link, true);
   }
   return link;
 }
 
-export function normalizeImagePath(imagePath: string) {
+function normalizeImagePath(imagePath: string) {
   if (isAbsoluteUrl(imagePath)) {
     return imagePath;
   }
@@ -58,4 +57,14 @@ function isAbsoluteUrl(path: string) {
   return isExternalUrl(path) || isDataUrl(path) || path.startsWith('//');
 }
 
-export { addLeadingSlash, removeTrailingSlash, normalizeSlash, isProduction };
+export {
+  addLeadingSlash,
+  removeTrailingSlash,
+  isProduction,
+  normalizeImagePath,
+  cleanUrlByConfig,
+  removeBase,
+  withBase,
+  isEqualPath,
+  normalizeHrefInRuntime,
+};

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,7 +18,6 @@ export {
   MDX_OR_MD_REGEXP,
   normalizeHref,
   normalizePosixPath,
-  normalizeSlash,
   parseUrl,
   QUERY_REGEXP,
   RSPRESS_TEMP_DIR,

--- a/packages/shared/src/runtime-utils/utils.test.ts
+++ b/packages/shared/src/runtime-utils/utils.test.ts
@@ -20,11 +20,14 @@ describe('test shared utils', () => {
     expect(withBase('/guide/', '/zh/')).toBe('/zh/guide/');
     expect(withBase('/guide/', '/')).toBe('/guide/');
     expect(withBase('/guide/', '')).toBe('/guide/');
-  });
+    expect(withBase('/', '/')).toBe('/');
+    expect(withBase('/base/', '/base/')).toBe('/base/');
+    expect(withBase('/base', '/base/')).toBe('/base/');
 
-  test('multiple withBase', () => {
+    // multiple withBase
     const base = '/my-base/';
     const firstResult = withBase('/guide/', base);
+    expect(firstResult).toBe('/my-base/guide/');
     const secondResult = withBase(firstResult, base);
     expect(secondResult).toBe('/my-base/guide/');
   });
@@ -33,6 +36,16 @@ describe('test shared utils', () => {
     expect(removeBase('/zh/guide/', '/zh/')).toBe('/guide/');
     expect(removeBase('/guide/', '/')).toBe('/guide/');
     expect(removeBase('/guide/', '')).toBe('/guide/');
+    expect(removeBase('/', '/')).toBe('/');
+    expect(removeBase('/base/', '/base/')).toBe('/');
+    expect(removeBase('/base', '/base/')).toBe('/');
+
+    // multiple removeBase
+    const base = '/my-base/';
+    const firstResult = removeBase('/my-base/guide/', base);
+    expect(firstResult).toBe('/guide/');
+    const secondResult = removeBase(firstResult, base);
+    expect(secondResult).toBe('/guide/');
   });
 
   test('normalizePosix', () => {

--- a/packages/shared/src/runtime-utils/utils.ts
+++ b/packages/shared/src/runtime-utils/utils.ts
@@ -81,10 +81,6 @@ export function removeTrailingSlash(url: string) {
   return url.charAt(url.length - 1) === '/' ? url.slice(0, -1) : url;
 }
 
-export function normalizeSlash(url: string) {
-  return removeTrailingSlash(addLeadingSlash(normalizePosixPath(url)));
-}
-
 export function isExternalUrl(url = '') {
   return (
     url.startsWith('http://') ||
@@ -258,18 +254,35 @@ export function withoutLang(path: string, langs: string[]) {
   return addLeadingSlash(path.replace(langRegexp, ''));
 }
 
+function normalizeSlash(url: string) {
+  return removeTrailingSlash(addLeadingSlash(normalizePosixPath(url)));
+}
+
 export function withBase(url: string, base: string): string {
   const normalizedUrl = addLeadingSlash(url);
   const normalizedBase = normalizeSlash(base);
-  // Avoid adding base path repeatedly
-  return normalizedUrl.startsWith(normalizedBase)
-    ? normalizedUrl
-    : `${normalizedBase}${normalizedUrl}`;
+
+  const hasBase = normalizedUrl.startsWith(normalizedBase);
+  if (hasBase) {
+    // normalizedUrl => '/base' base => '/base/'
+    if (normalizedUrl + '/' === base) {
+      return base;
+    }
+    return normalizedUrl;
+  }
+
+  return `${normalizedBase}${normalizedUrl}`;
 }
 
 export function removeBase(url: string, base: string) {
-  return addLeadingSlash(url).replace(
-    new RegExp(`^${normalizeSlash(base)}`),
+  const normalizedUrl = addLeadingSlash(url);
+  const normalizedBase = normalizeSlash(base);
+  const removedBaseUrl = normalizedUrl.replace(
+    new RegExp(`^${normalizedBase}`),
     '',
   );
+  if (removedBaseUrl === '') {
+    return '/';
+  }
+  return removedBaseUrl;
 }


### PR DESCRIPTION
## Summary

fix(core): "/base" should be rendered successfully when using `base`

When the base is set to ‘/’, `http://a.com/` and `http://a.com` point to the same page. (Browser default behavior)

<img width="254" height="97" alt="image" src="https://github.com/user-attachments/assets/a59cb964-7659-4af7-878d-a602d0bea9cb" />


However, when the base is set to ‘/base/’, `http://a.com/base/` and `http://a.com/base` actually represent different resources, but Rspress should allow access to `http://a.com/base` for compatibility, as users can deploy to /base. 

<img width="263" height="72" alt="image" src="https://github.com/user-attachments/assets/0a481c9b-9c7b-4873-81c9-7b66e2634b63" />

Rspress is compatible with both /base/ and /base

---

在 base 为 ‘/’ 时，`http://a.com/` 和  `http://a.com` 指向同一资源

但当 base 为 ‘/base/’ 时， `http://a.com/base/` 和 `http://a.com/base` 实际上代表着不同的资源，不过 Rspress 应该允许 `http://a.com/base` 的访问，以兼容用户可以部署到 /base 上

Rspress 兼容两种 /base/ 和 /base

## Some drawbacks

For relative URL links, they are very dangerous.

We use react-router-dom, which is a lenient routing matching mechanism.

For example, "/api" "/api/index" "/api/" all point to the same page, but different results will appear when they use relative path links, at this time, attention should be paid to

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
