### PR TITLE
fix(theme): use pointer cursor for menu

### DIFF
--- a/packages/core/src/theme/components/Nav/NavMenu.scss
+++ b/packages/core/src/theme/components/Nav/NavMenu.scss
@@ -21,6 +21,7 @@
 
     &__container {
       display: flex;
+      cursor: pointer;
       justify-content: center;
       align-items: center;
       gap: 6px;


### PR DESCRIPTION
## Summary

should use `pointer` cursor when hovering on select menu.

<img width="194" height="158" alt="image" src="https://github.com/user-attachments/assets/31e3fdfb-ecb0-48bf-9c5c-3414dc2d3c82" />

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
