### PR TITLE
fix(modern-plugin-rspress): tinyglob ends with unexpected '/'

### DIFF
--- a/packages/modern-plugin-rspress/src/launchDoc.ts
+++ b/packages/modern-plugin-rspress/src/launchDoc.ts
@@ -84,7 +84,9 @@ export async function launchDoc({
 
       // dir --> SidebarGroup[]
       const directoryItems = await Promise.all(
-        directories.map(async (directory: string) => {
+        directories.map(async (directoryRaw: string) => {
+          const directory = directoryRaw.replace(/\/+$/, ''); // tinyglob ends with /
+
           const directoryCwd = join(cwd, directory);
           const hasIndex =
             (


### PR DESCRIPTION
## Summary

fix(modern-plugin-rspress): tinyglob ends with unexpected '/'

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
