### PR TITLE
docs: add hero badge linking to Rspress 2.0 blog post

### DIFF
--- a/website/docs/en/index.md
+++ b/website/docs/en/index.md
@@ -7,6 +7,9 @@ hero:
   name: Rspress
   text: Lightning Fast Static Site Generator
   tagline: Simple, efficient and easy to extend
+  badge:
+    text: Rspress 2.0 is out!
+    link: ./blog/rspress-v2
   actions:
     - theme: brand
       text: Introduction

--- a/website/docs/zh/index.md
+++ b/website/docs/zh/index.md
@@ -9,6 +9,9 @@ hero:
     快如闪电的
     静态站点生成器
   tagline: 简单、高性能、易于扩展
+  badge:
+    text: Rspress 2.0 正式发布！
+    link: ./blog/rspress-v2
   image:
     src: https://assets.rspack.rs/rspress/rspress-logo.svg
     alt: Rspress Logo


### PR DESCRIPTION
## Summary

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

---

## AI Summary

Add a hero badge to the Rspress homepage (both EN and ZH) that links to the Rspress 2.0 release blog post, driving traffic to the latest announcement.

### Changes

- **`website/docs/en/index.md`**: Added `badge` field to the hero frontmatter with text "Rspress 2.0 is out!" linking to `./blog/rspress-v2`
- **`website/docs/zh/index.md`**: Added `badge` field to the hero frontmatter with text "Rspress 2.0 正式发布！" linking to `./blog/rspress-v2`

### Details

The `HomeHero` component already supports a `badge` property in the hero frontmatter — it accepts either a plain string or an object with `text` and `link` fields. When `link` is provided, the badge renders as a clickable `<Link>` element above the hero title. No code changes were needed; this is purely a content/frontmatter update.

This PR was written using [Vibe Kanban](https://vibekanban.com)

---