### PR TITLE
chore(theme): export missing component props types

### DIFF
--- a/packages/core/src/theme/components/Badge/index.tsx
+++ b/packages/core/src/theme/components/Badge/index.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import './index.scss';
 
-interface BadgeProps {
+export interface BadgeProps {
   /**
    * The content to display inside the badge. Can be a string or React nodes.
    */

--- a/packages/core/src/theme/components/Button/index.tsx
+++ b/packages/core/src/theme/components/Button/index.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 import React, { type JSX } from 'react';
 import './index.scss';
 
-interface ButtonProps {
+export interface ButtonProps {
   type?: string;
   size?: 'medium' | 'big';
   theme?: 'brand' | 'alt';

--- a/packages/core/src/theme/components/SourceCode/index.tsx
+++ b/packages/core/src/theme/components/SourceCode/index.tsx
@@ -2,7 +2,7 @@ import { useI18n } from '@rspress/core/runtime';
 import { IconGithub, IconGitlab, SvgWrapper } from '@theme';
 import './index.scss';
 
-interface SourceCodeProps {
+export interface SourceCodeProps {
   href: string;
   platform?: 'github' | 'gitlab';
 }

--- a/packages/core/src/theme/components/SvgWrapper/index.tsx
+++ b/packages/core/src/theme/components/SvgWrapper/index.tsx
@@ -15,7 +15,7 @@ function isUrlOrPath(str: string): boolean {
   );
 }
 
-type SvgWrapperProps = {
+export type SvgWrapperProps = {
   icon: string | React.FC<React.SVGProps<SVGSVGElement>>;
 } & React.SVGProps<SVGSVGElement>;
 

--- a/packages/core/src/theme/components/Tabs/index.tsx
+++ b/packages/core/src/theme/components/Tabs/index.tsx
@@ -18,7 +18,7 @@ type TabItem = {
   content?: ReactNode;
 };
 
-interface TabsProps {
+export interface TabsProps {
   values?: ReactNode[] | ReadonlyArray<ReactNode> | TabItem[];
   /**
    * @default 0

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -1,7 +1,7 @@
 // components
-export { Badge } from './components/Badge/index';
+export { Badge, type BadgeProps } from './components/Badge/index';
 export { Banner, type BannerProps } from './components/Banner/index';
-export { Button } from './components/Button/index';
+export { Button, type ButtonProps } from './components/Button/index';
 export { Callout, type CalloutProps } from './components/Callout/index';
 export { CodeBlock, type CodeBlockProps } from './components/CodeBlock/index';
 export {
@@ -90,11 +90,22 @@ export {
 } from './components/Search/SearchPanel';
 export { Sidebar, SidebarList } from './components/Sidebar/index';
 export { SocialLinks } from './components/SocialLinks/index';
-export { SourceCode } from './components/SourceCode/index';
+export {
+  SourceCode,
+  type SourceCodeProps,
+} from './components/SourceCode/index';
 export { Steps } from './components/Steps/index';
-export { SvgWrapper } from './components/SvgWrapper/index';
+export {
+  SvgWrapper,
+  type SvgWrapperProps,
+} from './components/SvgWrapper/index';
 export { SwitchAppearance } from './components/SwitchAppearance/index';
-export { Tab, Tabs } from './components/Tabs/index';
+export {
+  Tab,
+  type TabProps,
+  Tabs,
+  type TabsProps,
+} from './components/Tabs/index';
 export { Tag } from './components/Tag/index';
 export { Toc } from './components/Toc';
 export { useActiveAnchor } from './hooks/useActiveAnchor';


### PR DESCRIPTION
## Summary
- Export `BadgeProps`, `ButtonProps`, `SourceCodeProps`, `SvgWrapperProps`, `TabProps`, and `TabsProps` from `rspress/theme` public API
- These component props types were defined in source files but not re-exported, preventing proper type checking in custom implementations

close #1849