### PR TITLE
chore(e2e): stable plugin-preview-custom-entry test

### DIFF
--- a/e2e/fixtures/plugin-preview-custom-entry/rspress.config.ts
+++ b/e2e/fixtures/plugin-preview-custom-entry/rspress.config.ts
@@ -8,6 +8,8 @@ export default defineConfig({
   plugins: [
     pluginPreview({
       iframeOptions: {
+        // Provide a different port for the test to avoid port conflicts and crashes.
+        devPort: 7788,
         customEntry: ({ demoPath }) => {
           if (demoPath.endsWith('.vue')) {
             return `


### PR DESCRIPTION
## Summary

chore(e2e): stable plugin-preview-custom-entry test

## Related Issue

<img width="1393" height="803" alt="image" src="https://github.com/user-attachments/assets/5cc1117e-93f4-41f4-b753-7127024623f7" />


<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
