### PR TITLE
fix(theme/Layout): render `beforeNavMenu` correctly

### DIFF
--- a/packages/core/src/theme/layout/Layout/index.tsx
+++ b/packages/core/src/theme/layout/Layout/index.tsx
@@ -115,6 +115,7 @@ export function Layout(props: LayoutProps) {
     afterHero,
     beforeFeatures,
     afterFeatures,
+    beforeNavMenu,
     afterNavMenu,
     components,
     HomeLayout = DefaultHomeLayout,
@@ -222,6 +223,7 @@ export function Layout(props: LayoutProps) {
             beforeNavTitle={beforeNavTitle}
             afterNavTitle={afterNavTitle}
             navTitle={navTitle}
+            beforeNavMenu={beforeNavMenu}
             afterNavMenu={afterNavMenu}
           />
           {afterNav}


### PR DESCRIPTION
## Summary

render `beforeNavMenu` correctly

## Related Issue

<!--- Provide link of related issues -->

N/A

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
