### PR TITLE
fix(theme): improve SSR compatibility

### DIFF
--- a/packages/core/src/theme/logic/useStorageValue.ts
+++ b/packages/core/src/theme/logic/useStorageValue.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 const SYNC_STORAGE_EVENT_NAME = 'RSPRESS_SYNC_STORAGE_EVENT_NAME';
 
@@ -8,13 +8,17 @@ const SYNC_STORAGE_EVENT_NAME = 'RSPRESS_SYNC_STORAGE_EVENT_NAME';
  */
 export const useStorageValue = <T>(key: string, defaultValue: T) => {
   const [value, setValueInternal] = useState<T>(defaultValue);
-  // TODO: support SSR
-  useLayoutEffect(() => {
+
+  // Use useEffect instead of useLayoutEffect for SSR compatibility
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
     const storedValue = localStorage.getItem(key);
     if (storedValue != null) {
       setValueInternal(storedValue as T);
     }
-  }, []);
+  }, [key]);
 
   const setValue = useCallback(
     (value: T) => {


### PR DESCRIPTION
## Summary

- Replace `useLayoutEffect` with `useEffect` in `useStorageValue` to avoid SSR warnings
- Add SSR guard (`typeof window` check) in `useStorageValue` 
- Remove global `renderCountForTocUpdate` counter in `PageTabs` that causes hydration mismatch

## Background

### useStorageValue issues

The `useStorageValue` hook had two SSR compatibility issues:
1. Used `useLayoutEffect` which causes warnings during SSR
2. Accessed `localStorage` without checking if `window` is defined

### PageTabs hydration mismatch

The `PageTabs` component used a global counter `renderCountForTocUpdate` that was incremented on every render. This counter was used to conditionally render a hidden `<h2>` element for TOC updates. Since the counter value could differ between server and client renders, this caused hydration mismatches.

## Test plan

- [ ] Verify no SSR warnings in console during build
- [ ] Verify tabs with `groupId` work correctly (state persisted in localStorage)
- [ ] Verify PageTabs component renders correctly without hydration errors
