### PR TITLE
fix(PackageManagerTabs): correctly handle deno run args and add -A flag

### DIFF
--- a/e2e/fixtures/package-manager-tabs/doc/index.mdx
+++ b/e2e/fixtures/package-manager-tabs/doc/index.mdx
@@ -14,6 +14,13 @@ import { PackageManagerTabs } from '@theme';
 
 <PackageManagerTabs dlx command="example-cli-tool --yes" />
 
+## PackageManagerTabs dlx with multiple args
+
+<PackageManagerTabs
+  dlx
+  command="skills add rstackjs/agent-skills --skill migrate-to-rstest"
+/>
+
 ## PackageManagerTabs exec
 
 <PackageManagerTabs exec command="example-cli-tool --yes" />

--- a/e2e/fixtures/package-manager-tabs/index.test.ts
+++ b/e2e/fixtures/package-manager-tabs/index.test.ts
@@ -52,6 +52,11 @@ test.describe('tabs-component test', async () => {
       'pnpm',
       'bun',
       'deno',
+      'npm',
+      'yarn',
+      'pnpm',
+      'bun',
+      'deno',
     ]);
 
     const clickTabs = tabs;
@@ -68,6 +73,7 @@ test.describe('tabs-component test', async () => {
       'npm create rspress@latest',
       'npm install -D @rspress/core',
       'npx example-cli-tool --yes',
+      'npx skills add rstackjs/agent-skills --skill migrate-to-rstest',
       'npx example-cli-tool --yes',
       'npm create rspress@latest',
     ]);
@@ -77,6 +83,7 @@ test.describe('tabs-component test', async () => {
       'yarn create rspress',
       'yarn add -D @rspress/core',
       'yarn dlx example-cli-tool --yes',
+      'yarn dlx skills add rstackjs/agent-skills --skill migrate-to-rstest',
       'yarn example-cli-tool --yes',
       'yarn create rspress',
     ]);
@@ -86,6 +93,7 @@ test.describe('tabs-component test', async () => {
       'pnpm create rspress@latest',
       'pnpm add -D @rspress/core',
       'pnpm dlx example-cli-tool --yes',
+      'pnpm dlx skills add rstackjs/agent-skills --skill migrate-to-rstest',
       'pnpm example-cli-tool --yes',
       'pnpm create rspress@latest',
     ]);
@@ -95,6 +103,7 @@ test.describe('tabs-component test', async () => {
       'bun create rspress@latest',
       'bun add -D @rspress/core',
       'bunx example-cli-tool --yes',
+      'bunx skills add rstackjs/agent-skills --skill migrate-to-rstest',
       'bun example-cli-tool --yes',
       'bun create rspress@latest',
     ]);
@@ -103,8 +112,9 @@ test.describe('tabs-component test', async () => {
     expect(await getCommands()).toEqual([
       'deno init --npm rspress@latest',
       'deno add -D npm:@rspress/core',
-      'deno run npm:example-cli-tool --yes',
-      'deno run npm:example-cli-tool --yes',
+      'deno run -A npm:example-cli-tool --yes',
+      'deno run -A npm:skills add rstackjs/agent-skills --skill migrate-to-rstest',
+      'deno run -A npm:example-cli-tool --yes',
       'deno init --npm rspress@latest',
     ]);
   });

--- a/packages/core/src/theme/components/PackageManagerTabs/index.tsx
+++ b/packages/core/src/theme/components/PackageManagerTabs/index.tsx
@@ -44,6 +44,10 @@ export type PackageManagerTabProps = (
 // contains `--npm` or `--jsr` (in which case explicit npm behavior is desired).
 const transformDenoPositional = (cmd: string) => {
   const parts = cmd.split(' ');
+  const subcommand = parts[1];
+  const isRun = subcommand === 'run';
+  let transformedFirst = false;
+
   const transformed = parts.map((tok, idx) => {
     // only transform positional args (after "deno" and the subcommand)
     if (
@@ -52,6 +56,10 @@ const transformDenoPositional = (cmd: string) => {
       !tok.includes(':') &&
       !/^https?:/.test(tok)
     ) {
+      if (isRun && transformedFirst) {
+        return tok;
+      }
+      transformedFirst = true;
       return `npm:${tok}`;
     }
     return tok;
@@ -164,7 +172,7 @@ export function PackageManagerTabs({
           case 'bun':
             return 'bunx';
           case 'deno':
-            return 'deno run';
+            return 'deno run -A';
           default:
             return packageManager;
         }
@@ -180,7 +188,7 @@ export function PackageManagerTabs({
           case 'bun':
             return 'bun';
           case 'deno':
-            return 'deno run';
+            return 'deno run -A';
           default:
             return packageManager;
         }


### PR DESCRIPTION
## Summary

Correctly handle positional arguments for `deno run` in `PackageManagerTabs` component. Previously, all positional arguments were prefixed with `npm:`, which caused issues when running tools that take subcommands (e.g., `skills add ...`).

This PR:
1. Updates `transformDenoPositional` to only prefix the first positional argument with `npm:` when the subcommand is `run`.
2. Adds the `-A` (allow-all) flag to `deno run` by default to match the behavior of other package managers' execution commands (like `npx`, `bunx`).
3. Adds E2E test cases for `dlx` with multiple arguments.

## Related Issue

None.

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).