### PR TITLE
fix(theme/Sidebar): sidebar should also listen location changes

### DIFF
--- a/packages/runtime/src/hooks/useActiveMatcher.ts
+++ b/packages/runtime/src/hooks/useActiveMatcher.ts
@@ -1,18 +1,17 @@
-import { useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import { useLocation } from 'react-router-dom';
 import { isActive } from '../route';
 
 export const useActiveMatcher = () => {
   const { pathname: rawPathname } = useLocation();
 
-  const ref = useRef(rawPathname);
-  ref.current = rawPathname;
-
-  const activeMatcher = useCallback((link: string) => {
-    const rawPathname = ref.current;
-    const pathname = decodeURIComponent(rawPathname);
-    return isActive(link, pathname);
-  }, []);
+  const activeMatcher = useCallback(
+    (link: string) => {
+      const pathname = decodeURIComponent(rawPathname);
+      return isActive(link, pathname);
+    },
+    [rawPathname],
+  );
 
   return activeMatcher;
 };

--- a/packages/runtime/src/hooks/useSidebar.ts
+++ b/packages/runtime/src/hooks/useSidebar.ts
@@ -117,7 +117,6 @@ export function useSidebarDynamic(): [
   SidebarData,
   React.Dispatch<React.SetStateAction<SidebarData>>,
 ] {
-  const { pathname } = useLocation();
   const rawSidebarData = useSidebar();
   const activeMatcher = useActiveMatcher();
 
@@ -131,7 +130,7 @@ export function useSidebarDynamic(): [
 
   useLayoutEffect(() => {
     setSidebar(createInitialSidebar(rawSidebarData, activeMatcher));
-  }, [pathname, rawSidebarData]);
+  }, [activeMatcher, rawSidebarData]);
 
   return [sidebar, setSidebar];
 }


### PR DESCRIPTION
## Summary

when navigating from page A -> B, sidebar should also listen location changes

## Related Issue

<!--- Provide link of related issues -->

#2910

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
