### PR TITLE
fix(core): `Iterator#map` is only available on Node 22+

### DIFF
--- a/packages/core/src/node/ssg-md/llms/emitLlmsTxt.ts
+++ b/packages/core/src/node/ssg-md/llms/emitLlmsTxt.ts
@@ -63,9 +63,9 @@ export async function emitLlmsTxt(
     : [];
 
   const defaultLang = routeService.getDefaultLang();
-  const langs = new Set([defaultLang, ...routeService.getLangs()]);
+  const langs = [...new Set([defaultLang, ...routeService.getLangs()])];
   await Promise.all(
-    langs.values().map(async lang => {
+    langs.map(async lang => {
       const navList = noVersionNav.filter(i => i.lang === lang);
       const routeGroups: string[][] = new Array(navList.length)
         .fill(0)


### PR DESCRIPTION
## Summary

`Iterator#map` is only available on Node 22+ which is incompatible with rspress's baseline [`>=18.0.0`](https://github.com/web-infra-dev/rspress/blob/ddb52660e348dc09d0867a1e07b4f418628a066d/packages/core/package.json#L146C14-L146C22)

## Related Issue

<!--- Provide link of related issues -->

N/A

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
