### PR TITLE
docs: add documentation for markdown.crossCompilerCache option

### DIFF
--- a/website/docs/en/api/config/config-build.mdx
+++ b/website/docs/en/api/config/config-build.mdx
@@ -267,6 +267,25 @@ Whether to display the line number of the code block. Defaults to `false`.
 
 Whether to enable long code line wrapping display by default. Defaults to `false`.
 
+### markdown.crossCompilerCache
+
+- **Type**: `boolean`
+- **Default**: `true`
+
+Whether to enable cross-compiler cache for MDX compilation during `rspress build`. When enabled, Rspress will cache MDX parsing results across multiple compilers (web and node), which can speed up the production build process by approximately 10%.
+
+This option only takes effect in production builds and is inspired by [Docusaurus](https://docusaurus.io/).
+
+```ts title="rspress.config.ts"
+import { defineConfig } from '@rspress/core';
+
+export default defineConfig({
+  markdown: {
+    crossCompilerCache: true,
+  },
+});
+```
+
 ### markdown.globalComponents
 
 - **Type**: `string[]`

--- a/website/docs/zh/api/config/config-build.mdx
+++ b/website/docs/zh/api/config/config-build.mdx
@@ -269,6 +269,25 @@ export default defineConfig({
 
 是否默认启用长代码换行展示。默认为 `false`。
 
+### markdown.crossCompilerCache
+
+- **类型**: `boolean`
+- **默认值**: `true`
+
+是否在 `rspress build` 时启用跨编译器缓存。启用后，Rspress 会在多个编译器（web 和 node）之间缓存 MDX 解析结果，从而加速生产环境构建，构建时间可减少约 10%。
+
+该选项仅在生产环境构建时生效，灵感来自 [Docusaurus](https://docusaurus.io/)。
+
+```ts title="rspress.config.ts"
+import { defineConfig } from '@rspress/core';
+
+export default defineConfig({
+  markdown: {
+    crossCompilerCache: true,
+  },
+});
+```
+
 ### markdown.globalComponents
 
 - **类型**: `string[]`


### PR DESCRIPTION
## Summary

Add documentation for the `markdown.crossCompilerCache` configuration option in both English and Chinese.

## Related Issue

https://github.com/web-infra-dev/rspress/pull/2256

## Checklist

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).

---

### Changes Made

Added documentation for `markdown.crossCompilerCache` in:
- `website/docs/en/api/config/config-build.mdx`
- `website/docs/zh/api/config/config-build.mdx`

### Documentation Details

The `crossCompilerCache` option was introduced in PR #2256 but was not documented at the time. This PR adds the missing documentation with:

- **Type**: `boolean`
- **Default**: `true`
- **Description**: Enables cross-compiler cache for MDX compilation during production builds, caching parsing results across web and node compilers
- **Performance benefit**: Approximately 10% faster build times
- **Note**: Only takes effect in production builds, inspired by Docusaurus

This PR was written using [Vibe Kanban](https://vibekanban.com)

---