### PR TITLE
fix(plugin-preview): handle preEntry as string type

### DIFF
--- a/packages/plugin-preview/src/index.ts
+++ b/packages/plugin-preview/src/index.ts
@@ -85,7 +85,7 @@ export function pluginPreview(options?: Options): RspressPlugin {
           entry: await generateEntry(globalDemos, framework, customEntry),
           preEntry: [
             join(STATIC_DIR, 'iframe', 'entry.css'),
-            ...(builderConfig.source?.preEntry ?? []),
+            ...[builderConfig.source?.preEntry ?? []].flat(),
           ],
         },
         html: {


### PR DESCRIPTION
## Summary

<!-- This is the area edited by humans. -->

## Related Issue


## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## AI Summary

---

### What changes were made

Fixed the `preEntry` configuration handling in `@rspress/plugin-preview` to properly support both `string` and `string[]` types.

**Before:**
```typescript
...(builderConfig.source?.preEntry ?? [])
```

**After:**
```typescript
...[builderConfig.source?.preEntry ?? []].flat()
```

### Why they were made

According to Rsbuild's type definition, `preEntry` can be either `string | string[]`. The original code assumed `preEntry` was always an array. When a user passes a string value, the spread operator would incorrectly split the string into individual characters (e.g., `"./styles.css"` would become `[".", "/", "s", "t", "y", "l", "e", "s", ".", "c", "s", "s"]`).

### Implementation details

Using `[value].flat()` pattern to normalize the input:
- If `preEntry` is `undefined`: `[[]].flat()` → `[]`
- If `preEntry` is a string: `["./styles.css"].flat()` → `["./styles.css"]`
- If `preEntry` is an array: `[["a.css", "b.css"]].flat()` → `["a.css", "b.css"]`

This PR was written using [Vibe Kanban](https://vibekanban.com)

---