### PR TITLE
fix(theme/search): reset selected suggestion to first when search query changes

### DIFF
--- a/e2e/fixtures/search/index.test.ts
+++ b/e2e/fixtures/search/index.test.ts
@@ -147,4 +147,57 @@ test.describe('search keyboard', async () => {
     searchPanel = await page.$('.rp-search-panel__mask');
     expect(searchPanel).toBeNull();
   });
+
+  test('should reset to first suggestion when search query changes', async ({
+    page,
+  }) => {
+    await page.goto(`http://localhost:${appPort}/base/`, {
+      waitUntil: 'networkidle',
+    });
+
+    // Open search panel
+    const searchButton = await page.$('.rp-search-button');
+    await searchButton?.click();
+    await page.waitForSelector('.rp-search-panel__input');
+
+    // Type first search query
+    const searchInput = await page.$('.rp-search-panel__input');
+    await searchInput?.focus();
+    await page.keyboard.type('Foo');
+    await page.waitForTimeout(400);
+
+    // Wait for search results
+    await page.waitForSelector('.rp-suggest-item');
+    const suggestItems = await page.$$('.rp-suggest-item');
+    expect(suggestItems.length).toBeGreaterThan(0);
+
+    // Navigate to second item
+    await page.keyboard.press('ArrowDown');
+    await page.waitForTimeout(100);
+    let currentIndex = await page.evaluate(() => {
+      const items = Array.from(document.querySelectorAll('.rp-suggest-item'));
+      const current = document.querySelector(
+        '.rp-suggest-item.rp-suggest-item--current',
+      );
+      return items.indexOf(current as Element);
+    });
+    expect(currentIndex).toBe(1);
+
+    // Change search query
+    await searchInput?.fill('Bar');
+    await page.waitForTimeout(400);
+
+    // Wait for new search results
+    await page.waitForSelector('.rp-suggest-item');
+
+    // Verify that first item is now selected
+    currentIndex = await page.evaluate(() => {
+      const items = Array.from(document.querySelectorAll('.rp-suggest-item'));
+      const current = document.querySelector(
+        '.rp-suggest-item.rp-suggest-item--current',
+      );
+      return items.indexOf(current as Element);
+    });
+    expect(currentIndex).toBe(0);
+  });
 });

--- a/e2e/fixtures/search/index.test.ts
+++ b/e2e/fixtures/search/index.test.ts
@@ -166,7 +166,7 @@ test.describe('search keyboard', async () => {
     await searchInput.focus();
 
     // Type first search query
-    await page.keyboard.type('1.');
+    await page.keyboard.type('Foo');
     await page.waitForTimeout(500);
 
     // Wait for search results to be visible
@@ -187,7 +187,7 @@ test.describe('search keyboard', async () => {
     expect(currentIndex).toBe(1);
 
     // Change search query
-    await searchInput.fill('1');
+    await searchInput.fill('Fo');
     await page.waitForTimeout(500);
 
     // Wait for new search results to be visible

--- a/e2e/fixtures/search/index.test.ts
+++ b/e2e/fixtures/search/index.test.ts
@@ -176,31 +176,39 @@ test.describe('search keyboard', async () => {
 
     // Navigate to second item
     await page.keyboard.press('ArrowDown');
-    await page.waitForTimeout(200);
-    let currentIndex = await page.evaluate(() => {
-      const items = Array.from(document.querySelectorAll('.rp-suggest-item'));
-      const current = document.querySelector(
-        '.rp-suggest-item.rp-suggest-item--current',
-      );
-      return items.indexOf(current as Element);
-    });
-    expect(currentIndex).toBe(1);
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const items = Array.from(
+            document.querySelectorAll('.rp-suggest-item'),
+          );
+          const current = document.querySelector(
+            '.rp-suggest-item.rp-suggest-item--current',
+          );
+          return items.indexOf(current as Element);
+        }),
+      )
+      .toBe(1);
 
     // Change search query
     await searchInput.fill('Ba');
-    await page.waitForTimeout(500);
 
     // Wait for new search results to be visible
     await page.waitForSelector('.rp-suggest-item', { state: 'visible' });
 
     // Verify that first item is now selected
-    currentIndex = await page.evaluate(() => {
-      const items = Array.from(document.querySelectorAll('.rp-suggest-item'));
-      const current = document.querySelector(
-        '.rp-suggest-item.rp-suggest-item--current',
-      );
-      return items.indexOf(current as Element);
-    });
-    expect(currentIndex).toBe(0);
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const items = Array.from(
+            document.querySelectorAll('.rp-suggest-item'),
+          );
+          const current = document.querySelector(
+            '.rp-suggest-item.rp-suggest-item--current',
+          );
+          return items.indexOf(current as Element);
+        }),
+      )
+      .toBe(0);
   });
 });

--- a/e2e/fixtures/search/index.test.ts
+++ b/e2e/fixtures/search/index.test.ts
@@ -166,7 +166,7 @@ test.describe('search keyboard', async () => {
     await searchInput.focus();
 
     // Type first search query
-    await page.keyboard.type('Foo');
+    await page.keyboard.type('Bar');
     await page.waitForTimeout(500);
 
     // Wait for search results to be visible
@@ -187,7 +187,7 @@ test.describe('search keyboard', async () => {
     expect(currentIndex).toBe(1);
 
     // Change search query
-    await searchInput.fill('Fo');
+    await searchInput.fill('Ba');
     await page.waitForTimeout(500);
 
     // Wait for new search results to be visible

--- a/e2e/fixtures/search/index.test.ts
+++ b/e2e/fixtures/search/index.test.ts
@@ -163,7 +163,7 @@ test.describe('search keyboard', async () => {
     // Type first search query
     const searchInput = await page.$('.rp-search-panel__input');
     await searchInput?.focus();
-    await page.keyboard.type('Foo');
+    await page.keyboard.type('1.');
     await page.waitForTimeout(400);
 
     // Wait for search results
@@ -184,7 +184,7 @@ test.describe('search keyboard', async () => {
     expect(currentIndex).toBe(1);
 
     // Change search query
-    await searchInput?.fill('Bar');
+    await searchInput?.fill('1');
     await page.waitForTimeout(400);
 
     // Wait for new search results

--- a/e2e/fixtures/search/index.test.ts
+++ b/e2e/fixtures/search/index.test.ts
@@ -158,22 +158,25 @@ test.describe('search keyboard', async () => {
     // Open search panel
     const searchButton = await page.$('.rp-search-button');
     await searchButton?.click();
-    await page.waitForSelector('.rp-search-panel__input');
+
+    // Wait for search input to be visible and focus it
+    const searchInput = await page.waitForSelector('.rp-search-panel__input', {
+      state: 'visible',
+    });
+    await searchInput.focus();
 
     // Type first search query
-    const searchInput = await page.$('.rp-search-panel__input');
-    await searchInput?.focus();
     await page.keyboard.type('1.');
-    await page.waitForTimeout(400);
+    await page.waitForTimeout(500);
 
-    // Wait for search results
-    await page.waitForSelector('.rp-suggest-item');
+    // Wait for search results to be visible
+    await page.waitForSelector('.rp-suggest-item', { state: 'visible' });
     const suggestItems = await page.$$('.rp-suggest-item');
     expect(suggestItems.length).toBeGreaterThan(0);
 
     // Navigate to second item
     await page.keyboard.press('ArrowDown');
-    await page.waitForTimeout(100);
+    await page.waitForTimeout(200);
     let currentIndex = await page.evaluate(() => {
       const items = Array.from(document.querySelectorAll('.rp-suggest-item'));
       const current = document.querySelector(
@@ -184,11 +187,11 @@ test.describe('search keyboard', async () => {
     expect(currentIndex).toBe(1);
 
     // Change search query
-    await searchInput?.fill('1');
-    await page.waitForTimeout(400);
+    await searchInput.fill('1');
+    await page.waitForTimeout(500);
 
-    // Wait for new search results
-    await page.waitForSelector('.rp-suggest-item');
+    // Wait for new search results to be visible
+    await page.waitForSelector('.rp-suggest-item', { state: 'visible' });
 
     // Verify that first item is now selected
     currentIndex = await page.evaluate(() => {

--- a/e2e/fixtures/search/index.test.ts
+++ b/e2e/fixtures/search/index.test.ts
@@ -167,7 +167,6 @@ test.describe('search keyboard', async () => {
 
     // Type first search query
     await page.keyboard.type('Bar');
-    await page.waitForTimeout(500);
 
     // Wait for search results to be visible
     await page.waitForSelector('.rp-suggest-item', { state: 'visible' });

--- a/packages/core/src/theme/components/Search/SearchPanel.tsx
+++ b/packages/core/src/theme/components/Search/SearchPanel.tsx
@@ -345,11 +345,11 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
         await userSearchHooks[key](newQuery, searchResult);
       }
 
-      // Reset current suggestion index to 0 when search query changes
-      setCurrentSuggestionIndex(0);
       // only setSearchResult when query is current query value
       const currQuery = searchInputRef.current?.value;
       if (currQuery === newQuery) {
+        // Reset current suggestion index to 0 when search query changes
+        setCurrentSuggestionIndex(0);
         setSearchResult(searchResult || DEFAULT_RESULT);
         setIsSearching(false);
       }

--- a/packages/core/src/theme/components/Search/SearchPanel.tsx
+++ b/packages/core/src/theme/components/Search/SearchPanel.tsx
@@ -350,6 +350,8 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
       if (currQuery === newQuery) {
         setSearchResult(searchResult || DEFAULT_RESULT);
         setIsSearching(false);
+        // Reset current suggestion index to 0 when search query changes
+        setCurrentSuggestionIndex(0);
       }
     }
   };

--- a/packages/core/src/theme/components/Search/SearchPanel.tsx
+++ b/packages/core/src/theme/components/Search/SearchPanel.tsx
@@ -345,13 +345,13 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
         await userSearchHooks[key](newQuery, searchResult);
       }
 
+      // Reset current suggestion index to 0 when search query changes
+      setCurrentSuggestionIndex(0);
       // only setSearchResult when query is current query value
       const currQuery = searchInputRef.current?.value;
       if (currQuery === newQuery) {
         setSearchResult(searchResult || DEFAULT_RESULT);
         setIsSearching(false);
-        // Reset current suggestion index to 0 when search query changes
-        setCurrentSuggestionIndex(0);
       }
     }
   };


### PR DESCRIPTION
## Summary

When the search query changes, the selected suggestion in the search panel now automatically resets to the first item, providing a better user experience by always highlighting the most relevant result first.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
