### PR TITLE
fix(plugin-preview): fix missing whitespace in calc() expression

### DIFF
--- a/packages/plugin-preview/static/global-components/FixedDevice.css
+++ b/packages/plugin-preview/static/global-components/FixedDevice.css
@@ -14,7 +14,7 @@
   display: none;
   position: fixed;
   top: calc(
-    var(--rp-nav-height) + var(--rp-sidebar-menu-height)+
+    var(--rp-nav-height) + var(--rp-sidebar-menu-height) +
       var(--rp-preview-padding) + var(--rp-banner-height, 0px)
   );
   right: max(


### PR DESCRIPTION
## Summary
- Fix a missing space before `+` operator in `calc()` expression in `FixedDevice.css`

## Test plan
- [ ] Verify the preview panel positioning is correct with the fixed CSS