### PR TITLE
feat(core): add logoHref config option

### DIFF
--- a/packages/core/src/node/runtimeModule/siteData/createSiteData.ts
+++ b/packages/core/src/node/runtimeModule/siteData/createSiteData.ts
@@ -24,6 +24,7 @@ export async function createSiteData(userConfig: UserConfig): Promise<{
     locales: userConfig?.locales || userConfig.themeConfig?.locales || [],
     logo: userConfig?.logo || '',
     logoText: userConfig?.logoText || '',
+    logoHref: userConfig?.logoHref || '',
     multiVersion: {
       default: userConfig?.multiVersion?.default || '',
       versions: userConfig?.multiVersion?.versions || [],

--- a/packages/core/src/theme/components/NavTitle/index.tsx
+++ b/packages/core/src/theme/components/NavTitle/index.tsx
@@ -21,7 +21,7 @@ export const NavTitle = () => {
   const title = (localeInfo?.title ?? site.title) || 'Home';
   const langRoutePrefix = lang === defaultLang ? '/' : addTrailingSlash(lang);
 
-  const { logo: rawLogo, logoText } = site;
+  const { logo: rawLogo, logoText, logoHref } = site;
   const logo = useMemo(() => {
     if (!rawLogo) {
       return null;
@@ -57,7 +57,7 @@ export const NavTitle = () => {
   return (
     <div className="rp-nav__title">
       <Link
-        href={addLeadingSlash(langRoutePrefix)}
+        href={logoHref || addLeadingSlash(langRoutePrefix)}
         className="rp-nav__title__link"
       >
         {logo && <div className="rp-nav__title__logo">{logo}</div>}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -134,6 +134,11 @@ export interface UserConfig {
    */
   logoText?: string;
   /**
+   * Custom link for the logo.
+   * @default '/${lang}/'
+   */
+  logoHref?: string;
+  /**
    * Base path of the site.
    * @default '/'
    */
@@ -340,6 +345,7 @@ export interface SiteData {
   themeConfig: NormalizedDefaultThemeConfig;
   logo: string | { dark: string; light: string };
   logoText: string;
+  logoHref: string;
   search: SearchOptions;
   markdown: {
     showLineNumbers: boolean;

--- a/website/docs/en/api/config/config-basic.mdx
+++ b/website/docs/en/api/config/config-basic.mdx
@@ -205,6 +205,22 @@ export default defineConfig({
 });
 ```
 
+## logoHref
+
+- **Type**: `string`
+- **Default**: `/${lang}/`
+
+Custom link for the logo. By default, clicking the logo will navigate to the home page of the current language. For example:
+
+```ts title="rspress.config.ts"
+import { defineConfig } from '@rspress/core';
+
+export default defineConfig({
+  logo: '/logo.png',
+  logoHref: 'https://example.com',
+});
+```
+
 ## logoText
 
 - **Type**: `string`

--- a/website/docs/zh/api/config/config-basic.mdx
+++ b/website/docs/zh/api/config/config-basic.mdx
@@ -205,6 +205,22 @@ export default defineConfig({
 });
 ```
 
+## logoHref
+
+- **类型**： `string`
+- **默认值**： `/${lang}/`
+
+自定义 logo 的链接。默认情况下点击 logo 会跳转到当前语言的首页。例如：
+
+```ts title="rspress.config.ts"
+import { defineConfig } from '@rspress/core';
+
+export default defineConfig({
+  logo: '/logo.png',
+  logoHref: 'https://example.com',
+});
+```
+
 ## logoText
 
 - **类型**： `string`


### PR DESCRIPTION
## Summary

Add a new `logoHref` configuration option to customize the logo link destination.

## Related Issue

closes https://github.com/web-infra-dev/rspress/issues/2952

close https://github.com/web-infra-dev/rspress/issues/2963

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

---

## AI Summary

### What changes were made

1. **Type definitions** (`packages/shared/src/types/index.ts`):
   - Added new `logoHref` property to `UserConfig` interface with default value `/${lang}/`
   - Added `logoHref` property to `SiteData` interface

2. **createSiteData** (`packages/core/src/node/runtimeModule/siteData/createSiteData.ts`):
   - Added `logoHref` to the siteData object

3. **NavTitle component** (`packages/core/src/theme/components/Nav/NavTitle.tsx`):
   - Extract `logoHref` from site config
   - Use `logoHref || defaultHref` for the Link component, prioritizing custom href over the default language home page

4. **Documentation** (English and Chinese):
   - Added new `logoHref` configuration section with type `string` and default value `/${lang}/`
   - Added usage examples

### Why these changes were made

Users requested the ability to customize the logo link destination (e.g., to link to an external website or a different internal page). This feature enables that flexibility while maintaining backward compatibility - if `logoHref` is not specified, the logo still links to the current language's home page as before.

### Usage

```ts
export default defineConfig({
  logo: '/logo.png',
  logoHref: 'https://example.com',
});
```

This PR was written using [Vibe Kanban](https://vibekanban.com)

---