### PR TITLE
fix(plugin-preview): support QR code scanning on mobile devices and first screen SSR

### DIFF
--- a/packages/plugin-preview/src/index.ts
+++ b/packages/plugin-preview/src/index.ts
@@ -67,6 +67,8 @@ export function pluginPreview(options?: Options): RspressPlugin {
     const rsbuildConfig = mergeRsbuildConfig(
       {
         server: {
+          // allow QR code scan on mobile devices and access through local network
+          host: true,
           port: devPort,
           printUrls: () => undefined,
           strictPort: true,
@@ -181,6 +183,9 @@ export function pluginPreview(options?: Options): RspressPlugin {
     builderConfig: {
       source: {
         include: [join(__dirname, '..')],
+        define: {
+          'process.env.RSPRESS_IFRAME_DEV_PORT': JSON.stringify(devPort),
+        },
       },
       tools: {
         bundlerChain(chain) {
@@ -220,13 +225,6 @@ export function pluginPreview(options?: Options): RspressPlugin {
           },
         },
       ],
-    },
-    extendPageData(pageData, isProd) {
-      if (!isProd) {
-        // Property 'devPort' does not exist on type 'PageIndexInfo'.
-        // @ts-expect-error
-        pageData.devPort = port;
-      }
     },
     markdown: {
       remarkPlugins: [

--- a/packages/plugin-preview/static/global-components/FixedDevice.tsx
+++ b/packages/plugin-preview/static/global-components/FixedDevice.tsx
@@ -1,7 +1,8 @@
-import { NoSSR, useDark, usePage, withBase } from '@rspress/core/runtime';
+import { useDark, usePage } from '@rspress/core/runtime';
 import { useCallback, useEffect, useRef, useState } from 'react';
 // @ts-expect-error
 import { normalizeId } from '../../dist/utils';
+import { getPageFullUrl, getPageUrl } from './common/getPageUrl';
 import MobileOperation from './common/PreviewOperations';
 import './FixedDevice.css';
 
@@ -9,15 +10,8 @@ export default () => {
   const { page } = usePage();
   const pageName = `${normalizeId(page.pagePath)}`;
   const demoId = `_${pageName}`;
-  const url = `~demo/${demoId}`;
   const { haveIframeFixedDemos } = page;
 
-  const getPageUrl = (url: string) => {
-    if (page?.devPort) {
-      return `http://localhost:${page.devPort}/${demoId}`;
-    }
-    return withBase(url);
-  };
   const [iframeKey, setIframeKey] = useState(0);
   const dark = useDark();
   const refresh = useCallback(() => {
@@ -50,16 +44,14 @@ export default () => {
       }
     }
     `}</style>
-      <NoSSR>
-        <iframe
-          src={getPageUrl(url)}
-          className="rp-fixed-device__iframe"
-          key={iframeKey}
-          ref={iframeRef}
-        />
-      </NoSSR>
+      <iframe
+        src={getPageUrl(demoId)}
+        className="rp-fixed-device__iframe"
+        key={iframeKey}
+        ref={iframeRef}
+      />
       <MobileOperation
-        url={getPageUrl(url)}
+        url={getPageFullUrl(demoId)}
         className="rp-fixed-device__operations"
         refresh={refresh}
       />

--- a/packages/plugin-preview/static/global-components/Preview.tsx
+++ b/packages/plugin-preview/static/global-components/Preview.tsx
@@ -1,4 +1,4 @@
-import { NoSSR, useDark, usePageData, withBase } from '@rspress/core/runtime';
+import { useDark } from '@rspress/core/runtime';
 import {
   type MouseEvent,
   useCallback,
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { getPageFullUrl, getPageUrl } from './common/getPageUrl';
 import MobileOperation from './common/PreviewOperations';
 import IconCode from './icons/Code';
 import './Preview.css';
@@ -18,12 +19,12 @@ type PreviewProps = {
 
 interface BasePreviewProps {
   children: React.ReactNode[];
-  getPageUrl: () => string;
+  demoId: string;
 }
 
 const PreviewIframeFollow: React.FC<BasePreviewProps> = ({
   children,
-  getPageUrl,
+  demoId,
 }) => {
   const [iframeKey, setIframeKey] = useState(0);
   const refresh = useCallback(() => {
@@ -48,11 +49,11 @@ const PreviewIframeFollow: React.FC<BasePreviewProps> = ({
       <div className="rp-preview--iframe-follow__device">
         <iframe
           className="rp-preview--iframe-follow__device__iframe"
-          src={getPageUrl()}
+          src={getPageUrl(demoId)}
           key={iframeKey}
           ref={iframeRef}
         />
-        <MobileOperation url={getPageUrl()} refresh={refresh} />
+        <MobileOperation url={getPageFullUrl(demoId)} refresh={refresh} />
       </div>
     </div>
   );
@@ -104,26 +105,15 @@ const PreviewInternal: React.FC<{ children: React.ReactNode[] }> = ({
 
 const Preview: React.FC<PreviewProps> = props => {
   const { children, previewMode, demoId } = props;
-  const { page } = usePageData();
-
-  const getPageUrl = useCallback(() => {
-    const url = `/~demo/${demoId}`;
-    if (page?.devPort) {
-      return `http://localhost:${page.devPort}/${demoId}`;
-    }
-    return withBase(url);
-  }, [page?.devPort, demoId]);
 
   return (
-    <NoSSR>
+    <>
       {previewMode === 'iframe-follow' ? (
-        <PreviewIframeFollow getPageUrl={getPageUrl}>
-          {children}
-        </PreviewIframeFollow>
+        <PreviewIframeFollow demoId={demoId}>{children}</PreviewIframeFollow>
       ) : (
         <PreviewInternal>{children}</PreviewInternal>
       )}
-    </NoSSR>
+    </>
   );
 };
 

--- a/packages/plugin-preview/static/global-components/common/getPageUrl.ts
+++ b/packages/plugin-preview/static/global-components/common/getPageUrl.ts
@@ -1,0 +1,26 @@
+import { withBase } from '@rspress/core/runtime';
+
+const DEV_PORT = process.env.RSPRESS_IFRAME_DEV_PORT;
+
+/*
+ * We must provide the complete address for scanning QR Code.
+ */
+export const getPageFullUrl = (demoId: string) => {
+  if (DEV_PORT && import.meta.env.DEV) {
+    return `http://${window.location.hostname}:${DEV_PORT}/${demoId}`;
+  }
+  const url = `/~demo/${demoId}`;
+  if (typeof window !== 'undefined') {
+    return `${window.location.origin}${withBase(url)}`;
+  }
+  // do nothing in ssr
+  return '';
+};
+
+export const getPageUrl = (demoId: string) => {
+  if (DEV_PORT && import.meta.env.DEV) {
+    return `http://${window.location.hostname}:${DEV_PORT}/${demoId}`;
+  }
+  const url = `/~demo/${demoId}`;
+  return withBase(url);
+};


### PR DESCRIPTION
## Summary
- Replace hardcoded `localhost` with `window.location.hostname` in iframe URLs, enabling mobile devices to access previews via QR code on the local network
- Set dev server `host: true` to listen on all network interfaces
- Extract shared `getPageUrl`/`getPageFullUrl` utility and use `source.define` instead of `extendPageData` for passing dev port

### Before
QR Code content

/~demo/_components_button

### After
QR Code content

https://rspress.rs/~demo/_components_button


<img width="833" height="508" alt="image" src="https://github.com/user-attachments/assets/3b63efdf-ead0-4e91-83cd-208f61db5cdf" />



