### PR TITLE
fix(ssg-md): avoid generating "# undefined" in llms.txt and warn when title is missing

### DIFF
--- a/packages/core/src/node/ssg-md/llms/llmsTxt.ts
+++ b/packages/core/src/node/ssg-md/llms/llmsTxt.ts
@@ -23,7 +23,7 @@ async function generateLlmsTxt(
 
   if (!title) {
     logger.warn(
-      'No `title` found in your rspress config. It is recommended to set `title` in rspress.config.ts to generate a proper llms.txt heading.',
+      'No `title` is configured in your Rspress setup. Please set `title` in rspress.config.ts so llms.txt can include an appropriate heading.',
     );
   }
 

--- a/packages/plugin-llms/src/llmsTxt.ts
+++ b/packages/plugin-llms/src/llmsTxt.ts
@@ -29,7 +29,7 @@ function generateLlmsTxt(
 
   if (!onTitleGenerate && !title) {
     logger.warn(
-      'No `title` found in your rspress config. It is recommended to set `title` in rspress.config.ts to generate a proper llms.txt heading.',
+      'No `title` is configured in your Rspress setup. Please set `title` in rspress.config.ts so llms.txt can include an appropriate heading.',
     );
   }
 


### PR DESCRIPTION
## Summary

```ts
defineConfig({
  // title
})
```

```txt
# undefined

> undefined
```

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

---

## AI Summary

When `title` is not configured in `rspress.config.ts`, both `@rspress/plugin-llms` and the core `llms: true` feature generate `# undefined` as the heading in `llms.txt`. This is because the template literal `` `# ${title}` `` directly interpolates `undefined`.

### Changes

- **`packages/plugin-llms/src/llmsTxt.ts`**: When `title` is `undefined`, skip the heading instead of rendering `# undefined`, and emit a `logger.warn` to remind users to configure `title`.
- **`packages/core/src/node/ssg-md/llms/llmsTxt.ts`**: Same fix for the core `llms: true` code path.
- When `summary` is empty (no title), the final `llmsTxt` output starts directly from the section content with leading whitespace trimmed.

### Why

Generating `# undefined` in `llms.txt` is confusing and unhelpful. Instead of silently dropping the title, we warn users so they can fix their config, while still producing valid output.

This PR was written using [Vibe Kanban](https://vibekanban.com)

---