### PR TITLE
feat(theme/nav): Added fancy transition to nav background

### DIFF
--- a/packages/core/src/theme/components/Nav/index.scss
+++ b/packages/core/src/theme/components/Nav/index.scss
@@ -1,6 +1,6 @@
 .rp-nav {
   transition:
-    background 0.2s ease-in-out,
+    background-color 0.2s ease-in-out,
     border-bottom 0.2s ease-in-out;
   display: flex;
   height: var(--rp-nav-height);


### PR DESCRIPTION
## Summary

Just adds a transition to the background and bottom border of the nav bar to make the scrolling less jarring on the screen.


https://github.com/user-attachments/assets/cedfb208-d974-4de9-a9ba-9f2f8ef09166


## Related Issue

N/A

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
