### PR TITLE
security: enable pnpm's no-downgrade trustPolicy

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,9 +55,10 @@
     "vitest": "2.1.9",
     "zx": "^8.8.5"
   },
-  "packageManager": "pnpm@10.18.3",
+  "packageManager": "pnpm@10.22.0",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.0.0",
+    "pnpm": ">=10.22.0"
   },
   "publishConfig": {
     "access": "public",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,3 +16,4 @@ onlyBuiltDependencies:
 hoistPattern: []
 linkWorkspacePackages: true
 strictPeerDependencies: false
+trustPolicy: no-downgrade


### PR DESCRIPTION
## Summary

Enable pnpm's new `no-downgrade` trustPolicy. This helps prevent installing potentially compromised versions of a package.

## Related Links

- https://pnpm.io/settings#trustpolicy

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
