### PR TITLE
fix(plugin-twoslash): Make twoslashOptions optional

### DIFF
--- a/packages/plugin-twoslash/src/index.ts
+++ b/packages/plugin-twoslash/src/index.ts
@@ -119,7 +119,7 @@ export interface PluginTwoslashOptions {
   /**
    * Options to pass to Twoslash
    */
-  twoslashOptions: TwoslashOptions;
+  twoslashOptions?: TwoslashOptions;
 }
 
 /**


### PR DESCRIPTION
## Summary

Sorry, I forgot to make it optional in the previous PR, so this one fixes that.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
