### PR TITLE
fix(theme/nav): Fixed small layout shift on scroll

### DIFF
--- a/packages/core/src/theme/components/HomeBackground/useNavTransparent.tsx
+++ b/packages/core/src/theme/components/HomeBackground/useNavTransparent.tsx
@@ -36,7 +36,8 @@ export const useNavTransparent = () => {
 
   return (
     <style>
-      {'body:not(.notTopArrived) .rp-nav {background: transparent !important; border-bottom: none !important;}' +
+      {'body:not(.notTopArrived) ' +
+        '.rp-nav {background: transparent !important; border-bottom: 1px solid transparent !important;}' +
         // TODO: discussion
         '.rp-nav {background: color-mix(in srgb,var(--rp-c-bg) 60%,transparent);backdrop-filter: blur(25px);}'}
     </style>


### PR DESCRIPTION
## Summary

When scrolling: as the nav bar transitions to having a bottom border and a blurred background, the layout of the icons would shift up slightly due to the bottom border size changing. To fix this I've made it so that the bottom border is always 1px but is transparent by default. This prevents the layout shift when scrolling.

Super tiny PR but spotted this while experimenting with the latest release candidate.

### Before

https://github.com/user-attachments/assets/84b9d598-b0ca-4dad-a4c4-fc87560373d2

### After


https://github.com/user-attachments/assets/4cd6ec76-e61c-469c-9cde-b64ecfc2635d




## Related Issue

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
