### PR TITLE
docs: add documentation for themeDir and i18nSourcePath config options

### DIFF
--- a/website/docs/en/api/config/config-basic.mdx
+++ b/website/docs/en/api/config/config-basic.mdx
@@ -111,6 +111,28 @@ export default defineConfig({
 });
 ```
 
+## i18nSourcePath
+
+- **Type**: `string`
+- **Default**: `path.join(cwd, 'i18n.json')`
+
+Specifies the path of the i18n text data source file. By default, Rspress reads from `i18n.json` in the current working directory. For example:
+
+```ts title="rspress.config.ts"
+import { defineConfig } from '@rspress/core';
+import path from 'path';
+
+export default defineConfig({
+  i18nSourcePath: path.join(__dirname, 'config/i18n.json'),
+});
+```
+
+:::tip
+
+This has the same effect as placing an `i18n.json` at the project root. If you also configure `i18nSource`, the `i18nSource` will be merged with and take priority over the data loaded from `i18nSourcePath`.
+
+:::
+
 ## i18nSource
 
 - **Type**: `Record<string, Record<string, string>> | ((value: Record<string, Record<string, string>>) => Record<string, Record<string, string>> | Promise<Record<string, Record<string, string>>>)`
@@ -250,6 +272,26 @@ export default defineConfig({
   outDir: 'doc_build',
 });
 ```
+
+## themeDir
+
+- **Type**: `string`
+- **Default**: `theme`
+
+Specifies the custom theme directory. By default, Rspress uses the `theme` directory under the current working directory as the custom theme directory. You can use `themeDir` to customize it. For example:
+
+```ts title="rspress.config.ts"
+import { defineConfig } from '@rspress/core';
+import path from 'path';
+
+export default defineConfig({
+  themeDir: path.join(__dirname, 'my-theme'),
+});
+```
+
+This config supports both relative and absolute paths, with relative paths being relative to the current working directory.
+
+For more details on custom themes, see [Custom Theme](/guide/basic/custom-theme).
 
 ## locales
 

--- a/website/docs/zh/api/config/config-basic.mdx
+++ b/website/docs/zh/api/config/config-basic.mdx
@@ -111,6 +111,28 @@ export default defineConfig({
 });
 ```
 
+## i18nSourcePath
+
+- **类型**： `string`
+- **默认值**： `path.join(cwd, 'i18n.json')`
+
+指定国际化文案数据源文件的路径。默认情况下，Rspress 从当前工作目录下的 `i18n.json` 读取。例如：
+
+```ts title="rspress.config.ts"
+import { defineConfig } from '@rspress/core';
+import path from 'path';
+
+export default defineConfig({
+  i18nSourcePath: path.join(__dirname, 'config/i18n.json'),
+});
+```
+
+:::tip
+
+效果与在项目根目录放置 `i18n.json` 文件一致。如果同时配置了 `i18nSource`，`i18nSource` 的数据将会合并并覆盖 `i18nSourcePath` 加载的数据。
+
+:::
+
 ## i18nSource
 
 - **类型**： `Record<string, Record<string, string>> | ((value: Record<string, Record<string, string>>) => Record<string, Record<string, string>> | Promise<Record<string, Record<string, string>>>)`
@@ -250,6 +272,26 @@ export default defineConfig({
   outDir: 'doc_build',
 });
 ```
+
+## themeDir
+
+- **类型**： `string`
+- **默认值**： `theme`
+
+指定自定义主题目录。默认情况下，Rspress 使用当前工作目录下的 `theme` 目录作为自定义主题目录。你可以通过 `themeDir` 来自定义它。例如：
+
+```ts title="rspress.config.ts"
+import { defineConfig } from '@rspress/core';
+import path from 'path';
+
+export default defineConfig({
+  themeDir: path.join(__dirname, 'my-theme'),
+});
+```
+
+该配置同时支持相对路径和绝对路径，相对路径相对于当前工作目录。
+
+更多关于自定义主题的内容，请参阅 [自定义主题](/guide/basic/custom-theme)。
 
 ## locales
 


### PR DESCRIPTION
## Summary

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).

---

## AI Summary

### What changed

Added missing documentation for two `UserConfig` options in both English and Chinese (`config-basic.mdx`):

- **`themeDir`** — Specifies the custom theme directory (default: `theme`). Supports relative and absolute paths. Placed after the `outDir` section with a link to the Custom Theme guide.
- **`i18nSourcePath`** — Specifies the path of the i18n text data source file (default: `<cwd>/i18n.json`). Placed before the `i18nSource` section with a tip explaining the priority relationship between the two options.

### Why

These two config options were defined in the `UserConfig` TypeScript interface (`packages/shared/src/types/index.ts`) and fully functional in the codebase, but had no corresponding entries in the API documentation. This made them undiscoverable for users.

This PR was written using [Vibe Kanban](https://vibekanban.com)

---