### PR TITLE
docs: update links from rspack-contrib to rstackjs

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -45,7 +45,7 @@ jobs:
     if: github.repository == 'web-infra-dev/rspress' && github.event_name == 'workflow_dispatch'
     steps:
       - name: Trigger Ecosystem CI
-        uses: rspack-contrib/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@main
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@main
         with:
           github-token: ${{ secrets.REPO_rspress_ECO_CI_GITHUB_TOKEN_NEXT }}
           ecosystem-owner: web-infra-dev
@@ -61,7 +61,7 @@ jobs:
     if: github.repository == 'web-infra-dev/rspress' && github.event_name != 'workflow_dispatch' && needs.changes.outputs.changed == 'true'
     steps:
       - name: Trigger Ecosystem CI
-        uses: rspack-contrib/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@main
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@main
         with:
           github-token: ${{ secrets.REPO_RSPRESS_ECO_CI_GITHUB_TOKEN_NEXT }}
           ecosystem-owner: web-infra-dev

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Go to the [Quick start](https://rspress.rs/guide/start/getting-started.html) to 
 
 ## 🦀 Rstack
 
-Rstack is a unified JavaScript toolchain built around Rspack, with high performance and consistent architecture.
+Rstack is a unified JavaScript toolchain centered on Rspack, with high performance and consistent architecture.
 
 | Name                                                  | Description              | Version                                                                                                                                                                          |
 | ----------------------------------------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/packages/shared/src/types/Plugin.ts
+++ b/packages/shared/src/types/Plugin.ts
@@ -73,7 +73,7 @@ export interface RspressPlugin {
   ) => AdditionalPage[] | Promise<AdditionalPage[]>;
   /**
    * Add runtime modules
-   * @deprecated use [rsbuild-plugin-virtual-module](https://github.com/rspack-contrib/rsbuild-plugin-virtual-module) instead.
+   * @deprecated use [rsbuild-plugin-virtual-module](https://github.com/rstackjs/rsbuild-plugin-virtual-module) instead.
    */
   addRuntimeModules?: (
     config: UserConfig,

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -132,6 +132,7 @@ rslog
 rspack
 rspress
 rstack
+rstackjs
 rstest
 Rustify
 selfsign

--- a/website/README.md
+++ b/website/README.md
@@ -10,6 +10,6 @@ The same as Rspack: [Writing style guide](https://github.com/web-infra-dev/rspac
 
 ### Image assets
 
-For images you use in the document, it's better to upload them to the [rspack-contrib/rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources) repository, so the size of the current repository doesn't get too big.
+For images you use in the document, it's better to upload them to the [rstackjs/rstack-design-resources](https://github.com/rstackjs/rstack-design-resources) repository, so the size of the current repository doesn't get too big.
 
 After you upload the images there, they will be automatically deployed under the <https://assets.rspack.rs/>.

--- a/website/docs/en/api/config/config-build.mdx
+++ b/website/docs/en/api/config/config-build.mdx
@@ -63,7 +63,7 @@ export default defineConfig({
 });
 ```
 
-- Example: Add Google analytics through [rsbuild-plugin-google-analytics](https://github.com/rspack-contrib/rsbuild-plugin-google-analytics).
+- Example: Add Google analytics through [rsbuild-plugin-google-analytics](https://github.com/rstackjs/rsbuild-plugin-google-analytics).
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from '@rspress/core';
@@ -81,7 +81,7 @@ export default defineConfig({
 });
 ```
 
-- Example: Add Open Graph meta tags through [rsbuild-plugin-open-graph](https://github.com/rspack-contrib/rsbuild-plugin-open-graph).
+- Example: Add Open Graph meta tags through [rsbuild-plugin-open-graph](https://github.com/rstackjs/rsbuild-plugin-open-graph).
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from '@rspress/core';

--- a/website/docs/en/guide/advanced/extend-build.mdx
+++ b/website/docs/en/guide/advanced/extend-build.mdx
@@ -24,7 +24,7 @@ export default defineConfig({
 
 Rspress also provides the [builderConfig.plugins](/api/config/config-build#builderconfigplugins) config to register Rsbuild plugins. You can leverage Rsbuild's extensive plugin ecosystem to enhance and extend your build capabilities.
 
-For example, add Google analytics through [rsbuild-plugin-google-analytics](https://github.com/rspack-contrib/rsbuild-plugin-google-analytics):
+For example, add Google analytics through [rsbuild-plugin-google-analytics](https://github.com/rstackjs/rsbuild-plugin-google-analytics):
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from '@rspress/core';

--- a/website/docs/en/plugin/community-plugins/overview.mdx
+++ b/website/docs/en/plugin/community-plugins/overview.mdx
@@ -5,21 +5,21 @@
 Community plugins include:
 
 - [rspress-plugin-translate](https://github.com/byteHulk/rspress-plugin-translate): A plugin that integrates LLM for document translation.
-- [rspress-plugin-font-open-sans](https://github.com/rspack-contrib/rspress-plugin-font-open-sans): Use Open Sans as the default font in your Rspress website.
+- [rspress-plugin-font-open-sans](https://github.com/rstackjs/rspress-plugin-font-open-sans): Use Open Sans as the default font in your Rspress website.
   Rspress website.
-- [rspress-plugin-align-image](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-align-image): Rspress plugin to align images in markdown.
-- [rspress-plugin-directives](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-directives): Rspress plugin for custom directives support.
-- [rspress-plugin-file-tree](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-file-tree): Rspress plugin that add tree view for file structure display.
-- [rspress-plugin-gh-pages](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-gh-pages): Rspress plugin to add support for automatic deployment to GitHub Pages.
-- [rspress-plugin-google-analytics](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-google-analytics): Rspress plugin for Google Analytics integration.
-- [rspress-plugin-vercel-analytics](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-vercel-analytics): Rspress plugin for Vercel Analytics integration.
-- [rspress-plugin-katex](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-katex): Rspress plugin to add support for rendering math equations using [KaTeX](https://katex.org/).
-- [rspress-plugin-live2d](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-live2d): Rspress plugin for live2d, powered by [on-my-live2d](https://oml2d.com/).
-- [rspress-plugin-mermaid](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-mermaid): Rspress plugin to render [Mermaid](https://mermaid.js.org/#/) diagrams in markdown files.
-- [rspress-plugin-reading-time](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-reading-time): Rspress plugin to display reading time for your document pages.
-- [rspress-plugin-supersub](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-supersub): Rspress plugin to add superscript(`<super></super>`) and subscript(`<sub></sub>`) support.
-- [rspress-plugin-toc](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-toc): Rspress plugin that injects a table of contents into the page.
+- [rspress-plugin-align-image](https://github.com/rstackjs/rspress-plugins/tree/main/packages/rspress-plugin-align-image): Rspress plugin to align images in markdown.
+- [rspress-plugin-directives](https://github.com/rstackjs/rspress-plugins/tree/main/packages/rspress-plugin-directives): Rspress plugin for custom directives support.
+- [rspress-plugin-file-tree](https://github.com/rstackjs/rspress-plugins/tree/main/packages/rspress-plugin-file-tree): Rspress plugin that add tree view for file structure display.
+- [rspress-plugin-gh-pages](https://github.com/rstackjs/rspress-plugins/tree/main/packages/rspress-plugin-gh-pages): Rspress plugin to add support for automatic deployment to GitHub Pages.
+- [rspress-plugin-google-analytics](https://github.com/rstackjs/rspress-plugins/tree/main/packages/rspress-plugin-google-analytics): Rspress plugin for Google Analytics integration.
+- [rspress-plugin-vercel-analytics](https://github.com/rstackjs/rspress-plugins/tree/main/packages/rspress-plugin-vercel-analytics): Rspress plugin for Vercel Analytics integration.
+- [rspress-plugin-katex](https://github.com/rstackjs/rspress-plugins/tree/main/packages/rspress-plugin-katex): Rspress plugin to add support for rendering math equations using [KaTeX](https://katex.org/).
+- [rspress-plugin-live2d](https://github.com/rstackjs/rspress-plugins/tree/main/packages/rspress-plugin-live2d): Rspress plugin for live2d, powered by [on-my-live2d](https://oml2d.com/).
+- [rspress-plugin-mermaid](https://github.com/rstackjs/rspress-plugins/tree/main/packages/rspress-plugin-mermaid): Rspress plugin to render [Mermaid](https://mermaid.js.org/#/) diagrams in markdown files.
+- [rspress-plugin-reading-time](https://github.com/rstackjs/rspress-plugins/tree/main/packages/rspress-plugin-reading-time): Rspress plugin to display reading time for your document pages.
+- [rspress-plugin-supersub](https://github.com/rstackjs/rspress-plugins/tree/main/packages/rspress-plugin-supersub): Rspress plugin to add superscript(`<super></super>`) and subscript(`<sub></sub>`) support.
+- [rspress-plugin-toc](https://github.com/rstackjs/rspress-plugins/tree/main/packages/rspress-plugin-toc): Rspress plugin that injects a table of contents into the page.
 
-You can check out the Rspress plugins provided by the community at [awesome-rspack - Rspress Plugins](https://github.com/web-infra-dev/awesome-rspack?tab=readme-ov-file#rspress-plugins).
+You can check out the Rspress plugins provided by the community at [awesome-rstack - Rspress Plugins](https://github.com/rstackjs/awesome-rstack?tab=readme-ov-file#rspress-plugins).
 
 You can also discover more Rspress plugins on npm by searching for the keyword [rspress-plugin](https://www.npmjs.com/search?q=rspress-plugin&ranking=popularity).

--- a/website/docs/zh/api/config/config-build.mdx
+++ b/website/docs/zh/api/config/config-build.mdx
@@ -63,7 +63,7 @@ export default defineConfig({
 });
 ```
 
-- 示例：通过 [rsbuild-plugin-google-analytics](https://github.com/rspack-contrib/rsbuild-plugin-google-analytics) 添加 Google analytics。
+- 示例：通过 [rsbuild-plugin-google-analytics](https://github.com/rstackjs/rsbuild-plugin-google-analytics) 添加 Google analytics。
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from '@rspress/core';
@@ -81,7 +81,7 @@ export default defineConfig({
 });
 ```
 
-- 示例：通过 [rsbuild-plugin-open-graph](https://github.com/rspack-contrib/rsbuild-plugin-open-graph) 添加 Open Graph meta 标签。
+- 示例：通过 [rsbuild-plugin-open-graph](https://github.com/rstackjs/rsbuild-plugin-open-graph) 添加 Open Graph meta 标签。
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from '@rspress/core';

--- a/website/docs/zh/guide/advanced/extend-build.mdx
+++ b/website/docs/zh/guide/advanced/extend-build.mdx
@@ -26,7 +26,7 @@ export default defineConfig({
 
 Rspress 还提供了 [builderConfig.plugins](/api/config/config-build#builderconfigplugins) 配置项来注册 Rsbuild 插件。你可以利用 Rsbuild 丰富的插件生态来增强和扩展构建能力。
 
-比如通过 [rsbuild-plugin-google-analytics](https://github.com/rspack-contrib/rsbuild-plugin-google-analytics) 添加 Google analytics：
+比如通过 [rsbuild-plugin-google-analytics](https://github.com/rstackjs/rsbuild-plugin-google-analytics) 添加 Google analytics：
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from '@rspress/core';

--- a/website/docs/zh/plugin/community-plugins/overview.mdx
+++ b/website/docs/zh/plugin/community-plugins/overview.mdx
@@ -5,20 +5,20 @@
 社区插件包括:
 
 - [rspress-plugin-translate](https://github.com/byteHulk/rspress-plugin-translate)：集成 LLM 进行文档翻译的插件。
-- [rspress-plugin-font-open-sans](https://github.com/rspack-contrib/rspress-plugin-font-open-sans): 使用 Open Sans 作为 Rspress 网站中的默认字体。
-- [rspress-plugin-align-image](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-align-image): 让 markdown 中的图片居中展示.
-- [rspress-plugin-directives](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-directives): 支持自定义的指令到全局组件转换逻辑.
-- [rspress-plugin-file-tree](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-file-tree): 支持文件树的可视化展示.
-- [rspress-plugin-gh-pages](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-gh-pages): 自动部署到 GitHub Pages.
-- [rspress-plugin-google-analytics](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-google-analytics): 为 Rspress 站点集成 Google Analytics.
-- [rspress-plugin-vercel-analytics](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-vercel-analytics): 为 Rspress 站点集成 Vercel Analytics.
-- [rspress-plugin-katex](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-katex): 支持在 markdown 中编写数学公式，并使用 [KaTeX](https://katex.org/) 渲染.
-- [rspress-plugin-live2d](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-live2d): 为你的 Rspress 站点添加看板娘，基于 [on-my-live2d](https://oml2d.com/).
-- [rspress-plugin-mermaid](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-mermaid): 为 Rspress 支持基于 [Mermaid](https://mermaid.js.org/#/) 的流程图、时序图等.
-- [rspress-plugin-reading-time](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-reading-time): 计算每一页文档的预计阅读时间，并在文档的正上方展示.
-- [rspress-plugin-supersub](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-supersub): 为 Rspress 支持 上标(`<super></super>`) 与 下标(`<sub></sub>`) 语法.
-- [rspress-plugin-toc](https://github.com/rspack-contrib/rspress-plugins/tree/main/packages/rspress-plugin-toc): 自动为你的文档页面生成内容导航。
+- [rspress-plugin-font-open-sans](https://github.com/rstackjs/rspress-plugin-font-open-sans): 使用 Open Sans 作为 Rspress 网站中的默认字体。
+- [rspress-plugin-align-image](https://github.com/rstackjs/rspress-plugins/tree/main/packages/rspress-plugin-align-image): 让 markdown 中的图片居中展示.
+- [rspress-plugin-directives](https://github.com/rstackjs/rspress-plugins/tree/main/packages/rspress-plugin-directives): 支持自定义的指令到全局组件转换逻辑.
+- [rspress-plugin-file-tree](https://github.com/rstackjs/rspress-plugins/tree/main/packages/rspress-plugin-file-tree): 支持文件树的可视化展示.
+- [rspress-plugin-gh-pages](https://github.com/rstackjs/rspress-plugins/tree/main/packages/rspress-plugin-gh-pages): 自动部署到 GitHub Pages.
+- [rspress-plugin-google-analytics](https://github.com/rstackjs/rspress-plugins/tree/main/packages/rspress-plugin-google-analytics): 为 Rspress 站点集成 Google Analytics.
+- [rspress-plugin-vercel-analytics](https://github.com/rstackjs/rspress-plugins/tree/main/packages/rspress-plugin-vercel-analytics): 为 Rspress 站点集成 Vercel Analytics.
+- [rspress-plugin-katex](https://github.com/rstackjs/rspress-plugins/tree/main/packages/rspress-plugin-katex): 支持在 markdown 中编写数学公式，并使用 [KaTeX](https://katex.org/) 渲染.
+- [rspress-plugin-live2d](https://github.com/rstackjs/rspress-plugins/tree/main/packages/rspress-plugin-live2d): 为你的 Rspress 站点添加看板娘，基于 [on-my-live2d](https://oml2d.com/).
+- [rspress-plugin-mermaid](https://github.com/rstackjs/rspress-plugins/tree/main/packages/rspress-plugin-mermaid): 为 Rspress 支持基于 [Mermaid](https://mermaid.js.org/#/) 的流程图、时序图等.
+- [rspress-plugin-reading-time](https://github.com/rstackjs/rspress-plugins/tree/main/packages/rspress-plugin-reading-time): 计算每一页文档的预计阅读时间，并在文档的正上方展示.
+- [rspress-plugin-supersub](https://github.com/rstackjs/rspress-plugins/tree/main/packages/rspress-plugin-supersub): 为 Rspress 支持 上标(`<super></super>`) 与 下标(`<sub></sub>`) 语法.
+- [rspress-plugin-toc](https://github.com/rstackjs/rspress-plugins/tree/main/packages/rspress-plugin-toc): 自动为你的文档页面生成内容导航。
 
-你可以在 [awesome-rspack - Rspress Plugins](https://github.com/web-infra-dev/awesome-rspack?tab=readme-ov-file#rspress-plugins) 中查看社区提供的 Rspress 插件。
+你可以在 [awesome-rstack - Rspress Plugins](https://github.com/rstackjs/awesome-rstack?tab=readme-ov-file#rspress-plugins) 中查看社区提供的 Rspress 插件。
 
 也可以在 npm 上搜索 [rspress-plugin](https://www.npmjs.com/search?q=rspress-plugin&ranking=popularity) 关键词来发现更多 Rspress 插件。


### PR DESCRIPTION
## Summary

We have renamed the GitHub organization from `rspack-contrib` to `rstackjs` (https://github.com/rstackjs).

This change better reflects the Rstack brand and its growing ecosystem, while also providing a shorter organization name.

Existing links will continue to redirect correctly.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
