### PR TITLE
chore(theme/Tabs): update style when nested Tabs in Tabs

### DIFF
--- a/packages/core/src/theme/components/Tabs/index.scss
+++ b/packages/core/src/theme/components/Tabs/index.scss
@@ -7,6 +7,7 @@
 
   // nested
   & & {
+    border-radius: 0;
     margin: 0;
     border: none;
   }


### PR DESCRIPTION
## Summary

## Before

<img width="829" height="224" alt="image" src="https://github.com/user-attachments/assets/85e6042b-7103-42fa-b337-c98fa4b97469" />


## After

<img width="760" height="171" alt="image" src="https://github.com/user-attachments/assets/517e28d4-6cda-4706-a5cd-cece18b19c79" />


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
