### PR TITLE
fix(theme): Fixed step counter text alignment

### DIFF
--- a/packages/core/src/theme/components/Steps/index.scss
+++ b/packages/core/src/theme/components/Steps/index.scss
@@ -21,6 +21,7 @@
       justify-content: center;
       font-size: 1.1rem;
       font-weight: 400;
+      line-height: 30px;
       color: var(--rp-c-text-1);
       background-color: var(--rp-code-block-bg);
       border: 1.5px solid var(--rp-c-text-3);


### PR DESCRIPTION
## Summary

The text in the stepper counter was not quite centered because of how text renders. I've set the line height to match the height of the `:before` such that the alignment should now be more centered vertically.

Sorry for more small PRs for these tiny things I'm noticing as I tinker.

This essentially amounts to like a 1 pixel difference.

### Before

<img width="499" height="129" alt="image" src="https://github.com/user-attachments/assets/474e215c-bd44-4a66-9ddd-6bd27b7cbc19" />

### After

<img width="499" height="129" alt="image" src="https://github.com/user-attachments/assets/c4eedeba-1b33-4a0c-9653-aba88dd14e14" />

### Diff

<img width="499" height="129" alt="diff" src="https://github.com/user-attachments/assets/9fe84367-2d6a-48cf-930a-b3bd4ae43f19" />

## Related Issue

N/A

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
