### PR TITLE
perf(e2e): enable parallel workers for Playwright tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,8 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   // exclude webpack / rspack self-feature test cases when run rspack / webpack test
   testDir: './e2e',
+  fullyParallel: true,
+  workers: process.env.CI ? 4 : undefined,
   // 30 min for all tests
   globalTimeout: 30 * 60 * 1000,
   // 1 min for each test


### PR DESCRIPTION
## Summary

- Enable parallel test execution by adding `fullyParallel: true` to Playwright config
- This allows tests to run across multiple workers simultaneously, reducing total e2e test time

## Before
```
Running 176 tests using 1 worker
176 passed (5.3m)
```

## After
Tests will run in parallel using multiple workers (default: half of CPU cores), expected to reduce test time to ~1-2 minutes.

## Test plan
- [x] Verified port conflicts are handled by `getPort()` dynamic allocation
- [x] Verified each fixture is independent with no shared state

🤖 Generated with [Claude Code](https://claude.com/claude-code)