### PR TITLE
fix(CodeBlock/lineNumbers): When defaultWrapCode is set to true, line numbers greater than 1…

### DIFF
--- a/packages/core/src/theme/components/CodeBlock/index.scss
+++ b/packages/core/src/theme/components/CodeBlock/index.scss
@@ -76,7 +76,6 @@
     & .line::before {
       content: counter(step);
       counter-increment: step;
-      width: 1rem;
       margin-right: 1rem;
       display: inline-block;
       text-align: right;


### PR DESCRIPTION
<img width="975" height="728" alt="image" src="https://github.com/user-attachments/assets/bcf13ffc-1a81-4dd2-85a2-1eef33d2ef87" />
