### PR TITLE
docs: translate Chinese labels to English

### DIFF
--- a/website/docs/en/api/_meta.json
+++ b/website/docs/en/api/_meta.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "section-header",
-    "label": "总览"
+    "label": "Overview"
   },
   {
     "type": "file",
@@ -10,7 +10,7 @@
   },
   {
     "type": "section-header",
-    "label": "配置"
+    "label": "Config"
   },
   {
     "type": "dir",


### PR DESCRIPTION
## Summary
Hi! Thank you for maintaining this great project.

I noticed that in the English API documentation (`website/docs/en/api/_meta.json`), two section header labels were still written in Chinese:
- `"总览"` → `"Overview"`
- `"配置"` → `"Config"`

<img width="1299" height="433" alt="image" src="https://github.com/user-attachments/assets/04a22c70-5279-40eb-b524-d6a56af88639" />

I believe these were unintentionally left untranslated when the English docs were created, so I've updated them to English.

Also, if there's an opportunity and it wouldn't be a bother, I'd love to contribute Korean translations for the documentation in the future!

Please let me know if any changes are needed. Thank you for your time! 

## Related Issue

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
