### PR TITLE
chore(core): remove filename hash workaround for preserveModules build

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -53,7 +53,6 @@ export default defineConfig({
       output: {
         target: 'node',
         externals: COMMON_EXTERNALS,
-        filenameHash: true,
       },
       tools: {
         rspack: {


### PR DESCRIPTION
## Summary

- remove the `filenameHash` workaround from the `@rspress/core` Node preserveModules build
- the hash was originally added to avoid collisions between files with the same name
- rspack has fixed that underlying bug, so stable unhashed output paths are now safe again

## Related Issue

- N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Verification

- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm exec pnpm nx build @rspress/core`
