### PR TITLE
docs: update quick start to use @rspress/core instead of rspress

### DIFF
--- a/website/docs/en/guide/start/getting-started.mdx
+++ b/website/docs/en/guide/start/getting-started.mdx
@@ -26,7 +26,7 @@ mkdir rspress-app && cd rspress-app
 
 Execute `npm init -y` to initialize a project. You can install Rspress using npm, pnpm, yarn or bun:
 
-<PackageManagerTabs command="install rspress -D" />
+<PackageManagerTabs command="install @rspress/core -D" />
 
 Then create the file with the following command
 

--- a/website/docs/zh/guide/start/getting-started.mdx
+++ b/website/docs/zh/guide/start/getting-started.mdx
@@ -26,7 +26,7 @@ mkdir rspress-app && cd rspress-app
 
 执行 `npm init -y` 来初始化一个项目。你可以使用 npm、pnpm、yarn 或 bun 安装 Rspress:
 
-<PackageManagerTabs command="install rspress -D" />
+<PackageManagerTabs command="install @rspress/core -D" />
 
 然后通过如下命令创建文件:
 


### PR DESCRIPTION
## Summary

<!-- This is the area edited by humans. -->

## Related Issue

#3104

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## AI Summary

---

### What changed

Updated the "Quick Start" documentation in both Chinese (`zh`) and English (`en`) versions to change the package installation command from `rspress` to `@rspress/core`.

**Files modified:**
- `website/docs/zh/guide/start/getting-started.mdx`
- `website/docs/en/guide/start/getting-started.mdx`

### Why

The package name `rspress` has been deprecated in favor of `@rspress/core`. The documentation needed to be updated to reflect the correct package name that users should install.

### Details

Changed the `<PackageManagerTabs>` component command from:
```
install rspress -D
```
to:
```
install @rspress/core -D
```

This PR was written using [Vibe Kanban](https://vibekanban.com)

---