### PR TITLE
feat(twoslash): improve underline styling and adjust popup docs font-size

### DIFF
--- a/packages/plugin-twoslash/static/global-styles/twoslash.css
+++ b/packages/plugin-twoslash/static/global-styles/twoslash.css
@@ -45,12 +45,17 @@
 }
 
 /* ===== Hover Info ===== */
-.twoslash:hover .twoslash-hover {
-  border-color: var(--twoslash-underline-color);
+.twoslash:hover .twoslash-hover::after {
+  content: '';
+  position: absolute;
+  bottom: -3px;
+  left: 0;
+  right: 0;
+  opacity: 0.4;
+  border-bottom: 1px dotted var(--twoslash-underline-color);
 }
 
 .twoslash .twoslash-hover {
-  border-bottom: 1px dotted transparent;
   transition: border-color 0.3s;
   transition-timing-function: ease;
   position: relative;
@@ -149,7 +154,7 @@
 .twoslash .twoslash-popup-docs {
   color: var(--twoslash-docs-color);
   font-family: var(--twoslash-docs-font);
-  font-size: 0.8em;
+  font-size: 0.85em;
   border-top: 1px solid var(--twoslash-border-color);
 }
 


### PR DESCRIPTION
## Summary

Currently, twoslash's underline uses `currentColor` as its color, which appears a bit too dark. Therefore, I've converted it to a pseudo-element and added transparency, making it less visually prominent.

### Before

<img width="807" height="247" alt="Screenshot 2025-09-05 at 21 50 14" src="https://github.com/user-attachments/assets/8eb94fc4-805e-4b86-b3b3-8e7c20ee409c" />

### After

<img width="804" height="245" alt="Screenshot 2025-09-05 at 22 02 06" src="https://github.com/user-attachments/assets/5438b479-fa59-4706-a1c3-a13a0beda908" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
