### PR TITLE
docs(migration): add tip to fix broken links instead of disabling checkDeadLinks

### DIFF
--- a/website/docs/en/guide/migration/rspress-1-x.mdx
+++ b/website/docs/en/guide/migration/rspress-1-x.mdx
@@ -288,12 +288,16 @@ export default defineConfig({
 
 The following features are enabled by default in V2:
 
-| Feature                        | Description                             |
-| ------------------------------ | --------------------------------------- |
-| `markdown.link.checkDeadLinks` | Dead link checking with stricter logs   |
-| `search.codeBlocks`            | Search results include code blocks      |
-| `dev.lazyCompilation`          | Lazy compilation for faster dev startup |
-| `performance.buildCache`       | Persistent cache for faster builds      |
+| Feature                        | Description                                        |
+| ------------------------------ | -------------------------------------------------- |
+| `markdown.link.checkDeadLinks` | Dead link checking, fix broken links based on logs |
+| `search.codeBlocks`            | Search results include code blocks                 |
+| `dev.lazyCompilation`          | Lazy compilation for faster dev startup            |
+| `performance.buildCache`       | Persistent cache for faster builds                 |
+
+:::tip
+If you encounter dead link errors, try to fix the broken links rather than disabling the `markdown.link.checkDeadLinks` feature.
+:::
 
 To disable lazy compilation:
 

--- a/website/docs/zh/guide/migration/rspress-1-x.mdx
+++ b/website/docs/zh/guide/migration/rspress-1-x.mdx
@@ -274,12 +274,16 @@ export default defineConfig({
 
 以下功能在 V2 中默认开启：
 
-| 功能                           | 说明                 |
-| ------------------------------ | -------------------- |
-| `markdown.link.checkDeadLinks` | 死链检查，日志更严格 |
-| `search.codeBlocks`            | 搜索结果包含代码块   |
-| `dev.lazyCompilation`          | 懒编译加速开发启动   |
-| `performance.buildCache`       | 持久化缓存加速构建   |
+| 功能                           | 说明                             |
+| ------------------------------ | -------------------------------- |
+| `markdown.link.checkDeadLinks` | 死链检查，可按日志修复错误的链接 |
+| `search.codeBlocks`            | 搜索结果包含代码块               |
+| `dev.lazyCompilation`          | 懒编译加速开发启动               |
+| `performance.buildCache`       | 持久化缓存加速构建               |
+
+:::tip
+如果遇到死链检查的错误，建议优先修复坏掉的链接，而不是关闭 `markdown.link.checkDeadLinks` 功能。
+:::
 
 如需关闭懒编译：
 


### PR DESCRIPTION
## Summary

tips for agent

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).

---

## AI Summary

Update the Rspress 1.x → 2.x migration guide in both Chinese and English:

- Updated the `checkDeadLinks` description in the zh migration doc from "死链检查，日志更严格" to "死链检查，可按日志修复错误的链接" for clarity.
- Added a `:::tip` block after the default-enabled features table, advising users to fix broken links instead of disabling the `checkDeadLinks` feature when they encounter dead link errors.

This PR was written using [Vibe Kanban](https://vibekanban.com)

---