### PR TITLE
docs: restructure README npm badges into version table

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,26 @@ A fast Rsbuild-based static site generator.
 
 <p>
   <a href="https://discord.gg/mkVw5zPAtf"><img src="https://img.shields.io/badge/chat-discord-blue?logo=discord&colorA=564341&colorB=EDED91" alt="discord channel" /></a>
-  <a href="https://npmjs.com/package/rspress?activeTab=readme"><img src="https://img.shields.io/npm/v/rspress?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>
-  <a href="https://npmcharts.com/compare/rspress?minimal=true"><img src="https://img.shields.io/npm/dm/rspress.svg?style=flat-square&colorA=564341&colorB=EDED91" alt="downloads" /></a>
-  <a href="https://github.com/web-infra-dev/rspress/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/rspress?style=flat-square&colorA=564341&colorB=EDED91" alt="license" /></a>
+  <a href="https://github.com/web-infra-dev/rspress/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/@rspress/core?style=flat-square&colorA=564341&colorB=EDED91" alt="license" /></a>
   <a href="https://deepwiki.com/web-infra-dev/rspress"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
 </p>
+
+<table>
+  <tr>
+    <th>latest</th>
+    <td>
+      <a href="https://npmjs.com/package/@rspress/core?activeTab=readme"><img src="https://img.shields.io/npm/v/@rspress/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>
+      <a href="https://npmcharts.com/compare/@rspress/core?minimal=true"><img src="https://img.shields.io/npm/dm/@rspress/core.svg?style=flat-square&colorA=564341&colorB=EDED91" alt="downloads" /></a>
+    </td>
+  </tr>
+  <tr>
+    <th>1.x</th>
+    <td>
+      <a href="https://npmjs.com/package/rspress?activeTab=readme"><img src="https://img.shields.io/npm/v/rspress?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>
+      <a href="https://npmcharts.com/compare/rspress?minimal=true"><img src="https://img.shields.io/npm/dm/rspress.svg?style=flat-square&colorA=564341&colorB=EDED91" alt="downloads" /></a>
+    </td>
+  </tr>
+</table>
 
 ## 🔥 Features
 


### PR DESCRIPTION
## Summary

Difference from #3219:

Use a table to show badges for both major versions (`rspress` for 1.x / `@rspress/core` for 2.x).
I wish I could submit this several hours ago.

## Related Issue

<!--- Provide link of related issues -->

Fixes #3216
Conflicts with #3219

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
