### PR TITLE
feat(plugin-typedoc): Add description to frontmatter in generated docs

### DIFF
--- a/e2e/fixtures/plugin-typedoc/index.test.ts
+++ b/e2e/fixtures/plugin-typedoc/index.test.ts
@@ -6,6 +6,7 @@ import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 test.describe('plugin-typedoc single entry', async () => {
   let appPort: number;
   let app: Awaited<ReturnType<typeof runDevCommand>>;
+
   test.beforeAll(async () => {
     const appDir = path.join(__dirname, 'single');
     appPort = await getPort();
@@ -17,6 +18,7 @@ test.describe('plugin-typedoc single entry', async () => {
       await killProcess(app);
     }
   });
+
   test('Should render nav and sidebar correctly', async ({ page }) => {
     await page.goto(`http://localhost:${appPort}/api/`, {
       waitUntil: 'networkidle',
@@ -38,11 +40,26 @@ test.describe('plugin-typedoc single entry', async () => {
       ].join(','),
     );
   });
+
+  test('Should render description correctly', async ({ page }) => {
+    await page.goto(
+      `http://localhost:${appPort}/api/functions/mergeMiddlewares.html`,
+      {
+        waitUntil: 'networkidle',
+      },
+    );
+
+    const description = await page.$eval('meta[name="description"]', el =>
+      el.getAttribute('content'),
+    );
+    expect(description).toBe('将多个中间件，合并成一个中间件执行');
+  });
 });
 
 test.describe('plugin-typedoc multi entries', async () => {
   let appPort: number;
   let app: Awaited<ReturnType<typeof runDevCommand>>;
+
   test.beforeAll(async () => {
     const appDir = path.join(__dirname, 'multi');
     appPort = await getPort();
@@ -54,6 +71,7 @@ test.describe('plugin-typedoc multi entries', async () => {
       await killProcess(app);
     }
   });
+
   test('Should render nav and sidebar correctly', async ({ page }) => {
     await page.goto(`http://localhost:${appPort}/api/`, {
       waitUntil: 'networkidle',
@@ -92,5 +110,19 @@ test.describe('plugin-typedoc multi entries', async () => {
       el => el.textContent,
     );
     expect(rspressUrl).toBe('Rspress site');
+  });
+
+  test('Should render description correctly', async ({ page }) => {
+    await page.goto(
+      `http://localhost:${appPort}/api/functions/middleware.mergeMiddlewares.html`,
+      {
+        waitUntil: 'networkidle',
+      },
+    );
+
+    const description = await page.$eval('meta[name="description"]', el =>
+      el.getAttribute('content'),
+    );
+    expect(description).toBe('将多个中间件，合并成一个中间件执行');
   });
 });

--- a/packages/plugin-typedoc/package.json
+++ b/packages/plugin-typedoc/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "typedoc": "0.28.16",
+    "typedoc-plugin-frontmatter": "1.3.1",
     "typedoc-plugin-markdown": "4.9.0"
   },
   "devDependencies": {

--- a/packages/plugin-typedoc/src/index.ts
+++ b/packages/plugin-typedoc/src/index.ts
@@ -2,9 +2,11 @@ import path from 'node:path';
 import { cwd } from 'node:process';
 import type { RspressPlugin } from '@rspress/core';
 import { Application } from 'typedoc';
-import { load as loadPluginMarkdown } from 'typedoc-plugin-markdown';
+import { load as pluginFrontMatter } from 'typedoc-plugin-frontmatter';
+import { load as pluginMarkdown } from 'typedoc-plugin-markdown';
 import { API_DIR } from './constants';
 import { patchGeneratedApiDocs } from './patch';
+import { pluginDescription } from './plugin';
 
 export interface PluginTypeDocOptions {
   /**
@@ -55,7 +57,7 @@ export function pluginTypeDoc(options: PluginTypeDocOptions): RspressPlugin {
         githubPages: false,
         requiredToBeDocumented: ['Class', 'Function', 'Interface'],
         // @ts-expect-error - Typedoc does not export a type for this options
-        plugin: [loadPluginMarkdown],
+        plugin: [pluginMarkdown, pluginFrontMatter, pluginDescription],
         entryFileName: 'index',
         hidePageHeader: true,
         hideBreadcrumbs: true,

--- a/packages/plugin-typedoc/src/plugin.ts
+++ b/packages/plugin-typedoc/src/plugin.ts
@@ -1,0 +1,23 @@
+import { type Application, DeclarationReflection } from 'typedoc';
+import type { MarkdownTheme } from 'typedoc-plugin-markdown';
+import { MarkdownPageEvent } from 'typedoc-plugin-markdown';
+
+export function pluginDescription(app: Application) {
+  app.renderer.on(MarkdownPageEvent.BEGIN, page => {
+    if (!(page.model instanceof DeclarationReflection)) return;
+
+    const event = page as MarkdownPageEvent<DeclarationReflection>;
+    const context = (app.renderer.theme as MarkdownTheme).getRenderContext(
+      event,
+    );
+    const comment = event.model.comment || event.model.signatures?.[0]?.comment;
+    if (comment) {
+      event.frontmatter = {
+        ...(event.frontmatter || {}),
+        description: context.helpers
+          .getDescriptionForComment(comment)
+          ?.replaceAll(/\[([^\]]+)]\([^)]+\)/g, '$1'), // Remove markdown links
+      };
+    }
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1623,6 +1623,9 @@ importers:
       typedoc:
         specifier: 0.28.16
         version: 0.28.16(typescript@5.8.2)
+      typedoc-plugin-frontmatter:
+        specifier: 1.3.1
+        version: 1.3.1(typedoc-plugin-markdown@4.9.0(typedoc@0.28.16(typescript@5.8.2)))
       typedoc-plugin-markdown:
         specifier: 4.9.0
         version: 4.9.0(typedoc@0.28.16(typescript@5.8.2))
@@ -3429,23 +3432,14 @@ packages:
   '@shikijs/engine-javascript@3.21.0':
     resolution: {integrity: sha512-ATwv86xlbmfD9n9gKRiwuPpWgPENAWCLwYCGz9ugTJlsO2kOzhOkvoyV/UD+tJ0uT7YRyD530x6ugNSffmvIiQ==}
 
-  '@shikijs/engine-oniguruma@3.20.0':
-    resolution: {integrity: sha512-Yx3gy7xLzM0ZOjqoxciHjA7dAt5tyzJE3L4uQoM83agahy+PlW244XJSrmJRSBvGYELDhYXPacD4R/cauV5bzQ==}
-
   '@shikijs/engine-oniguruma@3.21.0':
     resolution: {integrity: sha512-OYknTCct6qiwpQDqDdf3iedRdzj6hFlOPv5hMvI+hkWfCKs5mlJ4TXziBG9nyabLwGulrUjHiCq3xCspSzErYQ==}
-
-  '@shikijs/langs@3.20.0':
-    resolution: {integrity: sha512-le+bssCxcSHrygCWuOrYJHvjus6zhQ2K7q/0mgjiffRbkhM4o1EWu2m+29l0yEsHDbWaWPNnDUTRVVBvBBeKaA==}
 
   '@shikijs/langs@3.21.0':
     resolution: {integrity: sha512-g6mn5m+Y6GBJ4wxmBYqalK9Sp0CFkUqfNzUy2pJglUginz6ZpWbaWjDB4fbQ/8SHzFjYbtU6Ddlp1pc+PPNDVA==}
 
   '@shikijs/rehype@3.21.0':
     resolution: {integrity: sha512-fTQvwsZL67QdosMFdTgQ5SNjW3nxaPplRy//312hqOctRbIwviTV0nAbhv3NfnztHXvFli2zLYNKsTz/f9tbpQ==}
-
-  '@shikijs/themes@3.20.0':
-    resolution: {integrity: sha512-U1NSU7Sl26Q7ErRvJUouArxfM2euWqq1xaSrbqMu2iqa+tSp0D1Yah8216sDYbdDHw4C8b75UpE65eWorm2erQ==}
 
   '@shikijs/themes@3.21.0':
     resolution: {integrity: sha512-BAE4cr9EDiZyYzwIHEk7JTBJ9CzlPuM4PchfcA5ao1dWXb25nv6hYsoDiBq2aZK9E3dlt3WB78uI96UESD+8Mw==}
@@ -3457,9 +3451,6 @@ packages:
     resolution: {integrity: sha512-iH360udAYON2JwfIldoCiMZr9MljuQA5QRBivKLpEuEpmVCSwrR+0WTQ0eS1ptgGBdH9weFiIsA5wJDzsEzTYg==}
     peerDependencies:
       typescript: '>=5.5.0'
-
-  '@shikijs/types@3.20.0':
-    resolution: {integrity: sha512-lhYAATn10nkZcBQ0BlzSbJA3wcmL5MXUUF8d2Zzon6saZDlToKaiRX60n2+ZaHJCmXEcZRWNzn+k9vplr8Jhsw==}
 
   '@shikijs/types@3.21.0':
     resolution: {integrity: sha512-zGrWOxZ0/+0ovPY7PvBU2gIS9tmhSUUt30jAcNV0Bq0gb2S98gwfjIs1vxlmH5zM7/4YxLamT6ChlqqAJmPPjA==}
@@ -7205,6 +7196,11 @@ packages:
     resolution: {integrity: sha512-G6zXWS1dLj6eagy6sVhOMQiLtJdxQBHIA9Z6HFUNLOlr6MFOgzV8wvmidtPONfPtEUv0uZsy77XJNzTAfwPDaA==}
     engines: {node: '>=16'}
 
+  typedoc-plugin-frontmatter@1.3.1:
+    resolution: {integrity: sha512-wXKnhpiOuG3lY9GGKiKcXNrhKbPYm/jA5wbzGE/kKdwlSu8++ZbEuKA0K2dvIna3F+5EQrv+3AeObHkS1QP7JA==}
+    peerDependencies:
+      typedoc-plugin-markdown: '>=4.9.0'
+
   typedoc-plugin-markdown@4.9.0:
     resolution: {integrity: sha512-9Uu4WR9L7ZBgAl60N/h+jqmPxxvnC9nQAlnnO/OujtG2ubjnKTVUFY1XDhcMY+pCqlX3N2HsQM2QTYZIU9tJuw==}
     engines: {node: '>= 18'}
@@ -8433,9 +8429,9 @@ snapshots:
 
   '@gerrit0/mini-shiki@3.17.1':
     dependencies:
-      '@shikijs/engine-oniguruma': 3.20.0
-      '@shikijs/langs': 3.20.0
-      '@shikijs/themes': 3.20.0
+      '@shikijs/engine-oniguruma': 3.21.0
+      '@shikijs/langs': 3.21.0
+      '@shikijs/themes': 3.21.0
       '@shikijs/types': 3.21.0
       '@shikijs/vscode-textmate': 10.0.2
 
@@ -9405,19 +9401,10 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.4
 
-  '@shikijs/engine-oniguruma@3.20.0':
-    dependencies:
-      '@shikijs/types': 3.20.0
-      '@shikijs/vscode-textmate': 10.0.2
-
   '@shikijs/engine-oniguruma@3.21.0':
     dependencies:
       '@shikijs/types': 3.21.0
       '@shikijs/vscode-textmate': 10.0.2
-
-  '@shikijs/langs@3.20.0':
-    dependencies:
-      '@shikijs/types': 3.20.0
 
   '@shikijs/langs@3.21.0':
     dependencies:
@@ -9431,10 +9418,6 @@ snapshots:
       shiki: 3.21.0
       unified: 11.0.5
       unist-util-visit: 5.0.0
-
-  '@shikijs/themes@3.20.0':
-    dependencies:
-      '@shikijs/types': 3.20.0
 
   '@shikijs/themes@3.21.0':
     dependencies:
@@ -9453,11 +9436,6 @@ snapshots:
       typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
-
-  '@shikijs/types@3.20.0':
-    dependencies:
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
 
   '@shikijs/types@3.21.0':
     dependencies:
@@ -14038,6 +14016,11 @@ snapshots:
   type-fest@2.19.0: {}
 
   type-fest@4.30.0: {}
+
+  typedoc-plugin-frontmatter@1.3.1(typedoc-plugin-markdown@4.9.0(typedoc@0.28.16(typescript@5.8.2))):
+    dependencies:
+      typedoc-plugin-markdown: 4.9.0(typedoc@0.28.16(typescript@5.8.2))
+      yaml: 2.8.2
 
   typedoc-plugin-markdown@4.9.0(typedoc@0.28.16(typescript@5.8.2)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,8 @@ packages:
   - '!**/tests/**'
   - '!packages/create-rspress/template-basic'
 
-hoistPattern: []
+hoistPattern:
+  - typedoc
 
 linkWorkspacePackages: true
 


### PR DESCRIPTION
## Summary

This PR enhances the plugin-typedoc to automatically add description metadata to the frontmatter of generated API documentation pages.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
