### PR TITLE
fix(theme): avoid selection gaps at line ends in code block

### DIFF
--- a/packages/core/src/theme/components/CodeBlock/index.scss
+++ b/packages/core/src/theme/components/CodeBlock/index.scss
@@ -50,9 +50,8 @@
     // #endregion text
 
     position: relative;
-    width: fit-content;
     margin: 0;
-    padding: 1rem 1.25rem;
+    padding: 1rem 0;
     background: transparent;
     z-index: 1;
   }
@@ -61,6 +60,7 @@
     font-size: var(--rp-code-font-size);
     font-family: var(--rp-font-family-mono);
     display: inline-block;
+    padding: 0 1.25rem;
     min-width: 100%;
     line-height: 1.7;
   }

--- a/packages/core/src/theme/styles/shiki.scss
+++ b/packages/core/src/theme/styles/shiki.scss
@@ -47,7 +47,9 @@
 
 .shiki.has-highlighted {
   .line.highlighted {
-    width: 100%;
+    width: calc(100% + 2.5rem);
+    margin: 0 -1.25rem;
+    padding: 0 1.25rem;
     position: static;
     display: inline-block;
   }


### PR DESCRIPTION
## Summary

| before | after |
| --- | --- |
| <img width="1300" height="438" alt="image" src="https://github.com/user-attachments/assets/9b0fe924-5e87-4e2c-b311-2d55a132963b" /> | <img width="1308" height="432" alt="image" src="https://github.com/user-attachments/assets/e7ad4353-17f7-4c18-89e2-b5a8fcf91f78" /> |

## Related Issue

*no response*

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
