### PR TITLE
fix(theme/Table): mark table a link styled

### DIFF
--- a/packages/core/src/theme/components/DocContent/doc.scss
+++ b/packages/core/src/theme/components/DocContent/doc.scss
@@ -27,7 +27,7 @@
     /* link */
     /* #region */
     // we do not style all the <a> links, only the links with class "rp-link" because there are too many usages of <a> tag in user custom components
-    &:where(a.rp-link):not(:where(.rp-header-anchor)) {
+    &:where(a.rp-link, table a):not(:where(.rp-header-anchor)) {
       font-weight: 500;
       color: var(--rp-c-link);
       transition: color 0.25s;

--- a/packages/core/src/theme/components/DocContent/docComponents/table.tsx
+++ b/packages/core/src/theme/components/DocContent/docComponents/table.tsx
@@ -1,5 +1,24 @@
+import clsx from 'clsx';
 import { type ComponentProps, forwardRef } from 'react';
 
+/**
+ * Table component with a scrollable container.
+ *
+ * Usage:
+ *
+ * ```tsx
+ * <Table>
+ *   <tr>
+ *     <th>Header 1</th>
+ *     <th>Header 2</th>
+ *   </tr>
+ *  <tr>
+ *    <td>Data 1</td>
+ *   <td>Data 2</td>
+ * </tr>
+ * </Table>
+ * ```
+ */
 export const Table = forwardRef<HTMLTableElement, ComponentProps<'table'>>(
   (props, ref) => {
     return (


### PR DESCRIPTION
## Summary

fix(theme/Table): mark table a link styled

## Related Issue

https://github.com/web-infra-dev/rspack/pull/12498

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
