### PR TITLE
chore(theme/Codeblock): beautify the shiki highlight

### DIFF
--- a/packages/core/src/theme/styles/shiki.scss
+++ b/packages/core/src/theme/styles/shiki.scss
@@ -51,13 +51,18 @@
     width: 100%;
     position: static;
     display: inline-block;
-    background-color: rgba(0, 99, 199, 0.1);
+  }
+  .line.highlighted:not(.error):not(.warning) {
+    background-color: rgba(59, 130, 246, 0.1);
+    box-shadow: inset 2px 0 0 0 rgb(59, 130, 246);
   }
   .line.highlighted.error {
-    background-color: rgba(244, 63, 94, 0.1);
+    background-color: rgba(237, 60, 80, 0.1);
+    box-shadow: inset 2px 0 0 0 rgb(237, 60, 80);
   }
   .line.highlighted.warning {
-    background-color: rgba(234, 179, 8, 0.1);
+    background-color: rgba(255, 197, 23, 0.1);
+    box-shadow: inset 2px 0 0 0 rgb(255, 197, 23);
   }
 }
 


### PR DESCRIPTION
## Summary

chore(theme/Codeblock): beautify the shiki highlight


before

<img width="859" height="642" alt="image" src="https://github.com/user-attachments/assets/cb1df7a4-6eaf-4499-a943-7c89f6945a4c" />

after

<img width="1513" height="946" alt="image" src="https://github.com/user-attachments/assets/ffca89e2-5fcc-4c8c-8cbe-066c0fde8203" />


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
