### PR TITLE
fix(Nav): conditionally render appearance switch based on darkMode setting (#3068)

### DIFF
--- a/e2e/fixtures/i18n/index.test.ts
+++ b/e2e/fixtures/i18n/index.test.ts
@@ -103,13 +103,14 @@ test.describe('i18n test', async () => {
     await expect(sidebarGroups).toHaveCount(1);
   });
 
-  test('Should render appearance switch button', async ({ page }) => {
+  test('Should not render appearance switch button when darkMode is false', async ({
+    page,
+  }) => {
     await page.goto(`http://localhost:${appPort}/guide/basic/quick-start`, {
       waitUntil: 'networkidle',
     });
     const button = page.locator('.rp-switch-appearance');
-    await expect(button).toHaveCount(1);
-    await expect(button).toBeVisible();
+    await expect(button).toHaveCount(0);
   });
 
   test('Should not 404 after redirecting in first visit', async ({ page }) => {

--- a/packages/core/src/theme/components/Nav/index.tsx
+++ b/packages/core/src/theme/components/Nav/index.tsx
@@ -1,4 +1,4 @@
-import { useNav } from '@rspress/core/runtime';
+import { useNav, useSite } from '@rspress/core/runtime';
 import {
   NavHamburger,
   NavTitle,
@@ -27,6 +27,8 @@ export function Nav(props: NavProps) {
     navTitle,
   } = props;
   const navList = useNav();
+  const { site } = useSite();
+  const hasAppearanceSwitch = site.themeConfig.darkMode !== false;
 
   return (
     <header className="rp-nav">
@@ -48,7 +50,7 @@ export function Nav(props: NavProps) {
           <NavMenuDivider />
           <NavLangs />
           <NavVersions />
-          <SwitchAppearance />
+          {hasAppearanceSwitch && <SwitchAppearance />}
           <SocialLinks />
         </div>
 


### PR DESCRIPTION
## Summary

Don't render the SwitchAppearance component in the Nav bar when Dark Mode is off.

## Related Issue

#3068 

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (**not required**).
