### PR TITLE
feat(theme): icon field support svg and img icon in HomeLayout

### DIFF
--- a/packages/core/src/theme/components/HomeFeature/index.scss
+++ b/packages/core/src/theme/components/HomeFeature/index.scss
@@ -97,6 +97,12 @@
     background-color: var(--rp-c-bg);
     border-radius: 1rem;
     border: 3px solid var(--rp-c-divider-light);
+
+    img,
+    svg {
+      width: 1.5rem;
+      height: 1.5rem;
+    }
   }
 
   &__title {

--- a/packages/core/src/theme/components/HomeFeature/index.tsx
+++ b/packages/core/src/theme/components/HomeFeature/index.tsx
@@ -1,9 +1,26 @@
 import type { Feature } from '@rspress/core';
 import { useFrontmatter } from '@rspress/core/runtime';
-import { renderHtmlOrText, useLinkNavigate } from '@theme';
+import { renderHtmlOrText, SvgWrapper, useLinkNavigate } from '@theme';
 import type { JSX } from 'react';
 import './index.scss';
 import { useCardAnimation } from './useCardAnimation';
+
+/**
+ * Check if a string should be rendered by SvgWrapper
+ * - SVG inline string (starts with `<svg`)
+ * - URL/path (starts with `/`, `./`, `../`, `http://`, `https://`)
+ */
+function shouldUseSvgWrapper(str: string): boolean {
+  const trimmed = str.trim();
+  return (
+    trimmed.startsWith('<svg') ||
+    trimmed.startsWith('/') ||
+    trimmed.startsWith('./') ||
+    trimmed.startsWith('../') ||
+    trimmed.startsWith('http://') ||
+    trimmed.startsWith('https://')
+  );
+}
 
 const getGridClass = (feature: Feature): string => {
   const { span } = feature;
@@ -48,10 +65,13 @@ function HomeFeatureItem({ feature }: { feature: Feature }): JSX.Element {
         >
           <div className="rp-home-feature__title-wrapper">
             {icon ? (
-              <div
-                className="rp-home-feature__icon"
-                {...renderHtmlOrText(icon)}
-              ></div>
+              <div className="rp-home-feature__icon">
+                {shouldUseSvgWrapper(icon) ? (
+                  <SvgWrapper icon={icon} />
+                ) : (
+                  <span {...renderHtmlOrText(icon)} />
+                )}
+              </div>
             ) : null}
 
             <h2 className="rp-home-feature__title">{title}</h2>

--- a/packages/core/src/theme/components/SvgWrapper/index.tsx
+++ b/packages/core/src/theme/components/SvgWrapper/index.tsx
@@ -1,19 +1,49 @@
 /**
+ * Check if a string is a URL or file path
+ */
+function isUrlOrPath(str: string): boolean {
+  return (
+    str.startsWith('/') ||
+    str.startsWith('./') ||
+    str.startsWith('../') ||
+    str.startsWith('http://') ||
+    str.startsWith('https://')
+  );
+}
+
+type SvgWrapperProps = {
+  icon: string | React.FC<React.SVGProps<SVGSVGElement>>;
+} & React.SVGProps<SVGSVGElement>;
+
+/**
  * A wrapper for custom SVG icon.
  * When the user uses a custom SVG, the imported icon can be a string or a React component.
+ * - React component: render directly
+ * - SVG string (starts with `<svg`): render with dangerouslySetInnerHTML
+ * - URL/path: render with `<img>`
  * @internal
  */
-export function SvgWrapper({
-  icon: Icon,
-  ...rest
-}: {
-  icon: string | React.FC<React.SVGProps<SVGSVGElement>>;
-} & React.SVGAttributes<SVGSVGElement | HTMLImageElement>) {
+export function SvgWrapper({ icon: Icon, ...rest }: SvgWrapperProps) {
   if (!Icon) {
     return null;
   }
   if (typeof Icon === 'string') {
-    return <img src={Icon} alt="" {...rest} />;
+    const { className } = rest;
+    // SVG inline string
+    if (Icon.trim().startsWith('<svg')) {
+      return (
+        <span
+          className={className}
+          dangerouslySetInnerHTML={{ __html: Icon }}
+        />
+      );
+    }
+    // URL or file path
+    if (isUrlOrPath(Icon)) {
+      return <img className={className} src={Icon} alt="" />;
+    }
+    // Fallback: return null for non-URL strings (emoji/text should be handled elsewhere)
+    return null;
   }
 
   return <Icon {...rest} />;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -413,6 +413,13 @@ export interface Hero {
 }
 
 export interface Feature {
+  /**
+   * Feature icon, supports:
+   * - Emoji: '🚀'
+   * - HTML string: '<span class="icon">...</span>'
+   * - SVG string: '<svg>...</svg>'
+   * - Image URL: '/icons/feature.svg' or 'https://example.com/icon.png'
+   */
   icon: string;
   title: string;
   details: string;

--- a/website/docs/en/ui/components/home-feature.mdx
+++ b/website/docs/en/ui/components/home-feature.mdx
@@ -43,7 +43,13 @@ const features = [
 
 ```ts
 interface Feature {
-  /** Feature icon, supports emoji or HTML string */
+  /**
+   * Feature icon, supports:
+   * - Emoji: '🚀'
+   * - HTML string: '<span class="icon">...</span>'
+   * - SVG string: '<svg>...</svg>'
+   * - Image URL: '/icons/feature.svg' or 'https://example.com/icon.png'
+   */
   icon: string;
   /** Feature title */
   title: string;
@@ -57,5 +63,6 @@ interface Feature {
 ```
 
 - `span` controls how many grid columns each card occupies, out of 12 total columns
-- `icon` and `details` support HTML strings
+- `icon` supports emoji, HTML strings, SVG strings, and image URLs
+- `details` supports HTML strings
 - Set `link` to make the card clickable

--- a/website/docs/zh/ui/components/home-feature.mdx
+++ b/website/docs/zh/ui/components/home-feature.mdx
@@ -36,7 +36,13 @@ import { HomeFeature } from '@rspress/core/theme';
 
 ```ts
 interface Feature {
-  /** 特性图标，支持 emoji 或 HTML 字符串 */
+  /**
+   * 特性图标，支持：
+   * - Emoji: '🚀'
+   * - HTML 字符串: '<span class="icon">...</span>'
+   * - SVG 字符串: '<svg>...</svg>'
+   * - 图片 URL: '/icons/feature.svg' 或 'https://example.com/icon.png'
+   */
   icon: string;
   /** 特性标题 */
   title: string;
@@ -50,5 +56,6 @@ interface Feature {
 ```
 
 - `span` 控制每个卡片占据的网格列数，总共 12 列
-- `icon` 和 `details` 支持 HTML 字符串
+- `icon` 支持 emoji、HTML 字符串、SVG 字符串、图片 URL
+- `details` 支持 HTML 字符串
 - 设置 `link` 后卡片可点击跳转


### PR DESCRIPTION
## Summary

<human>

## AI summary

---

This PR enhances the `HomeFeatures` component by extending the functionality of the `icon` property in the frontmatter.

Previously, the `icon` field was limited to displaying only emoji characters, which restricted its use cases.

With this update, the `icon` property now also supports SVG icons and image URLs, providing greater flexibility for customization. This is achieved by using a new `SvgWrapper` component that can render different types of icons.

The documentation for the `HomeFeatures` component has also been updated to reflect this new capability.

This PR was written using [Vibe Kanban](https://vibekanban.com)

---

## Related Links