### PR TITLE
refactor(plugin-rss)!: requires the `ssg` config, and remove `_html` field

### DIFF
--- a/e2e/fixtures/plugin-rss/doc/index.md
+++ b/e2e/fixtures/plugin-rss/doc/index.md
@@ -2,4 +2,4 @@
 link-rss: blog
 ---
 
-Nothing but should have rss <link>
+Nothing but should have rss `<link>`

--- a/packages/plugin-rss/src/createFeed.ts
+++ b/packages/plugin-rss/src/createFeed.ts
@@ -12,9 +12,14 @@ import type { FeedChannel, FeedItem } from './type';
 /**
  * @public
  * @param page Rspress Page Data
- * @param siteUrl
+ * @param siteUrl Site URL for generating absolute links
+ * @param htmlContent HTML content extracted from SSG output (optional)
  */
-export function generateFeedItem(page: PageIndexInfo, siteUrl: string) {
+export function generateFeedItem(
+  page: PageIndexInfo,
+  siteUrl: string,
+  htmlContent?: string | null,
+) {
   const { frontmatter: fm } = page;
   return {
     id: selectNonNullishProperty(fm.slug, fm.id, page.routePath) || '',
@@ -28,7 +33,9 @@ export function generateFeedItem(page: PageIndexInfo, siteUrl: string) {
       ) || '',
     ),
     description: selectNonNullishProperty(fm.description) || '',
-    content: selectNonNullishProperty(fm.summary, page._html) || '',
+    // Priority: frontmatter.summary > SSG HTML content > plain text content
+    content:
+      selectNonNullishProperty(fm.summary, htmlContent, page.content) || '',
     date: toDate((fm.date as string) || (fm.published_at as string))!,
     category: concatArray(fm.categories as string[], fm.category as string).map(
       cat => ({ name: cat }),

--- a/packages/plugin-rss/src/internals/node.ts
+++ b/packages/plugin-rss/src/internals/node.ts
@@ -9,3 +9,52 @@ export async function writeFile(
   await promises.mkdir(dir, { mode: 0o755, recursive: true });
   return promises.writeFile(path, content);
 }
+
+export async function readFile(path: string): Promise<string | null> {
+  try {
+    return await promises.readFile(path, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Convert routePath to HTML file path
+ * e.g. '/blog/foo/' -> 'blog/foo/index.html'
+ * e.g. '/blog/foo' -> 'blog/foo.html'
+ */
+export function routePathToHtmlPath(routePath: string): string {
+  let fileName = routePath;
+  if (fileName.endsWith('/')) {
+    fileName = `${routePath}index.html`;
+  } else {
+    fileName = `${routePath}.html`;
+  }
+  return fileName.replace(/^\/+/, '');
+}
+
+/**
+ * Extract content from HTML using regex to find .rspress-doc container
+ * This extracts the innerHTML of the element with class "rspress-doc"
+ */
+export function extractHtmlContent(html: string): string | null {
+  // Match the content inside <div class="rp-doc rspress-doc" ...>...</div>
+  // The content ends before </div><footer or </div></main
+  const match = html.match(
+    /<div[^>]*class="[^"]*rspress-doc[^"]*"[^>]*>([\s\S]*?)<\/div>(?=<footer|<\/main)/,
+  );
+  if (match) {
+    return match[1].trim();
+  }
+
+  // Fallback: try to find any element with rspress-doc class
+  // Use a greedy approach but stop at common ending patterns
+  const fallbackMatch = html.match(
+    /<div[^>]*class="[^"]*rspress-doc[^"]*"[^>]*>([\s\S]*?)<\/div>/,
+  );
+  if (fallbackMatch) {
+    return fallbackMatch[1].trim();
+  }
+
+  return null;
+}

--- a/packages/plugin-rss/src/plugin-rss.ts
+++ b/packages/plugin-rss/src/plugin-rss.ts
@@ -8,7 +8,14 @@ import { Feed } from 'feed';
 
 import { createFeed, generateFeedItem } from './createFeed';
 import { PluginComponents, PluginName } from './exports';
-import { concatArray, type ResolvedOutput, writeFile } from './internals';
+import {
+  concatArray,
+  extractHtmlContent,
+  type ResolvedOutput,
+  readFile,
+  routePathToHtmlPath,
+  writeFile,
+} from './internals';
 import { getDefaultFeedOption, getOutputInfo, testPage } from './options';
 import type { FeedChannel, FeedItem, PluginRssOptions } from './type';
 
@@ -47,17 +54,26 @@ class FeedsSet {
   }
 }
 
-function getRssItems(
+interface PageRssInfo {
+  page: PageIndexInfo;
+  channels: string[];
+}
+
+async function getRssItems(
   feeds: TransformedFeedChannel[],
   page: PageIndexInfo,
   siteUrl: string,
+  htmlContent: string | null,
 ): Promise<FeedItemWithChannel[]> {
   return Promise.all(
     feeds
       .filter(options => testPage(options.test, page))
       .map(async options => {
         const after = options.item || ((feed: FeedItem) => feed);
-        const item = await after(generateFeedItem(page, siteUrl), page);
+        const item = await after(
+          generateFeedItem(page, siteUrl, htmlContent),
+          page,
+        );
         return { ...item, channel: options.id };
       }),
   );
@@ -67,20 +83,17 @@ export function pluginRss(pluginRssOptions: PluginRssOptions): RspressPlugin {
   const feedsSet = new FeedsSet();
 
   /**
-   * workaround for retrieving data of pages in `afterBuild`
-   * TODO: get pageData list directly in `afterBuild`
-   **/
-  let _rssWorkaround: null | Record<
-    string,
-    PromiseLike<FeedItemWithChannel[]>
-  > = null;
+   * Store page data for generating RSS items in afterBuild
+   * Key: routePath, Value: PageRssInfo
+   */
+  let _pagesForRss: null | Map<string, PageRssInfo> = null;
 
   return {
     name: PluginName,
     globalUIComponents: Object.values(PluginComponents),
     beforeBuild(config, isProd) {
       if (!isProd) {
-        _rssWorkaround = null;
+        _pagesForRss = null;
         return;
       }
 
@@ -93,61 +106,85 @@ export function pluginRss(pluginRssOptions: PluginRssOptions): RspressPlugin {
         );
       }
 
-      _rssWorkaround = {};
+      _pagesForRss = new Map();
       feedsSet.set(pluginRssOptions, config);
     },
     async extendPageData(pageData) {
-      if (!_rssWorkaround) return;
+      if (!_pagesForRss) return;
 
-      // rspress run `extendPageData` for each page
-      //   - let's cache rss items within a complete rspress build
-      _rssWorkaround[pageData.routePath] =
-        _rssWorkaround[pageData.routePath] ||
-        getRssItems(feedsSet.get(), pageData, pluginRssOptions.siteUrl);
+      // Find which feeds this page belongs to
+      const matchedChannels = feedsSet
+        .get()
+        .filter(options => testPage(options.test, pageData))
+        .map(options => options.id);
 
-      const feeds = await _rssWorkaround[pageData.routePath];
+      if (matchedChannels.length > 0) {
+        _pagesForRss.set(pageData.routePath, {
+          page: pageData,
+          channels: matchedChannels,
+        });
+      }
+
+      // Set up feed links for the page
       const showRssList = new Set(
         concatArray(pageData.frontmatter['link-rss'] as string[] | string),
       );
-      for (const feed of feeds) {
-        showRssList.add(feed.channel);
+      for (const channel of matchedChannels) {
+        showRssList.add(channel);
       }
 
       pageData.feeds = Array.from(showRssList, id => {
-        const { output, language } = feedsSet.get(id)!;
+        const feedChannel = feedsSet.get(id);
+        if (!feedChannel) return null;
+        const { output, language } = feedChannel;
         return {
           url: output.url,
           mime: output.mime,
           language: language || pageData.lang,
         };
-      });
+      }).filter(Boolean) as typeof pageData.feeds;
     },
     async afterBuild(config) {
-      if (!_rssWorkaround) return;
+      if (!_pagesForRss) return;
 
-      const items = concatArray(
-        ...(await Promise.all(Object.values(_rssWorkaround))),
-      );
+      const outDir = config.outDir || 'doc_build';
       const feeds: Record<string, Feed> = Object.create(null);
 
-      for (const { channel, ...item } of items) {
-        feeds[channel] =
-          feeds[channel] ||
-          new Feed(createFeed(feedsSet.get(channel)!, config));
-        feeds[channel].addItem(item);
+      // Process each page: read HTML from SSG output and generate feed items
+      for (const [routePath, { page, channels }] of _pagesForRss) {
+        // Read HTML content from SSG output
+        const htmlPath = NodePath.resolve(
+          outDir,
+          routePathToHtmlPath(routePath),
+        );
+        const htmlFile = await readFile(htmlPath);
+        const htmlContent = htmlFile ? extractHtmlContent(htmlFile) : null;
+
+        // Generate feed items for each channel
+        const items = await getRssItems(
+          channels.map(id => feedsSet.get(id)!),
+          page,
+          pluginRssOptions.siteUrl,
+          htmlContent,
+        );
+
+        for (const { channel, ...item } of items) {
+          feeds[channel] =
+            feeds[channel] ||
+            new Feed(createFeed(feedsSet.get(channel)!, config));
+          feeds[channel].addItem(item);
+        }
       }
 
+      // Write feed files
       for (const [channel, feed] of Object.entries(feeds)) {
         const { output } = feedsSet.get(channel)!;
         feed.items.sort(output.sorting);
-        const path = NodePath.resolve(
-          config.outDir || 'doc_build',
-          output.dir,
-          output.filename,
-        );
+        const path = NodePath.resolve(outDir, output.dir, output.filename);
         await writeFile(path, output.getContent(feed));
       }
-      _rssWorkaround = null;
+
+      _pagesForRss = null;
     },
   };
 }


### PR DESCRIPTION
## Summary

Refactor `plugin-rss`, read HTML content from the SSG build output, replacing the deleted `page._html` attribute.

## Related Issue

closes https://github.com/web-infra-dev/rspress/issues/2290

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).

---



---