### PR TITLE
docs: add back-to-blog button on blog subpages via custom theme

### DIFF
--- a/website/i18n.json
+++ b/website/i18n.json
@@ -58,5 +58,9 @@
   "nonEjectableDescription": {
     "zh": "该组件目前暂不支持 <link> 通过 eject 命令复制源码。",
     "en": "This component currently does not support copying source code via the eject command."
+  },
+  "backToBlog": {
+    "zh": "← 返回博客",
+    "en": "← Back to Blog"
   }
 }

--- a/website/theme/components/BlogBackButton.tsx
+++ b/website/theme/components/BlogBackButton.tsx
@@ -1,0 +1,22 @@
+import { useI18n, useLang, useLocation } from '@rspress/core/runtime';
+import { Link } from '@rspress/core/theme-original';
+
+export function BlogBackButton() {
+  const { pathname } = useLocation();
+  const lang = useLang();
+  const t = useI18n<typeof import('i18n')>();
+
+  const blogPrefix = lang === 'en' ? '/blog' : `/${lang}/blog`;
+  const isBlogSubpage =
+    pathname.startsWith(`${blogPrefix}/`) && pathname !== `${blogPrefix}/`;
+
+  if (!isBlogSubpage) {
+    return null;
+  }
+
+  return (
+    <div className="blog-back-button">
+      <Link href={`${blogPrefix}/`}>{t('backToBlog')}</Link>
+    </div>
+  );
+}

--- a/website/theme/index.css
+++ b/website/theme/index.css
@@ -5,3 +5,19 @@
     width: 12vw !important;
   }
 }
+
+.blog-back-button {
+  margin-bottom: 1rem;
+}
+
+.blog-back-button a {
+  color: var(--rp-c-text-2);
+  font-size: 14px;
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.blog-back-button a:hover,
+.blog-back-button a:focus-visible {
+  color: var(--rp-c-brand);
+}

--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -5,11 +5,13 @@ import {
   useLocation,
 } from '@rspress/core/runtime';
 import {
+  DocLayout as BasicDocLayout,
   HomeHero as BasicHomeHero,
   HomeLayout as BasicHomeLayout,
   Layout as BasicLayout,
   getCustomMDXComponent as basicGetCustomMDXComponent,
   Callout,
+  type DocLayoutProps,
   type HomeHeroProps,
   Link,
   PackageManagerTabs,
@@ -23,6 +25,7 @@ import type { PropsWithChildren } from 'react';
 import { CssModificationProvider } from '../docs/components/CssModificationContext';
 import { CssModificationIndicator } from '../docs/components/CssModificationIndicator';
 import { CssStyleSync } from '../docs/components/CssStyleSync';
+import { BlogBackButton } from './components/BlogBackButton';
 import { HeroInteractive } from './components/HeroInteractive';
 import { Tag } from './components/Tag';
 import { ToolStack } from './components/ToolStack';
@@ -55,6 +58,20 @@ const Layout = () => {
       <CssModificationIndicator />
       <BasicLayout beforeNavTitle={<NavIcon />} />
     </CssModificationProvider>
+  );
+};
+
+const DocLayout = (props: DocLayoutProps) => {
+  return (
+    <BasicDocLayout
+      {...props}
+      beforeDocContent={
+        <>
+          <BlogBackButton />
+          {props.beforeDocContent}
+        </>
+      }
+    />
   );
 };
 
@@ -130,4 +147,12 @@ function getCustomMDXComponent() {
 }
 
 export * from '@rspress/core/theme-original';
-export { getCustomMDXComponent, HomeHero, HomeLayout, Layout, Search, Tag };
+export {
+  DocLayout,
+  getCustomMDXComponent,
+  HomeHero,
+  HomeLayout,
+  Layout,
+  Search,
+  Tag,
+};


### PR DESCRIPTION
## Summary

<img width="1523" height="889" alt="image" src="https://github.com/user-attachments/assets/294d18b2-bd34-448d-861a-9c8622960cf2" />


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

---

## AI Summary

### What
Added a "Back to Blog" button that appears at the top of all blog subpages (e.g., `/blog/rspress-v2`), linking back to the blog index (`/blog/`).

### Why
Blog subpages have `sidebar: false` set, so there is no sidebar navigation to help users return to the blog listing. A back button improves navigation UX for blog readers.

### Implementation Details
- **Custom theme override**: Overrode `DocLayout` in `website/theme/index.tsx` by wrapping `BasicDocLayout` and injecting a `BlogBackButton` component via the `beforeDocContent` slot.
- **`BlogBackButton` component** (`website/theme/components/BlogBackButton.tsx`): Uses `useLocation()` to detect if the current page is a blog subpage (matches `/blog/*` but not `/blog/` itself). Returns `null` on non-blog pages.
- **i18n support**: Added `backToBlog` entry in `website/i18n.json` with both English (`← Back to Blog`) and Chinese (`← 返回博客`) translations.
- **Styling**: Added `.blog-back-button` CSS in `website/theme/index.css` with secondary text color and brand color on hover.

This PR was written using [Vibe Kanban](https://vibekanban.com)

---