### PR TITLE
fix(plugin-twoslash): Prevent the contents of the popup from being copied when copying code

### DIFF
--- a/packages/plugin-twoslash/src/index.ts
+++ b/packages/plugin-twoslash/src/index.ts
@@ -121,7 +121,7 @@ export function pluginTwoslash(options?: PluginTwoslashOptions): RspressPlugin {
                   type: 'element',
                   tagName: 'twoslash-popup-container',
                   properties: {
-                    class: 'twoslash-popup-container',
+                    class: 'twoslash-popup-container rp-copy-ignore',
                     'data-always': 'true',
                   },
                   children: [
@@ -148,6 +148,9 @@ export function pluginTwoslash(options?: PluginTwoslashOptions): RspressPlugin {
               },
               hoverPopup: {
                 tagName: 'twoslash-popup-container',
+                properties: {
+                  class: 'twoslash-popup-container rp-copy-ignore',
+                },
                 children: elements => [
                   {
                     type: 'element',
@@ -172,6 +175,7 @@ export function pluginTwoslash(options?: PluginTwoslashOptions): RspressPlugin {
               queryPopup: {
                 tagName: 'twoslash-popup-container',
                 properties: {
+                  class: 'twoslash-popup-container rp-copy-ignore',
                   'data-always': 'true',
                 },
                 children: elements => [


### PR DESCRIPTION
## Summary

I forgot to add the class name. Sorry...

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
