### PR TITLE
fix: prevent hintSSGFailed log from printing multiple times

### DIFF
--- a/packages/core/src/node/logger/hint.ts
+++ b/packages/core/src/node/logger/hint.ts
@@ -85,7 +85,12 @@ ${picocolors.greenBright(`  builderConfig: {
 /**
  * Possible reasons for printing "ssg: false" and some troubleshooting guidelines for users.
  */
+let isSSGFailedLogged = false;
 export function hintSSGFailed() {
+  if (isSSGFailedLogged) {
+    return;
+  }
+  isSSGFailedLogged = true;
   logger.info(`[Rspress v2] \`ssg: true\` requires the source code to support SSR. If the code is not compatible to SSR, the build process will fail. You can try:
     1. Fix code to make it SSR-compatible.
     2. Set \`ssg: false\` if the code in node_modules may be difficult to fix, but the SSG feature will be lost.`);


### PR DESCRIPTION
## Summary

fix: prevent hintSSGFailed log from printing multiple times

## Related Issue

https://github.com/web-infra-dev/rspress/issues/3144

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

---

### What

Add a log-once guard to `hintSSGFailed()` so the SSG hint message is only printed once per process, instead of potentially appearing multiple times during a single build.

### Why

When SSG rendering fails, the error propagates through multiple layers:

1. `ssg/renderPage.ts` catches the error and calls `hintSSGFailed()`
2. The error is re-thrown and caught by `ssg/renderPages.ts`, which calls `hintSSGFailed()` again
3. The same pattern exists in `ssg-md/renderPage.ts`

This results in the same hint message being printed multiple times, which is noisy and confusing for users.

### How

Uses a module-level `isSSGFailedLogged` boolean flag — the same pattern already used by `hintRelativeMarkdownLink()` in the same file (`packages/core/src/node/logger/hint.ts`).

This PR was written using [Vibe Kanban](https://vibekanban.com)

---