### PR TITLE
feat(nodejs)!: drop support of node 18, upgrade engines to `node >= 20.9.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "packageManager": "pnpm@10.26.2",
   "engines": {
-    "node": ">=20.0.0",
+    "node": ">=20.9.0",
     "pnpm": ">=10.26.2"
   },
   "publishConfig": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -143,7 +143,7 @@
     "vfile": "^6.0.3"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/create-rspress/package.json
+++ b/packages/create-rspress/package.json
@@ -38,7 +38,7 @@
     "typescript": "^5.8.2"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-algolia/package.json
+++ b/packages/plugin-algolia/package.json
@@ -58,7 +58,7 @@
     "@rspress/core": "workspace:^2.0.0-rc.3"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-api-docgen/package.json
+++ b/packages/plugin-api-docgen/package.json
@@ -60,7 +60,7 @@
     }
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-client-redirects/package.json
+++ b/packages/plugin-client-redirects/package.json
@@ -48,7 +48,7 @@
     "@rspress/core": "workspace:^2.0.0-rc.3"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-llms/package.json
+++ b/packages/plugin-llms/package.json
@@ -58,7 +58,7 @@
     "@rspress/core": "workspace:^2.0.0-rc.3"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-playground/package.json
+++ b/packages/plugin-playground/package.json
@@ -65,7 +65,7 @@
     "react-router-dom": "^6.8.1"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-preview/package.json
+++ b/packages/plugin-preview/package.json
@@ -55,7 +55,7 @@
     "react-router-dom": "^6.8.1"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-rss/package.json
+++ b/packages/plugin-rss/package.json
@@ -44,7 +44,7 @@
     "@rspress/core": "workspace:^2.0.0-rc.3"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-sitemap/package.json
+++ b/packages/plugin-sitemap/package.json
@@ -38,7 +38,7 @@
     "@rspress/core": "workspace:^2.0.0-rc.3"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-twoslash/package.json
+++ b/packages/plugin-twoslash/package.json
@@ -55,7 +55,7 @@
     "typescript": "^5.8.2"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-typedoc/package.json
+++ b/packages/plugin-typedoc/package.json
@@ -51,7 +51,7 @@
     "@rspress/core": "workspace:^2.0.0-rc.3"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -48,7 +48,7 @@
     "typescript": "^5.8.2"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Summary

fix!: upgrade engines to >= 20


Our core code is compatible with node >=18, but since we have upgraded to react-router-dom V7, the engines field requires node >=20. Therefore, we have decided to only support node >=20 and ensure testing.


## Related Issue


https://github.com/web-infra-dev/rspress/issues/1802
<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
