### PR TITLE
fix(core): Fix an issue where the PackageManagerTabs component outputs broken Markdown

### DIFF
--- a/packages/core/src/theme/components/PackageManagerTabs/index.tsx
+++ b/packages/core/src/theme/components/PackageManagerTabs/index.tsx
@@ -210,6 +210,18 @@ export function PackageManagerTabs({
     commandInfo = command;
   }
 
+  if (process.env.__SSR_MD__) {
+    return Object.values(commandInfo).reduce((previous, current) => {
+      const [packageManager, command] = splitTo2Parts(current);
+      return (
+        previous +
+        `\n\`\`\`sh [${packageManager}]\n` +
+        `${packageManager}${command}\n` +
+        `\`\`\`\n`
+      );
+    }, '');
+  }
+
   return (
     <Tabs
       groupId="package.manager"


### PR DESCRIPTION
## Summary

This PR fixes an issue where the PackageManagerTabs component generated malformed Markdown.
Previously, all commands were emitted in a single continuous block, resulting in unreadable output:

<img width="677" height="548" alt="スクリーンショット 2025-12-08 17 56 31" src="https://github.com/user-attachments/assets/8545021b-eb16-4151-b47a-0cac89e6869c" />

After this fix, the component produces properly formatted and separated Markdown code blocks with labels:

<img width="691" height="548" alt="スクリーンショット 2025-12-08 17 55 23" src="https://github.com/user-attachments/assets/ffb0037a-96ff-4bd4-8030-e70be9837d02" />

## Related Issue

#2857

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
