### PR TITLE
fix(core): Fix an issue where llms.txt was not generated when locales was not set

### DIFF
--- a/packages/core/src/node/ssg-md/llms/emitLlmsTxt.ts
+++ b/packages/core/src/node/ssg-md/llms/emitLlmsTxt.ts
@@ -63,8 +63,9 @@ export async function emitLlmsTxt(
     : [];
 
   const defaultLang = routeService.getDefaultLang();
+  const langs = new Set([defaultLang, ...routeService.getLangs()]);
   await Promise.all(
-    routeService.getLangs().map(async lang => {
+    langs.values().map(async lang => {
       const navList = noVersionNav.filter(i => i.lang === lang);
       const routeGroups: string[][] = new Array(navList.length)
         .fill(0)


### PR DESCRIPTION
## Summary

If locales is not set in the config, getLangs returns an empty array.
As a result, llms.txt was not being generated.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
