### PR TITLE
chore(theme/style): nav group and add word-break: keep-all to navItem

### DIFF
--- a/packages/theme-default/src/components/Nav/NavMenuGroup.tsx
+++ b/packages/theme-default/src/components/Nav/NavMenuGroup.tsx
@@ -41,7 +41,13 @@ function ActiveGroupItem({ item }: { item: NavItemWithLink }) {
   );
 }
 
-function NormalGroupItem({ item }: { item: NavItemWithLink }) {
+function NormalGroupItem({
+  item,
+  isGroupItem,
+}: {
+  item: NavItemWithLink;
+  isGroupItem: boolean;
+}) {
   return (
     <div key={item.link} className="font-medium my-1">
       <Link href={item.link}>
@@ -49,6 +55,7 @@ function NormalGroupItem({ item }: { item: NavItemWithLink }) {
           className="rounded-2xl hover:bg-mute"
           style={{
             padding: '0.4rem 1.5rem 0.4rem 0.75rem',
+            ...(isGroupItem ? { color: 'var(--rp-c-text-2)' } : {}),
           }}
         >
           <div className="flex">
@@ -95,28 +102,38 @@ export function NavMenuGroup(item: NavMenuGroupItem) {
     setIsOpen(true);
   };
 
-  const renderLinkItem = (item: NavItemWithLink) => {
+  const renderLinkItem = (
+    item: NavItemWithLink,
+    isGroupItem: boolean = false,
+  ) => {
     const isLinkActive = new RegExp(item.activeMatch || item.link).test(
       withoutBase(pathname, base),
     );
     if (activeValue === item.text || (!activeValue && isLinkActive)) {
       return <ActiveGroupItem key={item.link} item={item} />;
     }
-    return <NormalGroupItem key={item.link} item={item} />;
+    return (
+      <NormalGroupItem key={item.link} item={item} isGroupItem={isGroupItem} />
+    );
   };
   const renderGroup = (
     item: NavItemWithChildren | NavItemWithLinkAndChildren,
   ) => {
     return (
-      <div>
-        {'link' in item ? (
-          renderLinkItem(item as NavItemWithLink)
+      <div className="my-2">
+        {'link' in item && item.link.length > 1 ? (
+          renderLinkItem(item as NavItemWithLink, true)
         ) : (
-          <p className="font-bold text-gray-400 my-1 not:first:border">
+          <p
+            className="font-sm text-gray-400 my-3 not:first:border px-2"
+            style={{
+              color: 'var(--rp-c-text-1)',
+            }}
+          >
             {item.text}
           </p>
         )}
-        {item.items.map(renderLinkItem)}
+        {item.items.map(item => renderLinkItem(item, true))}
       </div>
     );
   };
@@ -132,7 +149,7 @@ export function NavMenuGroup(item: NavMenuGroupItem) {
         ) : (
           <>
             <span
-              className="text-sm font-medium flex"
+              className="text-sm font-medium flex break-keep"
               style={{
                 marginRight: '2px',
               }}

--- a/packages/theme-default/src/components/Nav/NavMenuSingleItem.tsx
+++ b/packages/theme-default/src/components/Nav/NavMenuSingleItem.tsx
@@ -30,7 +30,7 @@ export function NavMenuSingleItem(
         key={item.text}
         className={`rspress-nav-menu-item ${styles.singleItem} ${
           isActive ? styles.activeItem : ''
-        } text-sm font-medium ${item.compact ? 'mx-0.5' : 'mx-1.5'} px-3 py-2 flex items-center`}
+        } text-sm font-medium ${item.compact ? 'mx-0.5' : 'mx-1.5'} px-3 py-2 flex items-center break-keep`}
       >
         <Tag tag={item.tag} />
         {item.text}

--- a/packages/theme-default/src/components/Nav/index.module.scss
+++ b/packages/theme-default/src/components/Nav/index.module.scss
@@ -79,16 +79,17 @@
   margin: 0 8px;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 960px) {
   .menu-item:before {
     display: none;
   }
   .mobileNavMenu {
     display: flex;
+    align-items: center;
   }
 }
 
-@media (min-width: 768px) {
+@media (min-width: 960px) {
   .menu-item {
     display: flex;
   }

--- a/packages/theme-default/src/components/NavHamburger/index.module.scss
+++ b/packages/theme-default/src/components/NavHamburger/index.module.scss
@@ -8,7 +8,7 @@
   background-color: transparent;
 }
 
-@media (min-width: 768px) {
+@media (min-width: 1280px) {
   .navHamburger {
     display: none;
   }

--- a/packages/theme-default/src/components/Search/index.tsx
+++ b/packages/theme-default/src/components/Search/index.tsx
@@ -8,7 +8,7 @@ import styles from './index.module.scss';
 export function Search() {
   const [focused, setFocused] = useState(false);
   const [metaKey, setMetaKey] = useState<null | string>(null);
-  const { searchPlaceholderText = 'Search Docs' } = useLocaleSiteData();
+  const { searchPlaceholderText = 'Search' } = useLocaleSiteData();
   useEffect(() => {
     setMetaKey(
       /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform) ? '⌘' : 'Ctrl',


### PR DESCRIPTION
## Summary

chore(theme/style): nav group and add word-break: keep-all to navItem

### 1. nav group item

before

<img width="214" height="387" alt="image" src="https://github.com/user-attachments/assets/be79893c-ef4f-4e49-80d6-0b756ce4ecbe" />


after


<img width="308" height="360" alt="image" src="https://github.com/user-attachments/assets/30e88291-7f94-4512-8316-5209e980206b" />

### 2. for nav `word-break: keep-all;'

before

<img width="341" height="86" alt="image" src="https://github.com/user-attachments/assets/c5c7b5c3-a54d-40c6-9ead-32d410198694" />


after

<img width="259" height="89" alt="image" src="https://github.com/user-attachments/assets/78c70dc3-6512-4984-b4d0-61b642cc7a33" />


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
