### PR TITLE
docs: add Node.js version requirements to getting started guide

### DIFF
--- a/website/docs/en/guide/start/getting-started.mdx
+++ b/website/docs/en/guide/start/getting-started.mdx
@@ -6,9 +6,21 @@ description: Quickly create an Rspress project via CLI or manually, and learn th
 
 import { PackageManagerTabs } from '@rspress/core/theme';
 
-## System requirements
+## Environment preparation
 
-- **Node.js**: version 20.19+, 22.12+.
+Rspress supports using [Node.js](https://nodejs.org/), [Deno](https://deno.com/), or [Bun](https://bun.sh/) as the JavaScript runtime.
+
+Use one of the following installation guides to set up a runtime:
+
+- [Install Node.js](https://nodejs.org/en/download)
+- [Install Bun](https://bun.com/docs/installation)
+- [Install Deno](https://docs.deno.com/runtime/getting_started/installation/)
+
+:::tip Version requirements
+
+Rspress requires Node.js version 20.19+, 22.12+.
+
+:::
 
 ## 1. Initialize the project
 

--- a/website/docs/zh/guide/start/getting-started.mdx
+++ b/website/docs/zh/guide/start/getting-started.mdx
@@ -6,9 +6,21 @@ description: 通过脚手架或手动方式快速创建 Rspress 项目，了解�
 
 import { PackageManagerTabs } from '@rspress/core/theme';
 
-## 环境要求
+## 环境准备
 
-- **Node.js**: 版本 20.19+, 22.12+。
+Rspress 支持使用 [Node.js](https://nodejs.org/)、[Deno](https://deno.com/) 或 [Bun](https://bun.sh/) 作为 JavaScript 运行时。
+
+请参考以下指南安装运行时：
+
+- [安装 Node.js](https://nodejs.org/en/download)
+- [安装 Bun](https://bun.com/docs/installation)
+- [安装 Deno](https://docs.deno.com/runtime/getting_started/installation/)
+
+:::tip 版本要求
+
+Rspress 需要 Node.js 版本 20.19+, 22.12+。
+
+:::
 
 ## 1. 初始化项目
 


### PR DESCRIPTION
## Summary

Update the Getting Started guide to include explicit Node.js version requirements (`20.19+, 22.12+`) and information about supported runtimes (Node.js, Deno, Bun).

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).

---

### AI Summary

This PR updates the `getting-started.mdx` files in both English and Chinese to add an "Environment preparation" section.

**Changes:**
- Added "Environment preparation" section detailing support for Node.js, Deno, and Bun.
- Added explicit Node.js version requirements: `20.19+, 22.12+`.
- Formatted the version requirements inside a `:::tip` block for better visibility.

This PR was written using [Vibe Kanban](https://vibekanban.com)
---