### PR TITLE
fix(theme): llms component should not be included in rp-doc

### DIFF
--- a/packages/plugin-llms/src/runtime/LlmsContainer.tsx
+++ b/packages/plugin-llms/src/runtime/LlmsContainer.tsx
@@ -4,5 +4,5 @@ import { llmsContainer } from './LlmsContainer.module.scss';
 export interface LlmsContainerProps
   extends React.HTMLAttributes<HTMLDivElement> {}
 export function LlmsContainer(props: LlmsContainerProps) {
-  return <div {...props} className={llmsContainer}></div>;
+  return <div {...props} className={`rp-not-doc ${llmsContainer}`}></div>;
 }

--- a/packages/plugin-llms/src/runtime/LlmsCopyButton.tsx
+++ b/packages/plugin-llms/src/runtime/LlmsCopyButton.tsx
@@ -95,6 +95,7 @@ function LlmsCopyButton(props: LlmsCopyButtonProps) {
       {...otherProps}
       disabled={isLoading}
       className={[
+        'rp-not-doc',
         llmsCopyButtonContainer,
         isLoading ? loading : '',
         isFinished ? success : '',

--- a/packages/plugin-llms/src/runtime/LlmsViewOptions.tsx
+++ b/packages/plugin-llms/src/runtime/LlmsViewOptions.tsx
@@ -218,7 +218,7 @@ const LlmsViewOptions = ({
     <>
       <button
         ref={dropdownRef}
-        className={[dropdownButton, isOpen ? active : '']
+        className={['rp-not-doc', dropdownButton, isOpen ? active : '']
           .filter(Boolean)
           .join(' ')}
         type="button"

--- a/packages/theme-default/src/styles/doc.scss
+++ b/packages/theme-default/src/styles/doc.scss
@@ -26,7 +26,8 @@
 
     /* link */
     /* #region */
-    &:where(a):not(:where(.header-anchor)) {
+    // we do not style all the <a> links, only the links with class "rp-link" because there are too many usages of <a> tag in user custom components
+    &:where(a.rp-link):not(:where(.header-anchor)) {
       font-weight: 500;
       color: var(--rp-c-link);
       transition: color 0.25s;


### PR DESCRIPTION
## Summary

fix(theme): llms component should not be included in rp-doc

<img width="686" height="337" alt="image" src="https://github.com/user-attachments/assets/a8d1cc82-97af-4a95-8001-db97518a8464" />


## Related Issue

introduced in ([#2579](https://github.com/web-infra-dev/rspress/issues/2579)) ([#2600](https://github.com/web-infra-dev/rspress/issues/2600))
<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
