### PR TITLE
chore(theme/Tabs): polish Tabs style to ::after instead of border-bottom

### DIFF
--- a/packages/core/src/theme/components/Tabs/index.scss
+++ b/packages/core/src/theme/components/Tabs/index.scss
@@ -36,7 +36,6 @@
 
       position: relative;
       color: var(--rp-c-text-2);
-      border-bottom: 2px solid transparent;
       box-sizing: border-box;
       margin-right: 10px;
       padding: 6px 12px;
@@ -51,7 +50,7 @@
       &:after {
         content: '';
         position: absolute;
-        bottom: -1px;
+        bottom: 0;
         left: 5%;
         width: 90%;
         height: 1px;


### PR DESCRIPTION
## Summary

chore(theme): polish Tabs style to ::after instead of border-bottom

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
