### PR TITLE
chore(deps): update rspress-plugin-file-tree to ^1.0.4

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1736,8 +1736,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(@rsbuild/core@2.0.0-beta.0(@module-federation/runtime-tools@0.22.0)(core-js@3.47.0))
       rspress-plugin-file-tree:
-        specifier: ^1.0.3
-        version: 1.0.3(@rspress/core@packages+core)
+        specifier: ^1.0.4
+        version: 1.0.4(@rspress/core@packages+core)
       rspress-plugin-font-open-sans:
         specifier: ^1.0.3
         version: 1.0.3(@rspress/core@packages+core)
@@ -6347,8 +6347,8 @@ packages:
     peerDependencies:
       '@rspress/core': ^2.0.0-rc.4 || ^2.0.0
 
-  rspress-plugin-file-tree@1.0.3:
-    resolution: {integrity: sha512-+z07cGbtxRELATSdDiM/TzsTfgxnycPgTNBjrzhljz9c4boaXCXX7X8slMBLY/QrZMRzIvV74sijoJT2V4iUhw==}
+  rspress-plugin-file-tree@1.0.4:
+    resolution: {integrity: sha512-VItnE51w/EDOdvliEnLKBNz2VVmOFx1zdZr8HfjII7Tu8/GQg+BtShjZR0Z8oYtP6zyxheY2H81pe2J4Wdwh0g==}
     peerDependencies:
       '@rspress/core': ^2.0.0-rc.4 || ^2.0.0
 
@@ -10282,14 +10282,14 @@ snapshots:
 
   esast-util-from-estree@2.0.0:
     dependencies:
-      '@types/estree-jsx': 1.0.0
+      '@types/estree-jsx': 1.0.5
       devlop: 1.1.0
       estree-util-visit: 2.0.0
       unist-util-position-from-estree: 2.0.0
 
   esast-util-from-js@2.0.1:
     dependencies:
-      '@types/estree-jsx': 1.0.0
+      '@types/estree-jsx': 1.0.5
       acorn: 8.15.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.2
@@ -10341,7 +10341,7 @@ snapshots:
 
   estree-util-visit@2.0.0:
     dependencies:
-      '@types/estree-jsx': 1.0.0
+      '@types/estree-jsx': 1.0.5
       '@types/unist': 3.0.3
 
   estree-walker@2.0.2: {}
@@ -12852,7 +12852,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rspress-plugin-file-tree@1.0.3(@rspress/core@packages+core):
+  rspress-plugin-file-tree@1.0.4(@rspress/core@packages+core):
     dependencies:
       '@rspress/core': link:packages/core
       rspress-plugin-devkit: 1.0.0(@rspress/core@packages+core)

--- a/website/package.json
+++ b/website/package.json
@@ -25,7 +25,7 @@
     "react-dom": "^19.2.4",
     "rsbuild-plugin-google-analytics": "^1.0.5",
     "rsbuild-plugin-open-graph": "^1.1.2",
-    "rspress-plugin-file-tree": "^1.0.3",
+    "rspress-plugin-file-tree": "^1.0.4",
     "rspress-plugin-font-open-sans": "^1.0.3",
     "rspress-plugin-og": "npm:@soonit/rspress-plugin-og@0.1.2",
     "tm-themes": "1.10.16",


### PR DESCRIPTION
## Summary
- Update `rspress-plugin-file-tree` from `^1.0.3` to `^1.0.4` in website dependencies

https://github.com/rstackjs/rspress-plugins/pull/22

## Test plan
- [ ] Verify website builds successfully with the updated dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)