### PR TITLE
docs: update home feature gap and remove V2 badge from homepage

### DIFF
--- a/packages/core/src/theme/components/HomeFeature/index.scss
+++ b/packages/core/src/theme/components/HomeFeature/index.scss
@@ -1,5 +1,5 @@
 .rp-home-feature {
-  --rp-home-feature-gap: 0.5rem;
+  --rp-home-feature-gap: 15px;
   overflow: hidden;
   margin: auto;
   display: flex;

--- a/website/docs/en/index.md
+++ b/website/docs/en/index.md
@@ -4,7 +4,6 @@ title: Rspress
 titleSuffix: 'Rsbuild-based Static Site Generator'
 
 hero:
-  badge: Rspress V2 is coming! 🚀
   name: Rspress
   text: Lightning Fast Static Site Generator
   tagline: Simple, efficient and easy to extend

--- a/website/docs/zh/index.md
+++ b/website/docs/zh/index.md
@@ -4,7 +4,6 @@ title: Rspress
 titleSuffix: '基于 Rsbuild 的静态站点生成器'
 
 hero:
-  badge: Rspress V2 即将发布! 🚀
   name: Rspress
   text: |
     快如闪电的


### PR DESCRIPTION
## Summary

<!-- This is the area edited by humans. -->

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## AI Summary

---

### Changes Made

1. **Updated `--rp-home-feature-gap` CSS variable**
   - File: `packages/core/src/theme/components/HomeFeature/index.scss`
   - Changed from `0.5rem` to `15px` for more precise control over homepage feature card spacing

2. **Removed V2 badge from homepage**
   - File: `website/docs/en/index.md` - Removed `badge: Rspress V2 is coming! 🚀`
   - File: `website/docs/zh/index.md` - Removed `badge: Rspress V2 即将发布! 🚀`
   - Since V2 has been released (rc.8), the "coming soon" badge is no longer needed

This PR was written using [Vibe Kanban](https://vibekanban.com)

---