### PR TITLE
fix(core): improve i18n missing keys warning with configuration hints

### DIFF
--- a/packages/core/src/node/runtimeModule/i18n.ts
+++ b/packages/core/src/node/runtimeModule/i18n.ts
@@ -109,8 +109,9 @@ export async function getI18nData(
 
   if (logKeys.size > 0 && !logged) {
     logger.warn(
-      `${logPrefix} The following i18n keys are missing for some languages and have fallen back to 'en': 
-      ${picocolors.gray(JSON.stringify(Object.fromEntries([...logKeys.keys()].map(i => [i, '...'])), null, 2))}`,
+      `${logPrefix} The following i18n keys are missing for some languages and have fallen back to 'en':
+      ${picocolors.gray(JSON.stringify(Object.fromEntries([...logKeys.keys()].map(i => [i, '...'])), null, 2))}
+      You can provide translations via ${picocolors.cyan('i18n.json')} file or ${picocolors.cyan('i18nSource')} config in rspress.config.ts`,
     );
     logged = true;
   }


### PR DESCRIPTION
## Summary

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

---

## AI Summary

### Changes Made
Improved the i18n warning message to include helpful configuration hints when translation keys are missing for some languages.

### Before
When i18n keys were missing, users saw:
```
[i18n] The following i18n keys are missing for some languages and have fallen back to 'en':
      { "key": "..." }
```

### After
The warning now includes guidance on how to provide translations:
```
[i18n] The following i18n keys are missing for some languages and have fallen back to 'en':
      { "key": "..." }
      You can provide translations via i18n.json file or i18nSource config in rspress.config.ts
```

### Why
This improves developer experience by immediately pointing users to the two ways they can provide missing translations:
1. Creating an `i18n.json` file in the project root
2. Using the `i18nSource` configuration option in `rspress.config.ts`

This PR was written using [Vibe Kanban](https://vibekanban.com)

---