### PR TITLE
perf(core): skip search index generation when search is disabled

### DIFF
--- a/packages/core/src/node/runtimeModule/pageData/createPageData.ts
+++ b/packages/core/src/node/runtimeModule/pageData/createPageData.ts
@@ -35,11 +35,16 @@ export async function createPageData(context: FactoryContext): Promise<{
 
   const replaceRules = userConfig?.replaceRules || [];
 
-  const searchConfig = userConfig?.search || {};
+  const searchConfig = userConfig?.search;
+  const searchEnabled = searchConfig !== false;
 
   // If the dev server restart when config file, we will reuse the siteData instead of extracting the siteData from source files again.
   const searchCodeBlocks =
-    'codeBlocks' in searchConfig ? Boolean(searchConfig.codeBlocks) : true;
+    searchConfig &&
+    typeof searchConfig === 'object' &&
+    'codeBlocks' in searchConfig
+      ? Boolean(searchConfig.codeBlocks)
+      : true;
 
   const pages = await extractPageData(routeService, {
     replaceRules,
@@ -47,6 +52,7 @@ export async function createPageData(context: FactoryContext): Promise<{
     root: userDocRoot,
     searchCodeBlocks,
     extractDescription: userConfig.markdown?.extractDescription,
+    searchEnabled,
   });
   // modify page index by plugins
   await pluginDriver.modifySearchIndexData(pages);


### PR DESCRIPTION
## Summary

Optimize build performance by skipping search index content generation when `search: false` is configured.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).

---

## AI Summary

### What changes were made

1. **Added `searchEnabled` option to `ExtractPageDataOptions`** in `extractPageData.ts`
   - New optional boolean parameter to control search index generation

2. **Modified `getPageIndexInfoByRoute` function** in `extractPageData.ts`
   - When `searchEnabled` is `false`, the function now returns early with:
     - Empty `content` field (no search content generated)
     - TOC items with `charIndex: -1` (skip character index calculation)
     - Essential metadata preserved (title, description, frontmatter)
   - Skips expensive operations: `processor.run()` and `processor.stringify()`

3. **Updated `createPageData` function** in `createPageData.ts`
   - Determines `searchEnabled` based on whether `search` config is `false`
   - Fixed `searchCodeBlocks` logic to properly handle when `searchConfig` is `false`
   - Passes `searchEnabled` to `extractPageData`

### Why these changes were made

When users configure `search: false` in their Rspress config (e.g., when using external search solutions like Algolia), the build process was still performing unnecessary work to generate search index content. This optimization:

- Reduces build time by skipping markdown processing for search
- Reduces memory usage by not storing search content
- Maintains all other page metadata needed for rendering

### Implementation details

- The optimization is applied at the earliest possible point in `extractPageData.ts`
- Basic page information (title, TOC structure, frontmatter, description) is still extracted for other features
- Only search-specific processing is skipped (content stringification and charIndex calculation)
- Default behavior (`searchEnabled: true`) is preserved for backward compatibility

This PR was written using [Vibe Kanban](https://vibekanban.com)

---