### PR TITLE
ci: add ecosystem CI

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -1,0 +1,70 @@
+name: Ecosystem CI
+
+on:
+  push:
+    branches: ['main']
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'The branch of the Ecosystem CI run'
+        required: true
+        default: 'main'
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    if: github.repository == 'web-infra-dev/rspress' && github.event_name != 'workflow_dispatch'
+    outputs:
+      changed: ${{ steps.changes.outputs.changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        with:
+          fetch-depth: 1
+
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            changed:
+              - "!**/*.md"
+              - "!**/*.mdx"
+              - "!**/_meta.json"
+              - "!**/dictionary.txt"
+              - "!document/**"
+
+  ecosystem_ci_dispatch:
+    name: Dispatch ecosystem CI
+    runs-on: ubuntu-latest
+    if: github.repository == 'web-infra-dev/rspress' && github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Trigger Ecosystem CI
+        uses: rspack-contrib/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@main
+        with:
+          github-token: ${{ secrets.REPO_rspress_ECO_CI_GITHUB_TOKEN_NEXT }}
+          ecosystem-owner: web-infra-dev
+          ecosystem-repo: rspress
+          workflow-file: rspress-ecosystem-ci-selected.yml
+          client-payload: '{"ref":"${{ github.event.inputs.branch }}","repo":"web-infra-dev/rspress","suite":"-","suiteRefType":"precoded","suiteRef":"precoded"}'
+          branch: ${{ github.event.inputs.branch }}
+
+  ecosystem_ci_per_commit:
+    name: Run ecosystem CI per commit
+    needs: changes
+    runs-on: ubuntu-latest
+    if: github.repository == 'web-infra-dev/rspress' && github.event_name != 'workflow_dispatch' && needs.changes.outputs.changed == 'true'
+    steps:
+      - name: Trigger Ecosystem CI
+        uses: rspack-contrib/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@main
+        with:
+          github-token: ${{ secrets.REPO_RSPRESS_ECO_CI_GITHUB_TOKEN_NEXT }}
+          ecosystem-owner: web-infra-dev
+          ecosystem-repo: rspress
+          workflow-file: rspress-ecosystem-ci-from-commit.yml
+          client-payload: '{"commitSHA":"${{ github.sha }}","updateComment":true,"repo":"web-infra-dev/rspress","suite":"-","suiteRefType":"precoded","suiteRef":"precoded"}'


### PR DESCRIPTION
## Summary

add Rspress to Rstack ecosystem CI so in the future we could see the ecosystem CI timeline in https://rstack-ecosystem-ci.netlify.app.

however, Rspress is a bit special, it does not affect the build process of downstream ecosystem, but a relative independent documentation build process. currently, the implementation in this PR only ensured the `build` command in `website` folder passes https://github.com/rspack-contrib/rstack-ecosystem-ci/blob/main/tests/rspress/rsbuild.ts#L10-L12. it could detect some terrible case, but not help enough.

another possible way to test the suite is by using the Netlify build hook. when Rspress triggers an ecosystem CI, all downstream ecosystems will build a non-production preview. this allows the maintainer to easily check if the downstream website works as expected. do you think that is useful? @SoonIter 

### TODO

- [ ] set up secret after PR got merged.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
