### PR TITLE
fix(theme): line-height in home-hreo-tagline

### DIFF
--- a/packages/theme-default/src/components/HomeHero/index.tsx
+++ b/packages/theme-default/src/components/HomeHero/index.tsx
@@ -61,7 +61,7 @@ export function HomeHero({
             ))}
 
           <p
-            className={`rspress-home-hero-tagline whitespace-pre-wrap pt-4 m-auto md:m-0 text-sm sm:tex-xl md:text-[1.5rem] text-text-2 font-medium z-10 ${textMaxWidth}`}
+            className={`rspress-home-hero-tagline whitespace-pre-wrap pt-4 m-auto md:m-0 md:text-[1.5rem] text-text-2 font-medium z-10 ${textMaxWidth}`}
           >
             {renderHtmlOrText(hero.tagline)}
           </p>


### PR DESCRIPTION
## Summary

fix(theme): line-height in home-hreo-tagline

<img width="982" height="610" alt="image" src="https://github.com/user-attachments/assets/923b14ad-3df2-4905-b9a8-2241a3e69753" />


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
