### PR TITLE
chore: allow build script of `sharp` package

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,18 +1,21 @@
 packages:
-  - 'scripts/config'
-  - 'packages/**'
-  - 'e2e/**'
-  - 'website'
+  - scripts/config
+  - packages/**
+  - e2e/**
+  - website
   - '!**/compiled/**'
   - '!**/tests/**'
   - '!packages/create-rspress/template-basic'
 
+hoistPattern: []
+
+linkWorkspacePackages: true
+
 onlyBuiltDependencies:
   - '@biomejs/biome'
-  - 'core-js'
-  - 'esbuild'
-  - 'nx'
+  - core-js
+  - esbuild
+  - nx
+  - sharp
 
-hoistPattern: []
-linkWorkspacePackages: true
 strictPeerDependencies: false


### PR DESCRIPTION
## Summary

When you run `pnpm i` in this repository, you will be notified that the build script of the `sharp` package has been blocked by pnpm.
It is a famous and popular image processing npm package and you do not have any reasons to block it. It should be allowed.

https://www.npmjs.com/package/sharp ![NPM Downloads](https://img.shields.io/npm/dm/sharp)


https://github.com/web-infra-dev/rspress/blob/fe7210de8a0f81286d3f20eeb32478088add02f4/pnpm-lock.yaml#L9479

The reason why the order of items in `pnpm-workspace.yaml` is changed is just because pnpm did it.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
