### PR TITLE
docs: mention rspress-description-generator agent skill in custom-head docs

### DIFF
--- a/website/docs/en/guide/advanced/custom-head.mdx
+++ b/website/docs/en/guide/advanced/custom-head.mdx
@@ -22,6 +22,10 @@ description: Custom description for this page.
 ---
 ```
 
+:::tip
+You can use the [rspress-description-generator](https://github.com/rstackjs/agent-skills#rspress-description-generator) agent skill to automatically generate descriptions for all pages. See [Agent Skills](/guide/start/ai#agent-skills) for more details.
+:::
+
 If you want to add head tags, you can use the following methods:
 
 ## Global head configuration

--- a/website/docs/zh/guide/advanced/custom-head.mdx
+++ b/website/docs/zh/guide/advanced/custom-head.mdx
@@ -22,6 +22,10 @@ description: 自定义页面描述。
 ---
 ```
 
+:::tip
+你可以使用 [rspress-description-generator](https://github.com/rstackjs/agent-skills#rspress-description-generator) agent skill 来自动为所有页面生成 description。详见 [Agent Skills](/guide/start/ai#agent-skills)。
+:::
+
 如果想增加 Head 标签可以通过以下几种方式：
 
 ## 全局 Head 配置


### PR DESCRIPTION
## Summary

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).

---

Added a tip in the "How description is determined" section of the custom-head docs (both English and Chinese) to mention the [`rspress-description-generator`](https://github.com/rstackjs/agent-skills#rspress-description-generator) agent skill, which can automatically generate `description` frontmatter for all pages.

This helps users discover the agent skill as a convenient alternative to manually writing descriptions for every page, complementing the existing documentation on how descriptions are extracted and overridden.

This PR was written using [Vibe Kanban](https://vibekanban.com)

---