### PR TITLE
chore(persistent-cache): add rspress version to cacheDigest to make it more safe

### DIFF
--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -7,6 +7,7 @@ import type {
   RsbuildPlugin,
 } from '@rsbuild/core';
 import { PLUGIN_REACT_NAME, pluginReact } from '@rsbuild/plugin-react';
+import { version as rspressVersion } from '@rspress/core/package.json';
 import {
   MDX_OR_MD_REGEXP,
   removeTrailingSlash,
@@ -274,6 +275,9 @@ async function createInternalBuildConfig(
                     sidebar: config.themeConfig?.sidebar,
                   },
                 ),
+
+                // add rspress version to persistent cache digest to make it more safe
+                rspressVersion,
               ],
             },
           }


### PR DESCRIPTION
## Summary

chore(persistent-cache): add rspress version to cacheDigest to make it more safe

https://github.com/web-infra-dev/rspress/pull/2577

https://app.netlify.com/projects/rspress-v2/deploys/68c182d639d2770008cf77f7

![img_v3_02q1_3df51395-a8ae-4596-b02b-c63f9f6e498g](https://github.com/user-attachments/assets/a580f657-ee1f-4c5b-b164-b5d852ff7a08)


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
