### PR TITLE
fix(theme): Outline font family was hardcoded

### DIFF
--- a/packages/core/src/theme/components/Outline/index.scss
+++ b/packages/core/src/theme/components/Outline/index.scss
@@ -15,7 +15,6 @@
     font-weight: 700;
     height: 32px;
     line-height: 32px;
-    font-family: Inter;
     font-style: normal;
     color: var(--rp-c-text-1);
     margin-bottom: 4px;


### PR DESCRIPTION
## Summary

The font family for the outline component title was hard coded as `Inter` but the base font family shipped with the docs doesn't include `Inter` instead including `Inter var` or others.

This could be changed to be `font-family: var(--rp-font-family-base);` but that seems redundant for this component where the only other places that overwrite the font family are for code blocks.

Current:

<img width="228" height="95" alt="image" src="https://github.com/user-attachments/assets/ea1d2483-2b48-4163-b849-ff9e07428ea7" />

With Fix:

<img width="229" height="96" alt="image" src="https://github.com/user-attachments/assets/278a7698-8974-48f2-92a8-8c8809f7a7c7" />

## Related Issue

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
