### PR TITLE
docs: fix the shiki highlighter ansi "/"

### DIFF
--- a/website/docs/en/guide/use-mdx/code-blocks.mdx
+++ b/website/docs/en/guide/use-mdx/code-blocks.mdx
@@ -139,10 +139,6 @@ console.log('Highlighted');
 console.log('Highlighted');
 ```
 
-:::warning
-The backslash (`\`) in `[\!code highlight]` is for escaping in Markdown to show the original syntax. Do not include the backslash when actually using this syntax.
-:::
-
 ## Meta line highlight
 
 :::warning

--- a/website/docs/zh/guide/use-mdx/code-blocks.mdx
+++ b/website/docs/zh/guide/use-mdx/code-blocks.mdx
@@ -139,10 +139,6 @@ console.log('Highlighted');
 console.log('Highlighted');
 ```
 
-:::warning
-在 `[\!code highlight]` 中的反斜杠（`\`）是为了在 Markdown 中转义以显示原始语法。在实际使用该语法时，请不要包含此反斜杠。
-:::
-
 ## Meta 行高亮
 
 :::warning

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -11,6 +11,7 @@ import {
   transformerNotationErrorLevel,
   transformerNotationFocus,
   transformerNotationHighlight,
+  transformerRemoveNotationEscape,
 } from '@shikijs/transformers';
 import fs from 'fs/promises';
 import path from 'path';
@@ -60,6 +61,7 @@ export default defineConfig({
         transformerNotationHighlight(),
         transformerNotationFocus(),
         transformerCompatibleMetaHighlight(),
+        transformerRemoveNotationEscape(),
       ],
     },
     link: {


### PR DESCRIPTION
## Summary

transformerRemoveNotationEscape


https://github.com/shikijs/shiki/blob/07ddef409d57c74b2c6cdd05ac81e2585eb9eff0/docs/.vitepress/config.ts#L145

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
