### PR TITLE
docs: clarify search.versioned behavior in multi-version docs

### DIFF
--- a/website/docs/en/api/config/config-basic.mdx
+++ b/website/docs/en/api/config/config-basic.mdx
@@ -400,8 +400,7 @@ For specific hook logic, you can read [Customize Search Functions](/guide/advanc
 - **Type**: `boolean`
 - **Default**: `false`
 
-If you are using `multiVersion`, the `versioned` parameter allows you to create a separate search index for each version of your documentation.
-When enabled, the search will only query the index corresponding to the currently selected version.
+When using [`multiVersion`](/guide/basic/multi-version), the search index includes all versions by default. Setting `versioned` to `true` creates a separate search index for each version, so that search results only include pages from the version the user is currently viewing.
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from '@rspress/core';

--- a/website/docs/en/guide/basic/multi-version.mdx
+++ b/website/docs/en/guide/basic/multi-version.mdx
@@ -1,5 +1,5 @@
 ---
-description: Manage multi-version documentation with simple configuration, intuitive directory structure, and version selector in the navbar.
+description: Manage multi-version documentation with simple configuration, intuitive directory structure, version selector in the navbar, and version-specific search.
 ---
 
 # Multi version
@@ -60,9 +60,9 @@ export default () => {
 };
 ```
 
-## Limit search to current version only
+## Version-specific search
 
-You can configure `search.versioned` to only search through the current version's documents.
+By default, the search index includes documents from all versions, so search results may contain pages from any version. To create separate search indexes for each version so that users only see results from the version they are currently viewing, enable `search.versioned`:
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from '@rspress/core';

--- a/website/docs/zh/api/config/config-basic.mdx
+++ b/website/docs/zh/api/config/config-basic.mdx
@@ -400,7 +400,7 @@ export default defineConfig({
 - **类型**： `boolean`
 - **默认值**： `false`
 
-如果你配置了 `multiVersion`，可以使用 `versioned` 参数为文档的每个版本创建单独的搜索索引。开启该选项后，搜索将仅会查询当前所选版本对应的索引。
+配置 [`multiVersion`](/zh/guide/basic/multi-version) 后，搜索索引默认包含所有版本的文档。将 `versioned` 设为 `true` 会为每个版本创建独立的搜索索引，使搜索结果仅包含用户当前所选版本的页面。
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from '@rspress/core';

--- a/website/docs/zh/guide/basic/multi-version.mdx
+++ b/website/docs/zh/guide/basic/multi-version.mdx
@@ -60,9 +60,9 @@ export default () => {
 };
 ```
 
-## 仅搜索当前版本
+## 按版本搜索
 
-可以配置 `search.versioned` 来仅搜索当前版本的文档。
+默认情况下，搜索索引包含所有版本的文档，因此搜索结果可能包含任意版本的页面。如需为每个版本创建独立的搜索索引，使用户仅看到当前所选版本的搜索结果，请启用 `search.versioned`：
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from '@rspress/core';


### PR DESCRIPTION
## Summary

## Related Issue

<!--- Provide link of related issues -->

close https://github.com/web-infra-dev/rspress/issues/3118

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).

---

### What changed

Reworded the `search.versioned` documentation in both English and Chinese across 4 files:

- **Guide pages** (`docs/{en,zh}/guide/basic/multi-version.mdx`): Renamed the section heading from "Limit search to current version only" / "仅搜索当前版本" to "Version-specific search" / "按版本搜索", and added a clear explanation of the default behavior.
- **API reference pages** (`docs/{en,zh}/api/config/config-basic.mdx`): Reworded the `versioned` parameter description and added a cross-reference link to the multi-version guide.

### Why

The previous wording — *"When enabled, the search will only query the index corresponding to the currently selected version"* — was misleading. It sounded like `versioned: true` **restricts** an existing capability, when in reality:

- **Default (`false`)**: A single search index contains documents from **all** versions, so search results may return pages from any version.
- **Enabled (`true`)**: Separate search indexes are created **per version**, so users only see results from the version they are currently viewing.

The updated docs now lead with the default behavior and clearly explain what enabling the option changes.

This PR was written using [Vibe Kanban](https://vibekanban.com)

---