### PR TITLE
fix(theme): h2 gap and twoslash codeblock style

### DIFF
--- a/packages/core/src/theme/components/DocContent/doc.scss
+++ b/packages/core/src/theme/components/DocContent/doc.scss
@@ -7,7 +7,7 @@
     /* #region */
     &:where(p) {
       margin-top: 1.25rem; /* 20px */
-      margin-bottom: 1.25rem;
+      margin-bottom: 1.25rem; /* 20px */
       line-height: 1.75rem; /* 28px */
     }
     &:where(strong, b) {
@@ -97,7 +97,7 @@
     &:where(h2) {
       font-size: 1.75rem; // 28px
       margin-top: 3rem; // 48px
-      margin-bottom: 2rem;
+      margin-bottom: 1.25rem; // 20px
     }
     &:where(h2:first-of-type)::before {
       content: '';

--- a/packages/plugin-twoslash/static/global-styles/twoslash.css
+++ b/packages/plugin-twoslash/static/global-styles/twoslash.css
@@ -144,11 +144,17 @@
   font-size: var(--twoslash-code-font-size);
 }
 
+.twoslash .rp-codeblock {
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
 .twoslash .rp-codeblock__content {
-  padding: 16px 0;
   color: var(--rp-code-block-color);
   background-color: var(--rp-code-block-bg);
-  border-radius: var(--rp-radius);
 }
 
 .twoslash .rp-codeblock__content .rp-code-button-group {


### PR DESCRIPTION
## Summary

fix(theme): h2 gap and twoslash codeblock style

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
