### PR TITLE
fix(Codeblock/lineNumbers): line numbers greater than 1 style, associated with #3158

### DIFF
--- a/packages/core/src/theme/components/CodeBlock/index.scss
+++ b/packages/core/src/theme/components/CodeBlock/index.scss
@@ -82,5 +82,9 @@
       text-align: right;
       color: rgba(115, 138, 148, 0.4);
     }
+    // 100+ for 3 digits
+    &:has(.line:nth-child(100)) .line::before {
+      width: 3ch;
+    }
   }
 }


### PR DESCRIPTION
## Summary

fix(Codeblock/lineNumbers): line numbers greater than 1 style, associated with #3158

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
