### PR TITLE
docs: fixed navbar example typo

### DIFF
--- a/website/docs/en/api/config/config-frontmatter.mdx
+++ b/website/docs/en/api/config/config-frontmatter.mdx
@@ -257,7 +257,7 @@ Whether to hide the top navigation bar. You can hide the top nav bar with the fo
 
 ```yaml
 ---
-navbar: true
+navbar: false
 ---
 ```
 


### PR DESCRIPTION
## Summary

Fixed a typo in v2 `en` documentation, the `cn` version is correct.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
