### PR TITLE
docs: add rendering flow image to SSG-MD guide

### DIFF
--- a/website/docs/en/guide/basic/ssg-md.mdx
+++ b/website/docs/en/guide/basic/ssg-md.mdx
@@ -69,6 +69,14 @@ In frontend frameworks based on React dynamic rendering, there is often a proble
 
 [Static Site Generation (SSG)](./ssg) can generate static HTML files for crawlers to crawl, improving [SEO](https://en.wikipedia.org/wiki/Search_engine_optimization). SSG-MD also solves similar problems, improving [GEO](https://en.wikipedia.org/wiki/Generative_engine_optimization) and the quality of static information for large language models. Compared to converting HTML to Markdown, React's virtual DOM during rendering has a better source of information.
 
+<div style={{ display: 'flex', justifyContent: 'center', marginTop: '1rem' }}>
+  <img
+    src="https://assets.rspack.rs/rspress/assets/ssg-md-flow.jpg"
+    width="600"
+    alt="SSG-MD rendering flow"
+  />
+</div>
+
 ## How to implement SSG-MD?
 
 1. Rspress internally implements a `renderToMarkdownString` method similar to `renderToString` in `react-dom`, which renders React components to Markdown strings:

--- a/website/docs/zh/guide/basic/ssg-md.mdx
+++ b/website/docs/zh/guide/basic/ssg-md.mdx
@@ -69,6 +69,14 @@ doc_build
 
 [静态站点生成（SSG）](./ssg) 可以生成静态的 HTML 文件供爬虫爬取，提升 [SEO](https://en.wikipedia.org/wiki/Search_engine_optimization)。SSG-MD 也是为了解决类似的问题，提升 [GEO](https://en.wikipedia.org/wiki/Generative_engine_optimization) 和面向大模型的静态信息质量。相比将 HTML 转化为 Markdown，React 在渲染期间的虚拟 DOM 拥有更好的信息源。
 
+<div style={{ display: 'flex', justifyContent: 'center', marginTop: '1rem' }}>
+  <img
+    src="https://assets.rspack.rs/rspress/assets/ssg-md-flow.jpg"
+    width="600"
+    alt="SSG-MD rendering flow"
+  />
+</div>
+
 ## 怎么实现 SSG-MD？
 
 1. Rspress 内部实现了类似 `react-dom` 中 `renderToString` 的 `renderToMarkdownString` 方法，将 React 组件渲染为 Markdown 字符串：


### PR DESCRIPTION
## Summary

add img

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an x -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).

---

### AI Generated Summary

This PR adds the "SSG-MD rendering flow" image to the "Why SSG-MD?" section in both the English and Chinese documentation (`guide/basic/ssg-md.mdx`).

**Changes:**
- Inserted `ssg-md-flow.jpg` into `website/docs/en/guide/basic/ssg-md.mdx`.
- Inserted `ssg-md-flow.jpg` into `website/docs/zh/guide/basic/ssg-md.mdx`.

**Reasoning:**
The image, originally referenced in the Rspress v2 blog post, provides a helpful visual comparison between the SSG-MD rendering process (using React's Virtual DOM) and traditional HTML-to-Markdown conversion. This clarifies the "Why SSG-MD?" explanation for readers.

This PR was written using [Vibe Kanban](https://vibekanban.com)

---