### PR TITLE
fix(theme): unify copy and success SVG icons in code button group

### DIFF
--- a/packages/core/src/theme/assets/copy.svg
+++ b/packages/core/src/theme/assets/copy.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 30 30"><path fill="currentColor" d="M28 10v18H10V10h18m0-2H10a2 2 0 0 0-2 2v18a2 2 0 0 0 2 2h18a2 2 0 0 0 2-2V10a2 2 0 0 0-2-2Z"/><path fill="currentColor" d="M4 18H2V4a2 2 0 0 1 2-2h14v2H4Z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><path fill="currentColor" d="M20 8v12H8V8h12m0-2H8a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2Z"/><path fill="currentColor" d="M4 16H2V4a2 2 0 0 1 2-2h12v2H4Z"/></svg>

--- a/packages/core/src/theme/assets/success.svg
+++ b/packages/core/src/theme/assets/success.svg
@@ -1,1 +1,1 @@
-<svg width="32" height="32" viewBox="0 0 30 30"><path fill="#49cd37" d="m13 24l-9-9l1.414-1.414L13 21.171L26.586 7.586L28 9L13 24z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><path fill="#49cd37" d="m9.55 18l-5.7-5.7l1.425-1.425L9.55 15.15l9.175-9.175L20.15 7.4z"/></svg>


### PR DESCRIPTION
## Summary
- Redraw `copy.svg` with `viewBox="0 0 24 24"` and 2px line weight, matching `wrap.svg` / `wrapped.svg` style
- Redraw `success.svg` with `viewBox="0 0 24 24"`, consistent with other code button group icons

<img width="689" height="415" alt="image" src="https://github.com/user-attachments/assets/564beee0-26e2-4ffb-b617-25887ce0adb8" />


Closes #3111

## Test plan
- [ ] Verify copy icon in code block visually matches wrap/wrapped icon style
- [ ] Verify success checkmark displays correctly after clicking copy