### PR TITLE
chore(theme/style): keep the html syntax in markdown original style

### DIFF
--- a/packages/theme-default/src/styles/base.css
+++ b/packages/theme-default/src/styles/base.css
@@ -122,3 +122,21 @@ p {
     'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   --rp-font-family-mono: Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
+
+/* #region keep the html syntax in markdown original style e.g: <ul></ul> */
+.rspress-doc ul {
+  list-style: disc;
+}
+.rspress-doc ol {
+  list-style: decimal;
+}
+
+.rspress-doc ul,
+.rspress-doc ol {
+  /* @apply pl-5 my-4 lefting-7; */
+  padding-left: 1.25rem;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  line-height: 1.75rem;
+}
+/* #endregion */

--- a/packages/theme-default/src/styles/base.css
+++ b/packages/theme-default/src/styles/base.css
@@ -124,19 +124,26 @@ p {
 }
 
 /* #region keep the html syntax in markdown original style e.g: <ul></ul> */
-.rspress-doc ul {
+/* why ".rspress-doc > ul"? Because not to affect the component library of users */
+.rspress-doc > ul {
   list-style: disc;
 }
-.rspress-doc ol {
+.rspress-doc > ol {
   list-style: decimal;
 }
 
-.rspress-doc ul,
-.rspress-doc ol {
+.rspress-doc > ul,
+.rspress-doc > ol {
   /* @apply pl-5 my-4 lefting-7; */
   padding-left: 1.25rem;
   margin-top: 1rem;
   margin-bottom: 1rem;
   line-height: 1.75rem;
+}
+.rspress-doc > ul li:not(:first-child) {
+  margin-top: 0.5rem;
+}
+.rspress-doc > ol li:not(:first-child) {
+  margin-top: 0.5rem;
 }
 /* #endregion */


### PR DESCRIPTION
## Summary

chore(theme/style): keep the html syntax in markdown original style

<img width="521" height="198" alt="image" src="https://github.com/user-attachments/assets/24028939-93f4-4cf8-804f-9cc70dc8e23a" />

<img width="410" height="275" alt="image" src="https://github.com/user-attachments/assets/8bdb9068-0419-450e-8b1d-df12b1f0d8ca" />



## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
