### PR TITLE
docs(plugin-preview): add preEntry usage tips for iframe-fixed mode

### DIFF
--- a/website/docs/en/plugin/official-plugins/preview.mdx
+++ b/website/docs/en/plugin/official-plugins/preview.mdx
@@ -174,6 +174,28 @@ Rendering result:
 
 ![](https://lf3-static.bytednsdoc.com/obj/eden-cn/uhbfnupenuhf/rspress/demo-preview-mobile-fixed.png)
 
+:::tip preEntry Tips
+
+You can inject global scripts or styles into the iframe preview environment using `iframeOptions.builderConfig.source.preEntry`. Here are some common use cases:
+
+- **Mobile touch event emulation**: Emulate mobile touch events on PC by importing [@vant/touch-emulator](https://www.npmjs.com/package/@vant/touch-emulator).
+
+- **Dark mode handling**: Inject a `MutationObserver` to watch for `html.dark` class changes, then sync to `body.dark` or perform other dark mode processing.
+
+```ts title="rspress.config.ts"
+pluginPreview({
+  iframeOptions: {
+    builderConfig: {
+      source: {
+        preEntry: ['@vant/touch-emulator', './src/dark-mode-observer.js'],
+      },
+    },
+  },
+});
+```
+
+:::
+
 ## Options
 
 This plugin accepts a configuration object with the following type definition:

--- a/website/docs/zh/plugin/official-plugins/preview.mdx
+++ b/website/docs/zh/plugin/official-plugins/preview.mdx
@@ -174,6 +174,28 @@ iframe 预览模式中的代码有单独的编译环境和运行环境。
 
 ![](https://lf3-static.bytednsdoc.com/obj/eden-cn/uhbfnupenuhf/rspress/demo-preview-mobile-fixed.png)
 
+:::tip preEntry 技巧
+
+你可以通过 `iframeOptions.builderConfig.source.preEntry` 在 iframe 预览环境中注入全局脚本或样式，以下是一些常见用法：
+
+- **移动端 touch 事件模拟**：在 PC 端模拟移动端触摸事件，可以引入 [@vant/touch-emulator](https://www.npmjs.com/package/@vant/touch-emulator)。
+
+- **处理暗黑模式**：注入 `MutationObserver` 监听 `html.dark` 变化，同步到 `body.dark` 或进行其他暗黑模式处理。
+
+```ts title="rspress.config.ts"
+pluginPreview({
+  iframeOptions: {
+    builderConfig: {
+      source: {
+        preEntry: ['@vant/touch-emulator', './src/dark-mode-observer.js'],
+      },
+    },
+  },
+});
+```
+
+:::
+
 ## 配置
 
 该插件接受一个配置对象，类型定义如下：


### PR DESCRIPTION
## Summary

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).

---

## AI Summary

This PR adds documentation for `iframeOptions.builderConfig.source.preEntry` usage tips in the plugin-preview documentation, specifically in the `preview="iframe-fixed"` section.

### Changes Made

Added a new tip section in both English and Chinese documentation that explains how to use `preEntry` for common scenarios:

- **Mobile touch event emulation**: How to use [@vant/touch-emulator](https://www.npmjs.com/package/@vant/touch-emulator) to emulate mobile touch events on PC for mobile component library development.

- **Dark mode handling**: How to inject a `MutationObserver` to watch for `html.dark` class changes and sync dark mode state to the iframe preview environment.

Includes a configuration example showing how to set up `preEntry` in `rspress.config.ts`.

### Why These Changes

The `preEntry` configuration is particularly useful for mobile component library documentation using `iframe-fixed` mode, where developers often need:
1. Touch event simulation for testing mobile interactions on desktop
2. Dark mode synchronization between the documentation site and the iframe preview

This PR was written using [Vibe Kanban](https://vibekanban.com)

---