### PR TITLE
style(theme/sidebar): remove redundant first-child margin-top reset

### DIFF
--- a/packages/core/src/theme/components/Sidebar/SidebarItem.scss
+++ b/packages/core/src/theme/components/Sidebar/SidebarItem.scss
@@ -15,10 +15,6 @@
     color 0.15s,
     background-color 0.15s;
 
-  &:first-child {
-    margin-top: 0;
-  }
-
   &:hover,
   &--pending {
     color: var(--rp-c-text-1);


### PR DESCRIPTION
## Summary

before

<img width="285" height="333" alt="image" src="https://github.com/user-attachments/assets/f2f3c5c5-3778-42b1-a8d4-bd0ab603f5ba" />

after

<img width="289" height="354" alt="image" src="https://github.com/user-attachments/assets/2e31b4b7-2312-47f6-8f22-cae710d0a29e" />


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

---

## AI Summary

Removed the redundant `&:first-child { margin-top: 0; }` rule from `.rp-sidebar-item` in `SidebarItem.scss`.

The `.rp-sidebar-item` has a `margin-top: 2px` applied to all items for spacing. The `:first-child` override to `margin-top: 0` is unnecessary because the first sidebar item's top margin does not cause any visual issue — the parent container already handles its own padding/spacing. Removing this rule simplifies the stylesheet without affecting layout.

This PR was written using [Vibe Kanban](https://vibekanban.com)

---