### PR TITLE
fix: hover group links should also calc active with matchNavbar by default

### DIFF
--- a/packages/core/src/theme/components/HoverGroup/index.tsx
+++ b/packages/core/src/theme/components/HoverGroup/index.tsx
@@ -1,6 +1,8 @@
 import type { NavItemWithChildren } from '@rspress/core';
+import { matchNavbar, useLocation } from '@rspress/core/runtime';
 import { Link } from '@theme';
 import cls from 'clsx';
+
 import './index.scss';
 
 type Items = NavItemWithChildren['items'];
@@ -24,6 +26,7 @@ function HoverGroup({
   position = 'center',
   activeMatcher,
 }: HoverGroupProps) {
+  const { pathname } = useLocation();
   return (
     <ul
       className={cls('rp-hover-group', {
@@ -36,7 +39,9 @@ function HoverGroup({
       {customChildren ??
         items?.map(item => {
           const { text, link } = item;
-          const isActiveItem = activeMatcher ? activeMatcher(item) : false;
+          const isActiveItem = activeMatcher
+            ? activeMatcher(item)
+            : matchNavbar(item, pathname);
 
           return (
             <li


### PR DESCRIPTION
## Summary

hover group links should also calc active with matchNavbar by default

No `activeMatcher` is passed by default at https://github.com/web-infra-dev/rspress/blob/b93fade4d0a0f5af5d1dfa5a1c691177caffeebc/packages/core/src/theme/components/Nav/NavMenu.tsx#L93

## Related Issue

<!--- Provide link of related issues -->

N/A

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
