### PR TITLE
docs(1.x): update create rspress command to use version 1.x `npm create rspress@1.x`

### DIFF
--- a/packages/create-rspress/README.md
+++ b/packages/create-rspress/README.md
@@ -5,7 +5,7 @@ Create a new Rspress project.
 Using `npm create`:
 
 ```bash
-npm create rspress@latest
+npm create rspress@1.x
 ```
 
 Using CLI flags:

--- a/packages/document/docs/en/guide/start/getting-started.mdx
+++ b/packages/document/docs/en/guide/start/getting-started.mdx
@@ -8,7 +8,7 @@ import { PackageManagerTabs } from '@theme';
 
 You can create a Rspress project using the `create-rspress` cli:
 
-<PackageManagerTabs command="create rspress@latest" />
+<PackageManagerTabs command="create rspress@1.x" />
 
 Input the project directory name, and then the cli will create the project for you.
 

--- a/packages/document/docs/zh/guide/start/getting-started.mdx
+++ b/packages/document/docs/zh/guide/start/getting-started.mdx
@@ -8,7 +8,7 @@ import { PackageManagerTabs } from '@theme';
 
 你可以通过 Rspress 脚手架命令来创建项目:
 
-<PackageManagerTabs command="create rspress@latest" />
+<PackageManagerTabs command="create rspress@1.x" />
 
 然后按照提示输入项目名称，即可创建一个 Rspress 项目。
 


### PR DESCRIPTION
## Summary

Updated the documentation to use `npm create rspress@1.x`.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).

---

### AI Summary

**Changes:**
- Updated `packages/create-rspress/README.md` to use `npm create rspress@1.x`.
- Updated `packages/document/docs/en/guide/start/getting-started.mdx` and `packages/document/docs/zh/guide/start/getting-started.mdx` to use `create rspress@1.x` in the `<PackageManagerTabs>` component.

**Reasoning:**
These changes were made to guide users to create projects using the specific `1.x` version tag instead of `latest`. This ensures better version control and stability for new projects.

This PR was written using [Vibe Kanban](https://vibekanban.com)
---
