### PR TITLE
docs: rename `eject-only` tag to `theme-only`

### DIFF
--- a/website/docs/en/ui/_meta.json
+++ b/website/docs/en/ui/_meta.json
@@ -34,7 +34,7 @@
     "type": "dir",
     "label": "Layout Components",
     "name": "layout-components",
-    "tag": "eject-only"
+    "tag": "theme-only"
   },
   {
     "type": "section-header",

--- a/website/docs/en/ui/icons/index.mdx
+++ b/website/docs/en/ui/icons/index.mdx
@@ -1,6 +1,6 @@
 ---
 description: List of Rspress built-in icons and how to replace them via custom theme.
-tag: eject-only
+tag: theme-only
 ---
 
 # Built-in icons

--- a/website/docs/en/ui/layout-components/tag.mdx
+++ b/website/docs/en/ui/layout-components/tag.mdx
@@ -81,7 +81,7 @@ The component has built-in common tags that display with `<Badge />`. All common
 
 The Tag component is ejectable. When you want to extend common tags, you can use wrap/eject to modify the Tag component. The tag value is passed as props to the Tag component.
 
-Here's an example from this site adding a custom `eject-only` tag through wrap:
+Here's an example from this site adding a custom `theme-only` tag through wrap:
 
 ```tsx title="theme/components/Tag/index.tsx"
 import {
@@ -90,8 +90,8 @@ import {
 } from '@rspress/core/theme-original';
 
 export const Tag = ({ tag }: { tag: string }) => {
-  if (tag === 'eject-only') {
-    return <BasicBadge text="eject-only" type="warning" />;
+  if (tag === 'theme-only') {
+    return <BasicBadge text="theme-only" type="warning" />;
   }
   return <BasicTag tag={tag} />;
 };
@@ -99,7 +99,7 @@ export const Tag = ({ tag }: { tag: string }) => {
 
 ```mdx title="index.mdx"
 ---
-tag: new, eject-only
+tag: new, theme-only
 ---
 ```
 

--- a/website/docs/zh/ui/_meta.json
+++ b/website/docs/zh/ui/_meta.json
@@ -34,7 +34,7 @@
     "type": "dir",
     "label": "布局组件",
     "name": "layout-components",
-    "tag": "eject-only"
+    "tag": "theme-only"
   },
   {
     "type": "section-header",

--- a/website/docs/zh/ui/icons/index.mdx
+++ b/website/docs/zh/ui/icons/index.mdx
@@ -1,6 +1,6 @@
 ---
 description: Rspress 内置图标列表，以及如何通过自定义主题替换图标。
-tag: eject-only
+tag: theme-only
 ---
 
 # 内置图标

--- a/website/docs/zh/ui/layout-components/tag.mdx
+++ b/website/docs/zh/ui/layout-components/tag.mdx
@@ -81,7 +81,7 @@ tag: new, experimental
 
 Tag 组件是 ejectable 的，当你想扩充常用标签时，可使用 wrap/eject 来对 Tag 组件进行修改，tag 的值会作为 props 传递给 Tag 组件。
 
-以下是一个本站通过 wrap 增加 `eject-only` 自定义标签的使用示例：
+以下是一个本站通过 wrap 增加 `theme-only` 自定义标签的使用示例：
 
 ```tsx title="theme/components/Tag/index.tsx"
 import {
@@ -90,8 +90,8 @@ import {
 } from '@rspress/core/theme-original';
 
 export const Tag = ({ tag }: { tag: string }) => {
-  if (tag === 'eject-only') {
-    return <BasicBadge text="eject-only" type="warning" />;
+  if (tag === 'theme-only') {
+    return <BasicBadge text="theme-only" type="warning" />;
   }
   return <BasicTag tag={tag} />;
 };
@@ -99,7 +99,7 @@ export const Tag = ({ tag }: { tag: string }) => {
 
 ```mdx title="index.mdx"
 ---
-tag: new, eject-only
+tag: new, theme-only
 ---
 ```
 

--- a/website/theme/components/Tag/index.tsx
+++ b/website/theme/components/Tag/index.tsx
@@ -8,8 +8,8 @@ export const Tag = ({ tag }: { tag?: string }) => {
     return null;
   }
 
-  if (tag === 'eject-only') {
-    return <BasicBadge text="eject-only" type="warning" />;
+  if (tag === 'theme-only') {
+    return <BasicBadge text="theme-only" type="warning" />;
   }
   if (tag === 'non-ejectable') {
     return <BasicBadge text="non-ejectable" type="danger" />;


### PR DESCRIPTION
## Summary

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## AI Summary

---

Rename the custom `eject-only` tag to `theme-only` across all documentation and the custom Tag component.

### What changed

- Updated the custom Tag component (`website/theme/components/Tag/index.tsx`) to recognize `theme-only` instead of `eject-only`
- Updated frontmatter tags in both EN and ZH icon docs (`website/docs/{en,zh}/ui/icons/index.mdx`)
- Updated sidebar metadata tags in both EN and ZH `_meta.json` files
- Updated code examples and descriptions in both EN and ZH Tag component docs (`website/docs/{en,zh}/ui/layout-components/tag.mdx`)

### Why

The term "eject" is an internal implementation concept that isn't intuitive for new users. `theme-only` clearly communicates that the feature "requires a custom theme", and is consistent in length and style with existing tags like `non-ejectable` and `experimental`.

This PR was written using [Vibe Kanban](https://vibekanban.com)

---