### PR TITLE
fix(theme/style): some components should not be included in rp-doc

### DIFF
--- a/packages/theme-default/src/components/Badge/index.tsx
+++ b/packages/theme-default/src/components/Badge/index.tsx
@@ -52,7 +52,7 @@ export function Badge({
 
   return (
     <span
-      className={`rp-inline-flex rp-items-center rp-justify-center rp-rounded-full rp-border rp-border-solid ${
+      className={`rp-not-doc rp-inline-flex rp-items-center rp-justify-center rp-rounded-full rp-border rp-border-solid ${
         outline ? 'rp-border-current' : 'rp-border-transparent'
       } rp-font-semibold rp-align-middle rp-px-2.5 rp-h-6 rp-gap-1 rp-text-xs ${styles.badge} ${styles[type]} ${
         outline ? styles.outline : ''

--- a/packages/theme-default/src/components/PrevNextPage/index.tsx
+++ b/packages/theme-default/src/components/PrevNextPage/index.tsx
@@ -1,5 +1,5 @@
 import { useLocaleSiteData } from '@rspress/runtime';
-import { Link } from '@theme';
+import { Link, renderInlineMarkdown } from '@theme';
 import * as styles from './index.module.scss';
 
 interface PrevNextPageProps {
@@ -19,7 +19,7 @@ export function PrevNextPage(props: PrevNextPageProps) {
   return (
     <Link href={href} className={linkClassName}>
       <span className={styles.desc}>{pageText}</span>
-      <span className={styles.title}>{text}</span>
+      <span className={styles.title} {...renderInlineMarkdown(text)} />
     </Link>
   );
 }

--- a/packages/theme-default/src/components/SourceCode/index.tsx
+++ b/packages/theme-default/src/components/SourceCode/index.tsx
@@ -14,7 +14,7 @@ export function SourceCode(props: SourceCodeProps) {
   const { sourceCodeText = 'Source' } = useLocaleSiteData();
   return (
     <div
-      className={`rp-inline-block rp-rounded rp-border rp-border-solid rp-border-gray-light-3 dark:rp-border-divider rp-text-gray-400 ${styles.sourceCode}`}
+      className={`rp-not-doc rp-inline-block rp-rounded rp-border rp-border-solid rp-border-gray-light-3 dark:rp-border-divider rp-text-gray-400 ${styles.sourceCode}`}
     >
       <a
         href={href}

--- a/packages/theme-default/src/components/Toc/index.tsx
+++ b/packages/theme-default/src/components/Toc/index.tsx
@@ -40,7 +40,7 @@ export function Toc({
   const headers = useDynamicToc();
   return (
     headers.length > 0 && (
-      <ul>
+      <ul className="rp-not-doc">
         {headers.map(item => (
           <TocItem key={item.id} header={item} onItemClick={onItemClick} />
         ))}


### PR DESCRIPTION
## Summary

1. 
<img width="592" height="603" alt="image" src="https://github.com/user-attachments/assets/cf2beee6-9bed-4adf-9b68-6ae308fc202f" />

2.
<img width="650" height="250" alt="image" src="https://github.com/user-attachments/assets/ce2ec84b-f646-4bde-ae6e-5fdf05d30a0a" />




## Related Issue

introducd in  (#2579) (#2600)

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
