### PR TITLE
fix(theme-default/style): add `color: inherit` back

### DIFF
--- a/packages/theme-default/src/styles/preflight.css
+++ b/packages/theme-default/src/styles/preflight.css
@@ -206,6 +206,7 @@ input,
 optgroup,
 select,
 textarea {
+  font: inherit;
   /* font-family: inherit;  */
   /* 1 */
   /* font-feature-settings: inherit; */
@@ -220,7 +221,7 @@ textarea {
   /* 1 */
   /* letter-spacing: inherit;  */
   /* 1 */
-  /* color: inherit;  */
+  color: inherit;
   /* 1 */
   margin: 0; /* 2 */
   padding: 0; /* 3 */


### PR DESCRIPTION
## Summary

fix(theme-default/style): add `color: inherit` back

<img width="630" height="929" alt="image" src="https://github.com/user-attachments/assets/5e45347c-11f8-40fc-a961-d3746e50f36d" />


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
