### PR TITLE
fix(theme/outline): line-height of toc item

### DIFF
--- a/packages/core/src/theme/components/Toc/TocItem.scss
+++ b/packages/core/src/theme/components/Toc/TocItem.scss
@@ -15,7 +15,6 @@
   &__text {
     font-weight: 400;
     font-size: 14px;
-    line-height: 1;
     color: var(--rp-c-text-2);
     overflow-wrap: break-word;
   }


### PR DESCRIPTION
## Summary


fix(theme/TOC): line-height of toc item

<img width="3436" height="1036" alt="image" src="https://github.com/user-attachments/assets/52df4c4e-6f63-40e9-af18-c070281cb47e" />


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
