### PR TITLE
fix(theme): Fixed overviewgroup item text wrapping

### DIFF
--- a/packages/core/src/theme/components/OverviewGroup/index.scss
+++ b/packages/core/src/theme/components/OverviewGroup/index.scss
@@ -118,6 +118,7 @@
           font-size: 14px;
           color: var(--rp-c-text-2);
           text-decoration: none;
+          word-break: normal;
           transition:
             color 0.2s ease,
             background-color 0.2s ease;


### PR DESCRIPTION
## Summary

In the overview group, individual link items would wrap text poorly such that the words could be split in the middle of the word. This just changes it such that if the item does require text wrapping then the word will be split more naturally.

### Before

<img width="1196" height="384" alt="localhost_3000_" src="https://github.com/user-attachments/assets/b2b857dd-4474-4ed8-b094-af145ee0d108" />

### After

<img width="1196" height="384" alt="localhost_3000_ (1)" src="https://github.com/user-attachments/assets/882cc836-83a6-4f7a-bb66-ab8cb2b815d1" />

## Related Issue

N/A

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
