### PR TITLE
docs: document using multi-version with i18n together

### DIFF
--- a/website/docs/en/guide/basic/multi-version.mdx
+++ b/website/docs/en/guide/basic/multi-version.mdx
@@ -47,6 +47,69 @@ For links in the document, you do not need to manually add the version prefix. R
 
 :::
 
+## Using with i18n
+
+Multi-version can be used together with [internationalization](/guide/basic/i18n). When both are enabled, the directory structure uses **version as the top level, then language subdirectories** within each version:
+
+```ts title="rspress.config.ts"
+import { defineConfig } from '@rspress/core';
+
+export default defineConfig({
+  lang: 'en',
+  locales: [
+    {
+      lang: 'en',
+      label: 'English',
+    },
+    {
+      lang: 'zh',
+      label: '简体中文',
+    },
+  ],
+  multiVersion: {
+    default: 'v1',
+    versions: ['v1', 'v2'],
+  },
+});
+```
+
+The document directory structure should be organized as follows:
+
+```tree
+docs
+├── v1
+│   ├── en
+│   │   ├── _nav.json
+│   │   ├── index.md
+│   │   └── guide
+│   │       └── index.md
+│   └── zh
+│       ├── _nav.json
+│       ├── index.md
+│       └── guide
+│           └── index.md
+└── v2
+    ├── en
+    │   ├── _nav.json
+    │   ├── index.md
+    │   └── guide
+    │       └── index.md
+    └── zh
+        ├── _nav.json
+        ├── index.md
+        └── guide
+            └── index.md
+```
+
+The generated routes follow the pattern `/{version}/{lang}/`:
+
+| File path        | Route                                                           |
+| ---------------- | --------------------------------------------------------------- |
+| `v1/en/index.md` | `/` (default version + default language, both prefixes omitted) |
+| `v1/zh/index.md` | `/zh/`                                                          |
+| `v2/en/index.md` | `/v2/`                                                          |
+| `v2/zh/index.md` | `/v2/zh/`                                                       |
+
 ## Get the current version in components
 
 In components, you can get the current version through [`useVersion`](/ui/hooks/use-version), for example:

--- a/website/docs/zh/guide/basic/multi-version.mdx
+++ b/website/docs/zh/guide/basic/multi-version.mdx
@@ -47,6 +47,69 @@ docs
 
 :::
 
+## 配合国际化使用
+
+多版本文档可以和[国际化](/guide/basic/i18n)一起使用。同时开启时，目录结构以**版本为顶层目录，语言为子目录**：
+
+```ts title="rspress.config.ts"
+import { defineConfig } from '@rspress/core';
+
+export default defineConfig({
+  lang: 'en',
+  locales: [
+    {
+      lang: 'en',
+      label: 'English',
+    },
+    {
+      lang: 'zh',
+      label: '简体中文',
+    },
+  ],
+  multiVersion: {
+    default: 'v1',
+    versions: ['v1', 'v2'],
+  },
+});
+```
+
+文档目录结构如下：
+
+```tree
+docs
+├── v1
+│   ├── en
+│   │   ├── _nav.json
+│   │   ├── index.md
+│   │   └── guide
+│   │       └── index.md
+│   └── zh
+│       ├── _nav.json
+│       ├── index.md
+│       └── guide
+│           └── index.md
+└── v2
+    ├── en
+    │   ├── _nav.json
+    │   ├── index.md
+    │   └── guide
+    │       └── index.md
+    └── zh
+        ├── _nav.json
+        ├── index.md
+        └── guide
+            └── index.md
+```
+
+生成的路由遵循 `/{version}/{lang}/` 的规则：
+
+| 文件路径         | 路由                                       |
+| ---------------- | ------------------------------------------ |
+| `v1/en/index.md` | `/`（默认版本 + 默认语言，两个前缀均省略） |
+| `v1/zh/index.md` | `/zh/`                                     |
+| `v2/en/index.md` | `/v2/`                                     |
+| `v2/zh/index.md` | `/v2/zh/`                                  |
+
 ## 组件中获取当前版本
 
 在组件中，你可以通过 [`useVersion`](/ui/hooks/use-version) 获取当前版本，比如：


### PR DESCRIPTION
## Summary

## Related Issue

<!--- Provide link of related issues -->

https://github.com/web-infra-dev/rspress/discussions/3088

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).

## AI Summary

---

Added a new "Using with i18n" section to the multi-version documentation (both English and Chinese) to clarify how to combine `multiVersion` with `locales`.

Users were confused about the correct directory structure when using both features together (see [#3088](https://github.com/web-infra-dev/rspress/discussions/3088)). The new section covers:

- A complete `rspress.config.ts` example with both `locales` and `multiVersion` configured
- The correct directory structure: **version as top level, language as subdirectory** (`docs/v1/en/`, `docs/v1/zh/`, `docs/v2/en/`, `docs/v2/zh/`)
- A route mapping table showing how default version and language prefixes are omitted:
  - `v1/en/` → `/`
  - `v1/zh/` → `/zh/`
  - `v2/en/` → `/v2/`
  - `v2/zh/` → `/v2/zh/`

This PR was written using [Vibe Kanban](https://vibekanban.com)

---