### PR TITLE
docs: add missing Layout slots (beforeNavMenu, afterNav) and add Layout Slots heading (Vibe Kanban)

### DIFF
--- a/website/docs/en/guide/basic/custom-theme.mdx
+++ b/website/docs/en/guide/basic/custom-theme.mdx
@@ -141,7 +141,9 @@ export * from '@rspress/core/theme-original';
 
 </Tabs>
 
-It's worth noting that the `Layout` component is designed with a series of props to support slot elements. You can use these props to extend the default theme layout:
+### Layout slots
+
+The `Layout` component is designed with a series of props to support slot elements. You can use these props to extend the default theme layout:
 
 <details>
 
@@ -176,13 +178,17 @@ const Layout = () => (
     afterDocContent={<div>afterDocContent</div>}
     /* Before nav bar */
     beforeNav={<div>beforeNav</div>}
+    /* After nav bar */
+    afterNav={<div>afterNav</div>}
     /* Before upper left nav bar title */
     beforeNavTitle={<span>😄</span>}
     /* Nav bar title */
     navTitle={<div>Custom Nav Title</div>}
     /* After upper left nav bar title */
     afterNavTitle={<div>afterNavTitle</div>}
-    /* Upper right corner of nav bar */
+    /* Before nav bar menu */
+    beforeNavMenu={<div>beforeNavMenu</div>}
+    /* After nav bar menu */
     afterNavMenu={<div>afterNavMenu</div>}
     /* Above left sidebar */
     beforeSidebar={<div>beforeSidebar</div>}

--- a/website/docs/zh/guide/basic/custom-theme.mdx
+++ b/website/docs/zh/guide/basic/custom-theme.mdx
@@ -141,7 +141,9 @@ export * from '@rspress/core/theme-original';
 
 </Tabs>
 
-值得注意的是，`Layout` 组件设计了一系列的 props 支持插槽元素，你可以通过这些 props 来扩展默认主题的布局：
+### Layout 插槽
+
+`Layout` 组件设计了一系列的 props 支持插槽元素，你可以通过这些 props 来扩展默认主题的布局：
 
 <details>
 
@@ -176,13 +178,17 @@ const Layout = () => (
     afterDocContent={<div>afterDocContent</div>}
     /* 导航栏之前 */
     beforeNav={<div>beforeNav</div>}
+    /* 导航栏之后 */
+    afterNav={<div>afterNav</div>}
     /* 左上角导航栏标题之前 */
     beforeNavTitle={<span>😄</span>}
     /* 导航栏标题 */
     navTitle={<div>Custom Nav Title</div>}
     /* 左上角导航栏标题之后 */
     afterNavTitle={<div>afterNavTitle</div>}
-    /* 导航栏右上角部分 */
+    /* 导航栏菜单之前 */
+    beforeNavMenu={<div>beforeNavMenu</div>}
+    /* 导航栏菜单之后 */
     afterNavMenu={<div>afterNavMenu</div>}
     /* 左侧侧边栏上面 */
     beforeSidebar={<div>beforeSidebar</div>}


### PR DESCRIPTION
## Summary

This PR improves the custom theme documentation by:

- Adding missing `beforeNavMenu` and `afterNav` slot documentation to the Layout component props
- Adding a "Layout Slots" / "Layout 插槽" subheading for better documentation structure

## Changes Made

### Missing Slots Added
- `beforeNavMenu` - Content rendered before the nav bar menu
- `afterNav` - Content rendered after the nav bar

These slots were available in the Layout component (`packages/core/src/theme/layout/Layout/index.tsx`) but were not documented.

### Documentation Structure
- Added `### Layout Slots` (English) / `### Layout 插槽` (Chinese) heading to clearly identify the slot props section
- Updated the comment for `afterNavMenu` to be more descriptive ("After nav bar menu" instead of "Upper right corner of nav bar")

## Why

The documentation was incomplete - users looking to customize their theme layout could not discover the `beforeNavMenu` and `afterNav` slots without reading the source code. This PR ensures all Layout slots are properly documented.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)