### PR TITLE
chore(infra): separate rstack and shiki into distinct renovate groups

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,26 +9,6 @@
       // always bump package.json
       rangeStrategy: 'bump',
     },
-    // Group Rstack ecosystem packages
-    {
-      groupName: 'rstack',
-      matchPackagePatterns: [
-        'rsbuild',
-        'rsdoctor',
-        'rslib',
-        'rspack',
-        'rstest',
-        'rspress',
-        'create-rstack',
-      ],
-      groupSlug: 'rstack',
-    },
-    // Group Shiki packages
-    {
-      groupName: 'shiki',
-      matchPackagePatterns: ['shiki'],
-      groupSlug: 'shiki',
-    },
     {
       groupName: 'modern-js',
       matchPackagePatterns: ['modern-js'],
@@ -65,6 +45,26 @@
       groupSlug: 'all-patch',
       matchPackagePatterns: ['*'],
       matchUpdateTypes: ['patch'],
+    },
+    // Group Rstack ecosystem packages (placed after all-patch to take precedence)
+    {
+      groupName: 'rstack',
+      matchPackagePatterns: [
+        'rsbuild',
+        'rsdoctor',
+        'rslib',
+        'rspack',
+        'rstest',
+        'rspress',
+        'create-rstack',
+      ],
+      groupSlug: 'rstack',
+    },
+    // Group Shiki packages (placed after all-patch to take precedence)
+    {
+      groupName: 'shiki',
+      matchPackagePatterns: ['shiki', '@shikijs/'],
+      groupSlug: 'shiki',
     },
     // manually update peer dependencies
     {


### PR DESCRIPTION
## Summary
- Group rstack ecosystem packages (rsbuild, rsdoctor, rslib, rspack, rstest, rspress, create-rstack) into a single `rstack` renovate group
- Group shiki packages into a separate `shiki` renovate group
- Previously rsbuild/rslib/rspack/rspress and shiki were mixed together in patch updates

## Test plan
- [ ] Verify renovate creates separate PRs for rstack and shiki updates