### PR TITLE
chore(infra): upgrade pnpm configuration to remove hoist

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,1 @@
 registry = 'https://registry.npmjs.org/'
-strict-peer-dependencies=false
-link-workspace-packages=true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,3 +12,7 @@ onlyBuiltDependencies:
   - 'core-js'
   - 'esbuild'
   - 'nx'
+
+hoistPattern: []
+linkWorkspacePackages: true
+strictPeerDependencies: true


### PR DESCRIPTION
## Summary

chore(infra): upgrade pnpm configuration to remove hoist

remove `<root>/node_modules/.pnpm/node_modules`

private hoist node_modules is a evil

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
