### PR TITLE
chore(deps): update rspress-plugin-file-tree to ^1.0.3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1704,8 +1704,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0(@rsbuild/core@1.7.1)
       rspress-plugin-file-tree:
-        specifier: ^1.0.2
-        version: 1.0.2(@rspress/core@packages+core)
+        specifier: ^1.0.3
+        version: 1.0.3(@rspress/core@packages+core)
       rspress-plugin-font-open-sans:
         specifier: ^1.0.3
         version: 1.0.3(@rspress/core@packages+core)
@@ -6322,8 +6322,8 @@ packages:
     peerDependencies:
       '@rspress/core': ^2.0.0-rc.4 || ^2.0.0
 
-  rspress-plugin-file-tree@1.0.2:
-    resolution: {integrity: sha512-OKQgb5zYklXHWKMVVKPSVMWTdJVpV+r2RrP18GxAhvvKLe7kmKgDY+I11jwDA5/mn70I2Yio/RPE88oL/dm1zg==}
+  rspress-plugin-file-tree@1.0.3:
+    resolution: {integrity: sha512-+z07cGbtxRELATSdDiM/TzsTfgxnycPgTNBjrzhljz9c4boaXCXX7X8slMBLY/QrZMRzIvV74sijoJT2V4iUhw==}
     peerDependencies:
       '@rspress/core': ^2.0.0-rc.4 || ^2.0.0
 
@@ -12890,7 +12890,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rspress-plugin-file-tree@1.0.2(@rspress/core@packages+core):
+  rspress-plugin-file-tree@1.0.3(@rspress/core@packages+core):
     dependencies:
       '@rspress/core': link:packages/core
       rspress-plugin-devkit: 1.0.0(@rspress/core@packages+core)

--- a/website/package.json
+++ b/website/package.json
@@ -23,7 +23,7 @@
     "react-dom": "^19.2.3",
     "rsbuild-plugin-google-analytics": "^1.0.4",
     "rsbuild-plugin-open-graph": "^1.1.0",
-    "rspress-plugin-file-tree": "^1.0.2",
+    "rspress-plugin-file-tree": "^1.0.3",
     "rspress-plugin-font-open-sans": "^1.0.3",
     "rspress-plugin-og": "npm:@soonit/rspress-plugin-og@0.1.2",
     "tm-themes": "1.10.13",


### PR DESCRIPTION
## Summary

Update `rspress-plugin-file-tree` dependency from `^1.0.2` to `^1.0.3`.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

---

## AI Summary

### Changes Made
- Updated `rspress-plugin-file-tree` dependency version from `^1.0.2` to `^1.0.3` in `website/package.json`
- Updated `pnpm-lock.yaml` to reflect the new version

### Why
This is a routine dependency update to keep the rspress-plugin-file-tree plugin at its latest patch version, which may include bug fixes and minor improvements.

### Implementation Details
- The update is a minor patch version bump (1.0.2 → 1.0.3)
- No breaking changes expected as this follows semver patch versioning
- Lock file has been regenerated with `pnpm install`

This PR was written using [Vibe Kanban](https://vibekanban.com)

---