### PR TITLE
feat(theme): add text-autospace: normal;

### DIFF
--- a/packages/core/src/theme/styles/base.css
+++ b/packages/core/src/theme/styles/base.css
@@ -59,6 +59,11 @@ body {
     'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans',
     'Helvetica Neue', sans-serif;
   --rp-font-family-mono: Menlo, Monaco, Consolas, 'Courier New', monospace;
+
+  /* The text-autospace CSS property allows you to specify the space applied between Chinese/Japanese/Korean (CJK) and non-CJK characters. */
+  /* @see https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/text-autospace */
+  /* If you don't like it, you can cancel it by using `body { text-autospace: unset; }` */
+  text-autospace: normal;
 }
 
 :root #nprogress .bar {


### PR DESCRIPTION
## Summary

feat(theme): add text-autospace: normal;

## Related Issue


https://x.com/yisibl/status/1979132340942041270

`:root { text-autospace: normal; }`

**Benefits**  
Automatically adds an 1/8 em space between Chinese and English text.

**Drawbacks**  
- Performance degradation in certain scenarios.

- The length of 1/8em isn't identical to a regular space.
<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
