### PR TITLE
docs: update Rspress 1.x documentation links

### DIFF
--- a/website/docs/en/_nav.json
+++ b/website/docs/en/_nav.json
@@ -29,7 +29,7 @@
       },
       {
         "text": "Rspress 1.x Docs",
-        "link": "http://v1.rspress.rs/"
+        "link": "https://v1.rspress.rs/"
       }
     ]
   }

--- a/website/docs/zh/_nav.json
+++ b/website/docs/zh/_nav.json
@@ -29,7 +29,7 @@
       },
       {
         "text": "Rspress 1.x 文档",
-        "link": "http://v1.rspress.rs/zh/"
+        "link": "https://v1.rspress.rs/zh/"
       }
     ]
   }


### PR DESCRIPTION
## Summary

Update Rspress 1.x documentation links, from `http://rspress.rs/` to `https://v1.rspress.rs/`

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
