### PR TITLE
fix(theme): disable text-autospace in pre elements

### DIFF
--- a/packages/core/src/theme/styles/base.css
+++ b/packages/core/src/theme/styles/base.css
@@ -66,6 +66,10 @@ body {
   text-autospace: normal;
 }
 
+pre {
+  text-autospace: no-autospace;
+}
+
 :root #nprogress .bar {
   background: var(--rp-c-brand);
 }


### PR DESCRIPTION
## Summary

## Related Issue

<!--- Provide link of related issues -->

close https://github.com/web-infra-dev/rspress/issues/3110

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

---

## AI Summary

Rspress sets `text-autospace: normal` on `:root` to improve spacing between CJK (Chinese/Japanese/Korean) and non-CJK characters. However, this also applies to `<pre>` elements, which causes unwanted extra spacing in code blocks and ASCII art when using CJK-capable monospace fonts.

### Changes

- Added `text-autospace: no-autospace` to `pre` elements in `packages/core/src/theme/styles/base.css`

### Why

The `text-autospace` property inserts spaces between CJK and non-CJK characters, which breaks monospaced alignment in preformatted text blocks (code blocks, ASCII art, etc.). The [W3C CSS spec itself](https://github.com/w3c/csswg-drafts/issues/12386#issuecomment-3638204509) plans to exclude `<pre>` from default `text-autospace` behavior. This fix aligns Rspress with the spec's intended behavior.

This PR was written using [Vibe Kanban](https://vibekanban.com)

---