### PR TITLE
chore(plugin-twoslash): add hover style back

### DIFF
--- a/packages/plugin-twoslash/src/index.ts
+++ b/packages/plugin-twoslash/src/index.ts
@@ -142,9 +142,10 @@ export function pluginTwoslash(options?: PluginTwoslashOptions): RspressPlugin {
               ],
               hoverToken: {
                 tagName: 'twoslash-popup-trigger',
-                properties: {
-                  class: 'twoslash-popup-trigger',
-                },
+                // TODO: css changes
+                // properties: {
+                //   class: 'twoslash-popup-trigger',
+                // },
               },
               hoverPopup: {
                 tagName: 'twoslash-popup-container',

--- a/website/docs/en/plugin/official-plugins/twoslash.mdx
+++ b/website/docs/en/plugin/official-plugins/twoslash.mdx
@@ -12,7 +12,7 @@ Integration of [Twoslash](https://github.com/twoslashes/twoslash)'s Rspress Plug
 
 ### 1. Register the plugin
 
-```ts title="rspress.config.ts"
+```ts twoslash title="rspress.config.ts"
 import { defineConfig } from '@rspress/core';
 import { pluginTwoslash } from '@rspress/plugin-twoslash';
 
@@ -29,7 +29,7 @@ For more detailed usage, please refer to the [Twoslash documentation](https://tw
 
 #### Extract type
 
-```ts
+```ts twoslash
 const hi = 'Hello';
 const msg = `${hi}, world`;
 //    ^?
@@ -37,7 +37,7 @@ const msg = `${hi}, world`;
 
 #### Completions
 
-```ts
+```ts twoslash
 // @noErrors
 console.e;
 //       ^|
@@ -45,7 +45,7 @@ console.e;
 
 #### Highlighting
 
-```ts
+```ts twoslash
 function add(a: number, b: number) {
   //     ^^^
   return a + b;
@@ -54,7 +54,7 @@ function add(a: number, b: number) {
 
 #### Error
 
-```ts
+```ts twoslash
 // @noErrorValidation
 const str: string = 1;
 ```

--- a/website/docs/zh/plugin/official-plugins/twoslash.mdx
+++ b/website/docs/zh/plugin/official-plugins/twoslash.mdx
@@ -12,7 +12,7 @@ import { SourceCode, PackageManagerTabs } from '@rspress/core/theme';
 
 ### 1. 注册插件
 
-```ts title="rspress.config.ts"
+```ts twoslash title="rspress.config.ts"
 import { defineConfig } from '@rspress/core';
 import { pluginTwoslash } from '@rspress/plugin-twoslash';
 
@@ -29,7 +29,7 @@ export default defineConfig({
 
 #### 提取类型
 
-```ts
+```ts twoslash
 const hi = 'Hello';
 const msg = `${hi}, world`;
 //    ^?
@@ -37,7 +37,7 @@ const msg = `${hi}, world`;
 
 #### 自动补全
 
-```ts
+```ts twoslash
 // @noErrors
 console.e;
 //       ^|
@@ -45,7 +45,7 @@ console.e;
 
 #### 高亮显示
 
-```ts
+```ts twoslash
 function add(a: number, b: number) {
   //     ^^^
   return a + b;
@@ -54,7 +54,7 @@ function add(a: number, b: number) {
 
 #### 错误提示
 
-```ts
+```ts twoslash
 // @noErrorValidation
 const str: string = 1;
 ```
@@ -63,7 +63,7 @@ const str: string = 1;
 
 该插件接受一个对象，具有以下类型：
 
-```ts
+```ts twoslash
 export interface PluginTwoslashOptions {
   explicitTrigger?: boolean;
 }


### PR DESCRIPTION
## Summary

chore(plugin-twoslash): add hover style back

before

<img width="818" height="398" alt="image" src="https://github.com/user-attachments/assets/b10386e0-a7e9-4165-9bff-248c9ab7b6d9" />


after

<img width="848" height="403" alt="image" src="https://github.com/user-attachments/assets/1613242b-cb0d-4b7e-8701-f107320f3029" />


## Related Issue

https://github.com/web-infra-dev/rspress/pull/2538#pullrequestreview-3175087980

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
