### PR TITLE
feat(rspack)!: revert Rspack native watcher by default

### DIFF
--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -342,11 +342,11 @@ async function createInternalBuildConfig(
           })
           .end();
 
-        chain.experiments({
-          // Enable native watcher by default unless RSPRESS_NATIVE_WATCHER is set to 'false'
-          ...chain.get('experiments'),
-          nativeWatcher: process.env.RSPRESS_NATIVE_WATCHER !== 'false',
-        });
+        // chain.experiments({
+        //   // Enable native watcher by default unless RSPRESS_NATIVE_WATCHER is set to 'false'
+        //   ...chain.get('experiments'),
+        //   nativeWatcher: process.env.RSPRESS_NATIVE_WATCHER !== 'false',
+        // });
 
         if (chain.plugins.has(CHAIN_ID.PLUGIN.REACT_FAST_REFRESH)) {
           chain.plugin(CHAIN_ID.PLUGIN.REACT_FAST_REFRESH).tap(options => {


### PR DESCRIPTION
## Summary

There exists some native watcher issue on ubuntu, disable it for now.

- https://github.com/web-infra-dev/rspack/actions/runs/19848405747/job/56870358082

<img width="1844" height="496" alt="image" src="https://github.com/user-attachments/assets/72743c98-1c9c-4404-944a-8e13bce8c3db" />


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
