### PR TITLE
perf(theme-default): defer main content rendering on navigation

### DIFF
--- a/packages/core/src/theme/layout/DocLayout/index.tsx
+++ b/packages/core/src/theme/layout/DocLayout/index.tsx
@@ -1,4 +1,4 @@
-import { useFrontmatter } from '@rspress/core/runtime';
+import { useFrontmatter, useLocation } from '@rspress/core/runtime';
 import {
   DocContent,
   DocFooter,
@@ -8,6 +8,7 @@ import {
   useWatchToc,
 } from '@theme';
 import clsx from 'clsx';
+import { useEffect, useRef, useState, useTransition } from 'react';
 import { useSidebarMenu } from '../../components/SidebarMenu/useSidebarMenu';
 import './index.scss';
 
@@ -77,6 +78,30 @@ export function DocLayout(props: DocLayoutProps) {
 
   const { rspressDocRef } = useWatchToc();
 
+  // Defer main content rendering on client-side navigation so the sidebar
+  // commits to the DOM first, avoiding jank when pages are content-heavy.
+  const { pathname } = useLocation();
+  const [, startTransition] = useTransition();
+  const [contentVisible, setContentVisible] = useState(true);
+  const prevPathname = useRef(pathname);
+
+  if (prevPathname.current !== pathname) {
+    prevPathname.current = pathname;
+    if (contentVisible) {
+      setContentVisible(false);
+    }
+  }
+
+  useEffect(() => {
+    if (!contentVisible) {
+      startTransition(() => {
+        setContentVisible(true);
+      });
+    }
+  }, [contentVisible]);
+
+  const docContent = <DocContent components={components} />;
+
   return (
     <>
       <div className="rp-doc-layout__menu">{sidebarMenu}</div>
@@ -104,35 +129,39 @@ export function DocLayout(props: DocLayoutProps) {
         )}
 
         {/* Main document content */}
-        {isOverviewPage ? (
-          <>
-            <main className="rp-doc-layout__overview">
-              {beforeDocContent}
-              <Overview
-                content={<DocContent components={components} isOverviewPage />}
-              />
-              {afterDocContent}
-            </main>
-          </>
-        ) : (
-          <div
-            className={clsx(
-              'rp-doc-layout__doc',
-              isDocWide && 'rp-doc-layout__doc--wide',
-            )}
-          >
-            <main className="rp-doc-layout__doc-container">
-              {beforeDocContent}
-              <div className="rp-doc rspress-doc" ref={rspressDocRef}>
-                <DocContent components={components} />
-              </div>
-              {afterDocContent}
-              {beforeDocFooter}
-              {showDocFooter && <DocFooter />}
-              {afterDocFooter}
-            </main>
-          </div>
-        )}
+        {contentVisible ? (
+          isOverviewPage ? (
+            <>
+              <main className="rp-doc-layout__overview">
+                {beforeDocContent}
+                <Overview
+                  content={
+                    <DocContent components={components} isOverviewPage />
+                  }
+                />
+                {afterDocContent}
+              </main>
+            </>
+          ) : (
+            <div
+              className={clsx(
+                'rp-doc-layout__doc',
+                isDocWide && 'rp-doc-layout__doc--wide',
+              )}
+            >
+              <main className="rp-doc-layout__doc-container">
+                {beforeDocContent}
+                <div className="rp-doc rspress-doc" ref={rspressDocRef}>
+                  {docContent}
+                </div>
+                {afterDocContent}
+                {beforeDocFooter}
+                {showDocFooter && <DocFooter />}
+                {afterDocFooter}
+              </main>
+            </div>
+          )
+        ) : null}
 
         {/* Right outline */}
         {isOverviewPage ? null : showOutline ? (


### PR DESCRIPTION
## Summary

When pages have heavy MDX content, rendering the sidebar and content together in one React commit causes jank during client-side navigation. This PR uses React 18's `useTransition` to split rendering into two commits:

1. **Commit 1**: Sidebar renders immediately, giving instant navigation feedback
2. **Commit 2**: Doc content renders as a non-urgent transition, allowing React to time-slice and keep the UI responsive

SSR hydration is unaffected — content renders immediately on initial load since the deferral only activates on pathname changes.

## Related Issue

N/A

## Checklist

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).