### PR TITLE
perf(ssg): regression after output.asyncChunks = true

### DIFF
--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -360,6 +360,7 @@ async function createInternalBuildConfig(
             `${NODE_SSG_BUNDLE_FOLDER}/${NODE_SSG_BUNDLE_NAME}`,
           );
           chain.output.chunkFilename(`${NODE_SSG_BUNDLE_FOLDER}/[name].cjs`);
+          // For perf
           chain.output.set('asyncChunks', false);
         }
       },


### PR DESCRIPTION
## Summary

https://github.com/web-infra-dev/rspress/pull/2295

a large rspress site with 4000+ pages


V1 before

<img width="1166" height="488" alt="image" src="https://github.com/user-attachments/assets/9dfa9f49-4449-4f9c-90cc-0dab8ce3951e" />


V2 after

```
 info    Rendering pages...                                                  
 success Pages rendered in 14048 ms                                   
 ready   built in 25.2 s (web)
 ready   built in 37.5 s (node)
```


Regression reasom

OOM because of the sourcemap size after splitting to small chunks, every soucemap file size is 30 MB + cause that large GC process

<img width="3596" height="1554" alt="image" src="https://github.com/user-attachments/assets/99bd1868-bbdf-45f3-887f-6891730f401a" />



## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
