### PR TITLE
feat(core): add import.meta.env.SSR and import.meta.env.SSG_MD

### DIFF
--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -403,6 +403,8 @@ async function createInternalBuildConfig(
           define: {
             'process.env.__SSR__': JSON.stringify(false),
             'process.env.__SSR_MD__': JSON.stringify(false),
+            'import.meta.env.SSR': JSON.stringify(false),
+            'import.meta.env.SSG_MD': JSON.stringify(false),
           },
         },
         output: {
@@ -436,6 +438,8 @@ async function createInternalBuildConfig(
                 define: {
                   'process.env.__SSR__': JSON.stringify(true),
                   'process.env.__SSR_MD__': JSON.stringify(false),
+                  'import.meta.env.SSR': JSON.stringify(true),
+                  'import.meta.env.SSG_MD': JSON.stringify(false),
                 },
               },
               performance: {
@@ -475,6 +479,8 @@ async function createInternalBuildConfig(
                 define: {
                   'process.env.__SSR__': JSON.stringify(true),
                   'process.env.__SSR_MD__': JSON.stringify(true),
+                  'import.meta.env.SSR': JSON.stringify(true),
+                  'import.meta.env.SSG_MD': JSON.stringify(true),
                 },
               },
               performance: {

--- a/website/docs/en/guide/basic/ssg-md.mdx
+++ b/website/docs/en/guide/basic/ssg-md.mdx
@@ -50,11 +50,11 @@ describe('renderToMarkdownString', () => {
 });
 ```
 
-2. Provides `process.env.__SSR_MD__` environment variable, making it easy for users to distinguish between SSG-MD rendering and browser rendering in MDX components, thus achieving more flexible content customization. For example:
+2. Provides `import.meta.env.SSG_MD` environment variable, making it easy for users to distinguish between SSG-MD rendering and browser rendering in MDX components, thus achieving more flexible content customization. For example:
 
 ```tsx
 export function Tab({ label }: { label: string }) {
-  if (process.env.__SSR_MD__) {
+  if (import.meta.env.SSG_MD) {
     return <>{`** Here is a Tab named ${label}**`}</>;
   }
   return <div>{label}</div>;

--- a/website/docs/zh/guide/basic/ssg-md.mdx
+++ b/website/docs/zh/guide/basic/ssg-md.mdx
@@ -50,11 +50,11 @@ describe('renderToMarkdownString', () => {
 });
 ```
 
-2. 提供 `process.env.__SSR_MD__` 环境变量，方便用户在 React 组件中区分 SSG-MD 渲染和浏览器渲染，从而实现更灵活的内容定制。例如：
+2. 提供 `import.meta.env.SSG_MD` 环境变量，方便用户在 React 组件中区分 SSG-MD 渲染和浏览器渲染，从而实现更灵活的内容定制。例如：
 
 ```tsx
 export function Tab({ label }: { label: string }) {
-  if (process.env.__SSR_MD__) {
+  if (import.meta.env.SSG_MD) {
     return <>{`** Here is a Tab named ${label}**`}</>;
   }
   return <div>{label}</div>;


### PR DESCRIPTION
## Summary

Add `import.meta.env.SSR` and `import.meta.env.SSG_MD` environment variables (keeping existing `process.env.__SSR__` and `process.env.__SSR_MD__` APIs).

| env | `import.meta.env.SSR` | `import.meta.env.SSG_MD` |
|------|----------------------|-------------------------|
| web | `false` | `false` |
| node | `true` | `false` |
| node_md | `true` | `true` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)