### PR TITLE
fix(theme): avoid circular dependency and ensure CSS orders via add preEntry

### DIFF
--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -180,6 +180,12 @@ async function createInternalBuildConfig(
           getSocialIcons(config.themeConfig?.socialLinks),
         ),
       },
+      preEntry: [
+        // ensure CSS orders and access @theme before @rspress/theme-default to avoid circular dependency
+        path.join(DEFAULT_THEME, '../bundle.css'), // 1. @rspress/theme-default global styles
+        'virtual-global-styles', // 2. virtual-global-styles
+        '@theme', // 3. import './index.css'; from 'theme/index.tsx'
+      ],
     },
     performance: {
       chunkSplit: {


### PR DESCRIPTION
## Summary

fix: add preEntry to ensure CSS orders and access @theme before @rspress/theme-default to avoid circular dependency 

## Related Issue

closes https://github.com/web-infra-dev/rspress/issues/2701 and https://github.com/web-infra-dev/rspress/issues/1922

https://github.com/web-infra-dev/rspress/issues/2701#issuecomment-3484478016

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
