### PR TITLE
feat(theme): support clickable badge in HomeHero

### DIFF
--- a/packages/core/src/theme/components/HomeHero/index.scss
+++ b/packages/core/src/theme/components/HomeHero/index.scss
@@ -78,10 +78,18 @@
     font-size: 0.875rem;
     font-weight: 500;
     color: var(--rp-c-text-0);
+    text-decoration: none;
+    transition:
+      background 0.2s,
+      border-color 0.2s;
 
     &:hover {
       background: var(--rp-c-bg-mute);
       cursor: pointer;
+    }
+
+    &:is(a):hover {
+      border-color: var(--rp-c-brand);
     }
   }
 

--- a/packages/core/src/theme/components/HomeHero/index.tsx
+++ b/packages/core/src/theme/components/HomeHero/index.tsx
@@ -1,6 +1,6 @@
 import type { FrontMatterMeta } from '@rspress/core';
 import { normalizeImagePath, useFrontmatter } from '@rspress/core/runtime';
-import { Button, renderHtmlOrText } from '@theme';
+import { Button, Link, renderHtmlOrText } from '@theme';
 
 import './index.scss';
 import clsx from 'clsx';
@@ -39,7 +39,16 @@ function HomeHero({ beforeHeroActions, afterHeroActions }: HomeHeroProps) {
       className={clsx('rp-home-hero', { 'rp-home-hero--no-image': !hasImage })}
     >
       <div className="rp-home-hero__container">
-        {hero.badge && <div className="rp-home-hero__badge">{hero.badge}</div>}
+        {hero.badge &&
+          (typeof hero.badge === 'string' ? (
+            <div className="rp-home-hero__badge">{hero.badge}</div>
+          ) : hero.badge.link ? (
+            <Link href={hero.badge.link} className="rp-home-hero__badge">
+              {hero.badge.text}
+            </Link>
+          ) : (
+            <div className="rp-home-hero__badge">{hero.badge.text}</div>
+          ))}
         <div className="rp-home-hero__content">
           <div className="rp-home-hero__title">
             <span

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -384,7 +384,7 @@ export type RemotePageInfo = PageIndexInfo & {
 };
 
 export interface Hero {
-  badge?: string;
+  badge?: string | { text: string; link?: string };
   name?: string;
   text?: string;
   tagline?: string;


### PR DESCRIPTION
This PR enhances the `HomeHero` component by allowing the badge to be a clickable link.

**Features:**

- The `badge` property in the frontmatter now accepts an object with `text` and `link`.
- If a `link` is provided, the badge will be rendered as a link.
- Adds a hover effect for the clickable badge.

**Usage:**

**New Usage (Clickable):**

```yaml
hero:
  badge:
    text: Rspress is officially released!
    link: /guide/
```

**Old Usage (Backward compatible):**

```yaml
hero:
  badge: Rspress is officially released!
```