### PR TITLE
fix(theme): replace @theme imports with @rspress/core/theme to fix type resolve

### DIFF
--- a/packages/core/src/theme/components/Banner/index.tsx
+++ b/packages/core/src/theme/components/Banner/index.tsx
@@ -1,4 +1,4 @@
-import { IconClose, Link, mergeRefs, SvgWrapper } from '@theme';
+import { IconClose, Link, mergeRefs, SvgWrapper } from '@rspress/core/theme';
 import clsx from 'clsx';
 import { forwardRef, type ReactNode, useEffect, useState } from 'react';
 import './index.scss';

--- a/packages/core/src/theme/components/Button/index.tsx
+++ b/packages/core/src/theme/components/Button/index.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@theme';
+import { Link } from '@rspress/core/theme';
 import clsx from 'clsx';
 import React, { type JSX } from 'react';
 import './index.scss';

--- a/packages/core/src/theme/components/CodeBlock/index.tsx
+++ b/packages/core/src/theme/components/CodeBlock/index.tsx
@@ -4,7 +4,7 @@ import {
   IconArrowDown,
   SvgWrapper,
   useCodeButtonGroup,
-} from '@theme';
+} from '@rspress/core/theme';
 import clsx from 'clsx';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import './index.scss';

--- a/packages/core/src/theme/components/CodeBlockRuntime/index.tsx
+++ b/packages/core/src/theme/components/CodeBlockRuntime/index.tsx
@@ -1,5 +1,5 @@
-import type { CodeBlockProps } from '@theme';
-import { getCustomMDXComponent } from '@theme';
+import type { CodeBlockProps } from '@rspress/core/theme';
+import { getCustomMDXComponent } from '@rspress/core/theme';
 import { toJsxRuntime } from 'hast-util-to-jsx-runtime';
 import {
   Fragment,

--- a/packages/core/src/theme/components/CodeButtonGroup/CopyCodeButton.tsx
+++ b/packages/core/src/theme/components/CodeButtonGroup/CopyCodeButton.tsx
@@ -1,4 +1,4 @@
-import { IconCopy, IconSuccess, SvgWrapper } from '@theme';
+import { IconCopy, IconSuccess, SvgWrapper } from '@rspress/core/theme';
 import copy from 'copy-to-clipboard';
 import { useRef } from 'react';
 import './CopyCodeButton.scss';

--- a/packages/core/src/theme/components/CodeButtonGroup/index.tsx
+++ b/packages/core/src/theme/components/CodeButtonGroup/index.tsx
@@ -1,5 +1,5 @@
 import { useSite } from '@rspress/core/runtime';
-import { IconWrap, IconWrapped, SvgWrapper } from '@theme';
+import { IconWrap, IconWrapped, SvgWrapper } from '@rspress/core/theme';
 import clsx from 'clsx';
 import { useRef, useState } from 'react';
 import './index.scss';

--- a/packages/core/src/theme/components/DocContent/docComponents/a.tsx
+++ b/packages/core/src/theme/components/DocContent/docComponents/a.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@theme';
+import { Link } from '@rspress/core/theme';
 import type { ComponentProps } from 'react';
 
 export const A = (props: ComponentProps<'a'>) => {

--- a/packages/core/src/theme/components/DocContent/docComponents/pre.tsx
+++ b/packages/core/src/theme/components/DocContent/docComponents/pre.tsx
@@ -1,4 +1,4 @@
-import { CodeBlock, type CodeBlockProps } from '@theme';
+import { CodeBlock, type CodeBlockProps } from '@rspress/core/theme';
 
 export type ShikiPreProps = CodeBlockProps &
   React.HTMLAttributes<HTMLPreElement>;

--- a/packages/core/src/theme/components/DocContent/docComponents/title.tsx
+++ b/packages/core/src/theme/components/DocContent/docComponents/title.tsx
@@ -1,5 +1,10 @@
 import { useFrontmatter, useSite } from '@rspress/core/runtime';
-import { LlmsContainer, LlmsCopyButton, LlmsViewOptions, Tag } from '@theme';
+import {
+  LlmsContainer,
+  LlmsCopyButton,
+  LlmsViewOptions,
+  Tag,
+} from '@rspress/core/theme';
 import clsx from 'clsx';
 import type React from 'react';
 

--- a/packages/core/src/theme/components/DocContent/index.tsx
+++ b/packages/core/src/theme/components/DocContent/index.tsx
@@ -5,7 +5,7 @@ import {
   FallbackHeading,
   getCustomMDXComponent,
   useScrollAfterNav,
-} from '@theme';
+} from '@rspress/core/theme';
 import './doc.scss';
 
 function FallbackTitle() {

--- a/packages/core/src/theme/components/DocFooter/index.tsx
+++ b/packages/core/src/theme/components/DocFooter/index.tsx
@@ -1,4 +1,4 @@
-import { EditLink, LastUpdated, PrevNextPage } from '@theme';
+import { EditLink, LastUpdated, PrevNextPage } from '@rspress/core/theme';
 import './index.scss';
 
 export function DocFooter() {

--- a/packages/core/src/theme/components/EditLink/index.tsx
+++ b/packages/core/src/theme/components/EditLink/index.tsx
@@ -1,4 +1,4 @@
-import { IconEdit, Link, SvgWrapper } from '@theme';
+import { IconEdit, Link, SvgWrapper } from '@rspress/core/theme';
 import './index.scss';
 import { useEditLink } from './useEditLink';
 

--- a/packages/core/src/theme/components/FallbackHeading/index.tsx
+++ b/packages/core/src/theme/components/FallbackHeading/index.tsx
@@ -1,4 +1,7 @@
-import { getCustomMDXComponent, renderInlineMarkdown } from '@theme';
+import {
+  getCustomMDXComponent,
+  renderInlineMarkdown,
+} from '@rspress/core/theme';
 import { slug } from 'github-slugger';
 import { useMemo } from 'react';
 

--- a/packages/core/src/theme/components/HomeFeature/index.tsx
+++ b/packages/core/src/theme/components/HomeFeature/index.tsx
@@ -1,6 +1,10 @@
 import type { Feature } from '@rspress/core';
 import { useFrontmatter } from '@rspress/core/runtime';
-import { renderHtmlOrText, SvgWrapper, useLinkNavigate } from '@theme';
+import {
+  renderHtmlOrText,
+  SvgWrapper,
+  useLinkNavigate,
+} from '@rspress/core/theme';
 import type { JSX } from 'react';
 import './index.scss';
 import { useCardAnimation } from './useCardAnimation';

--- a/packages/core/src/theme/components/HomeFooter/index.tsx
+++ b/packages/core/src/theme/components/HomeFooter/index.tsx
@@ -1,5 +1,5 @@
 import { useSite } from '@rspress/core/runtime';
-import { renderHtmlOrText } from '@theme';
+import { renderHtmlOrText } from '@rspress/core/theme';
 import './index.scss';
 
 export function HomeFooter() {

--- a/packages/core/src/theme/components/HomeHero/index.tsx
+++ b/packages/core/src/theme/components/HomeHero/index.tsx
@@ -1,6 +1,6 @@
 import type { FrontMatterMeta } from '@rspress/core';
 import { normalizeImagePath, useFrontmatter } from '@rspress/core/runtime';
-import { Button, Link, renderHtmlOrText } from '@theme';
+import { Button, Link, renderHtmlOrText } from '@rspress/core/theme';
 
 import './index.scss';
 import clsx from 'clsx';

--- a/packages/core/src/theme/components/HoverGroup/index.tsx
+++ b/packages/core/src/theme/components/HoverGroup/index.tsx
@@ -1,6 +1,6 @@
 import type { NavItemWithChildren } from '@rspress/core';
 import { matchNavbar, useLocation } from '@rspress/core/runtime';
-import { Link, Tag } from '@theme';
+import { Link, Tag } from '@rspress/core/theme';
 import cls from 'clsx';
 
 import './index.scss';

--- a/packages/core/src/theme/components/Link/useLinkNavigate.ts
+++ b/packages/core/src/theme/components/Link/useLinkNavigate.ts
@@ -61,7 +61,7 @@ export function getHref(href: string): {
 }
 
 /**
- * For import { Link } from '@theme';
+ * For import { Link } from '@rspress/core/theme';
  * useNavigate with preload logic
  */
 export function useLinkNavigate(

--- a/packages/core/src/theme/components/Llms/LlmsCopyButton.tsx
+++ b/packages/core/src/theme/components/Llms/LlmsCopyButton.tsx
@@ -4,7 +4,7 @@
  * @license MIT
  */
 import { useI18n } from '@rspress/core/runtime';
-import { IconCopy, IconSuccess } from '@theme';
+import { IconCopy, IconSuccess } from '@rspress/core/theme';
 import { useCallback, useRef, useState } from 'react';
 import { SvgWrapper } from '../SvgWrapper';
 import './index.scss';

--- a/packages/core/src/theme/components/Llms/LlmsCopyRow.tsx
+++ b/packages/core/src/theme/components/Llms/LlmsCopyRow.tsx
@@ -1,5 +1,5 @@
 import { useI18n } from '@rspress/core/runtime';
-import { IconCopy, IconSuccess, SvgWrapper } from '@theme';
+import { IconCopy, IconSuccess, SvgWrapper } from '@rspress/core/theme';
 import { useCallback, useRef, useState } from 'react';
 import { copyToClipboard } from './copy';
 import { useMdUrl } from './useMdUrl';

--- a/packages/core/src/theme/components/Llms/LlmsOpenRow.tsx
+++ b/packages/core/src/theme/components/Llms/LlmsOpenRow.tsx
@@ -1,5 +1,5 @@
 import { useI18n, useSite } from '@rspress/core/runtime';
-import { IconExternalLink, SvgWrapper } from '@theme';
+import { IconExternalLink, SvgWrapper } from '@rspress/core/theme';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import './LlmsOpenRow.scss';
 import './LlmsViewOptions.scss';

--- a/packages/core/src/theme/components/Llms/LlmsViewOptions.tsx
+++ b/packages/core/src/theme/components/Llms/LlmsViewOptions.tsx
@@ -4,7 +4,7 @@
  * @license MIT
  */
 import { useI18n, useSite } from '@rspress/core/runtime';
-import { IconDown, IconExternalLink, IconLink } from '@theme';
+import { IconDown, IconExternalLink, IconLink } from '@rspress/core/theme';
 import type React from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { SvgWrapper } from '../SvgWrapper';

--- a/packages/core/src/theme/components/Nav/NavMenu.tsx
+++ b/packages/core/src/theme/components/Nav/NavMenu.tsx
@@ -5,8 +5,14 @@ import type {
   NavItemWithLinkAndChildren,
 } from '@rspress/core';
 import { matchNavbar, useLocation } from '@rspress/core/runtime';
-import type { HoverGroupProps } from '@theme';
-import { IconArrowDown, Link, SvgWrapper, Tag, useHoverGroup } from '@theme';
+import type { HoverGroupProps } from '@rspress/core/theme';
+import {
+  IconArrowDown,
+  Link,
+  SvgWrapper,
+  Tag,
+  useHoverGroup,
+} from '@rspress/core/theme';
 import cls from 'clsx';
 import { type ReactNode, useMemo } from 'react';
 import { useLangsMenu, useVersionsMenu } from './hooks';

--- a/packages/core/src/theme/components/Nav/index.tsx
+++ b/packages/core/src/theme/components/Nav/index.tsx
@@ -5,7 +5,7 @@ import {
   Search,
   SocialLinks,
   SwitchAppearance,
-} from '@theme';
+} from '@rspress/core/theme';
 import './index.scss';
 import { NavLangs, NavMenu, NavMenuDivider, NavVersions } from './NavMenu';
 

--- a/packages/core/src/theme/components/NavHamburger/index.tsx
+++ b/packages/core/src/theme/components/NavHamburger/index.tsx
@@ -1,4 +1,9 @@
-import { IconSmallMenu, SocialLinks, SvgWrapper, useHoverGroup } from '@theme';
+import {
+  IconSmallMenu,
+  SocialLinks,
+  SvgWrapper,
+  useHoverGroup,
+} from '@rspress/core/theme';
 import clsx from 'clsx';
 import { createPortal } from 'react-dom';
 import { NavVersions } from '../Nav/NavMenu';

--- a/packages/core/src/theme/components/NavScreen/NavScreenAppearance.tsx
+++ b/packages/core/src/theme/components/NavScreen/NavScreenAppearance.tsx
@@ -1,5 +1,5 @@
 import { NoSSR, useI18n, useSite } from '@rspress/core/runtime';
-import { SwitchAppearance } from '@theme';
+import { SwitchAppearance } from '@rspress/core/theme';
 import './NavScreenAppearance.scss';
 
 export function NavScreenAppearance() {

--- a/packages/core/src/theme/components/NavScreen/NavScreenLangs.tsx
+++ b/packages/core/src/theme/components/NavScreen/NavScreenLangs.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useLangsMenu } from '../Nav/hooks';
 import './NavScreenLangs.scss';
 import { useI18n } from '@rspress/core/runtime';
-import { Link } from '@theme';
+import { Link } from '@rspress/core/theme';
 import clsx from 'clsx';
 import { SvgDown } from './NavScreenMenuItem';
 

--- a/packages/core/src/theme/components/NavScreen/NavScreenMenuItem.tsx
+++ b/packages/core/src/theme/components/NavScreen/NavScreenMenuItem.tsx
@@ -5,7 +5,7 @@ import type {
   NavItemWithLinkAndChildren,
 } from '@rspress/core';
 import { matchNavbar, useLocation } from '@rspress/core/runtime';
-import { IconArrowDown, Link, SvgWrapper, Tag } from '@theme';
+import { IconArrowDown, Link, SvgWrapper, Tag } from '@rspress/core/theme';
 import clsx from 'clsx';
 import type React from 'react';
 import { useMemo, useState } from 'react';

--- a/packages/core/src/theme/components/NavScreen/NavScreenMenuOthers.tsx
+++ b/packages/core/src/theme/components/NavScreen/NavScreenMenuOthers.tsx
@@ -1,5 +1,5 @@
 import { NoSSR, useSite } from '@rspress/core/runtime';
-import { SocialLinks, SwitchAppearance } from '@theme';
+import { SocialLinks, SwitchAppearance } from '@rspress/core/theme';
 import './index.scss';
 import { NavScreenLangs } from './NavScreenLangs';
 import { NavScreenVersions } from './NavScreenVersions';

--- a/packages/core/src/theme/components/NavScreen/NavScreenVersions.tsx
+++ b/packages/core/src/theme/components/NavScreen/NavScreenVersions.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useVersionsMenu } from '../Nav/hooks';
 import './NavScreenVersions.scss';
 import { useI18n } from '@rspress/core/runtime';
-import { Link } from '@theme';
+import { Link } from '@rspress/core/theme';
 import clsx from 'clsx';
 import { SvgDown } from './NavScreenMenuItem';
 

--- a/packages/core/src/theme/components/NavScreen/index.tsx
+++ b/packages/core/src/theme/components/NavScreen/index.tsx
@@ -1,5 +1,5 @@
 import { useNav } from '@rspress/core/runtime';
-import { SocialLinks } from '@theme';
+import { SocialLinks } from '@rspress/core/theme';
 import { clearAllBodyScrollLocks, disableBodyScroll } from 'body-scroll-lock';
 import clsx from 'clsx';
 import { useEffect, useRef } from 'react';

--- a/packages/core/src/theme/components/NavTitle/index.tsx
+++ b/packages/core/src/theme/components/NavTitle/index.tsx
@@ -5,7 +5,7 @@ import {
   useLang,
   useSite,
 } from '@rspress/core/runtime';
-import { Link } from '@theme';
+import { Link } from '@rspress/core/theme';
 import { useMemo } from 'react';
 import './index.scss';
 

--- a/packages/core/src/theme/components/Outline/ScrollToTop.tsx
+++ b/packages/core/src/theme/components/Outline/ScrollToTop.tsx
@@ -1,5 +1,9 @@
 import { useI18n } from '@rspress/core/runtime';
-import { IconScrollToTop, SvgWrapper, useReadPercent } from '@theme';
+import {
+  IconScrollToTop,
+  SvgWrapper,
+  useReadPercent,
+} from '@rspress/core/theme';
 
 export function ScrollToTop() {
   const scrollToTop = () => {

--- a/packages/core/src/theme/components/Outline/index.tsx
+++ b/packages/core/src/theme/components/Outline/index.tsx
@@ -6,7 +6,7 @@ import {
   ReadPercent,
   Toc,
   useDynamicToc,
-} from '@theme';
+} from '@rspress/core/theme';
 import './index.scss';
 import { ScrollToTop } from './ScrollToTop';
 

--- a/packages/core/src/theme/components/Overview/index.tsx
+++ b/packages/core/src/theme/components/Overview/index.tsx
@@ -15,7 +15,7 @@ import {
   type Group,
   type GroupItem,
   OverviewGroup,
-} from '@theme';
+} from '@rspress/core/theme';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   isSidebarDivider,

--- a/packages/core/src/theme/components/OverviewGroup/index.tsx
+++ b/packages/core/src/theme/components/OverviewGroup/index.tsx
@@ -1,8 +1,8 @@
-import { Link, renderInlineMarkdown } from '@theme';
+import { Link, renderInlineMarkdown } from '@rspress/core/theme';
 import './index.scss';
 import type { Header } from '@rspress/core';
 import { routePathToMdPath } from '@rspress/core/runtime';
-import { FallbackHeading, SvgWrapper } from '@theme';
+import { FallbackHeading, SvgWrapper } from '@rspress/core/theme';
 import { useMemo } from 'react';
 import IconPlugin from './icons/plugin.svg';
 

--- a/packages/core/src/theme/components/PackageManagerTabs/index.tsx
+++ b/packages/core/src/theme/components/PackageManagerTabs/index.tsx
@@ -1,4 +1,4 @@
-import { getCustomMDXComponent, Tab, Tabs } from '@theme';
+import { getCustomMDXComponent, Tab, Tabs } from '@rspress/core/theme';
 import { type ReactNode, useMemo } from 'react';
 import { Bun } from './icons/Bun';
 import { Deno } from './icons/Deno';

--- a/packages/core/src/theme/components/PrevNextPage/index.tsx
+++ b/packages/core/src/theme/components/PrevNextPage/index.tsx
@@ -5,7 +5,7 @@ import {
   renderInlineMarkdown,
   SvgWrapper,
   usePrevNextPage,
-} from '@theme';
+} from '@rspress/core/theme';
 import clsx from 'clsx';
 import './index.scss';
 

--- a/packages/core/src/theme/components/Root/index.tsx
+++ b/packages/core/src/theme/components/Root/index.tsx
@@ -23,7 +23,7 @@ export interface RootProps {
  * @example
  * Default usage (no customization needed):
  * ```tsx
- * import { Root } from '@theme';
+ * import { Root } from '@rspress/core/theme';
  *
  * function App() {
  *   return (

--- a/packages/core/src/theme/components/Search/NoSearchResult.tsx
+++ b/packages/core/src/theme/components/Search/NoSearchResult.tsx
@@ -1,5 +1,5 @@
 import { useI18n } from '@rspress/core/runtime';
-import { IconEmpty, SvgWrapper } from '@theme';
+import { IconEmpty, SvgWrapper } from '@rspress/core/theme';
 import './NoSearchResult.scss';
 
 export function NoSearchResult({ query }: { query: string }) {

--- a/packages/core/src/theme/components/Search/SearchButton.tsx
+++ b/packages/core/src/theme/components/Search/SearchButton.tsx
@@ -1,5 +1,5 @@
 import { useI18n } from '@rspress/core/runtime';
-import { IconSearch, SvgWrapper } from '@theme';
+import { IconSearch, SvgWrapper } from '@rspress/core/theme';
 import { useEffect, useState } from 'react';
 import './SearchButton.scss';
 

--- a/packages/core/src/theme/components/Search/SearchPanel.tsx
+++ b/packages/core/src/theme/components/Search/SearchPanel.tsx
@@ -7,7 +7,7 @@ import {
   Tab,
   Tabs,
   useLinkNavigate,
-} from '@theme';
+} from '@rspress/core/theme';
 import { debounce } from 'lodash-es';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';

--- a/packages/core/src/theme/components/Search/SuggestItem.tsx
+++ b/packages/core/src/theme/components/Search/SuggestItem.tsx
@@ -5,7 +5,7 @@ import {
   IconTitle,
   Link,
   SvgWrapper,
-} from '@theme';
+} from '@rspress/core/theme';
 import { useRef } from 'react';
 import './SuggestItem.scss';
 import type { DefaultMatchResultItem, HighlightInfo } from './logic/types';

--- a/packages/core/src/theme/components/Search/index.tsx
+++ b/packages/core/src/theme/components/Search/index.tsx
@@ -1,5 +1,5 @@
 import { NoSSR } from '@rspress/core/runtime';
-import { SearchButton, SearchPanel } from '@theme';
+import { SearchButton, SearchPanel } from '@rspress/core/theme';
 import { useState } from 'react';
 
 export function Search() {

--- a/packages/core/src/theme/components/Sidebar/SidebarGroup.tsx
+++ b/packages/core/src/theme/components/Sidebar/SidebarGroup.tsx
@@ -5,7 +5,11 @@ import type {
   SidebarSectionHeader as SidebarSectionHeaderType,
 } from '@rspress/core';
 import { useActiveMatcher } from '@rspress/core/runtime';
-import { IconArrowRight, SvgWrapper, useLinkNavigate } from '@theme';
+import {
+  IconArrowRight,
+  SvgWrapper,
+  useLinkNavigate,
+} from '@rspress/core/theme';
 import clsx from 'clsx';
 import type React from 'react';
 import { SidebarDivider } from './SidebarDivider';

--- a/packages/core/src/theme/components/Sidebar/SidebarItem.tsx
+++ b/packages/core/src/theme/components/Sidebar/SidebarItem.tsx
@@ -3,7 +3,7 @@ import type {
   SidebarItem as SidebarItemType,
 } from '@rspress/core';
 import { useActiveMatcher } from '@rspress/core/runtime';
-import { Link, renderInlineMarkdown, Tag } from '@theme';
+import { Link, renderInlineMarkdown, Tag } from '@rspress/core/theme';
 import clsx from 'clsx';
 import type React from 'react';
 import { useEffect, useRef, useTransition } from 'react';

--- a/packages/core/src/theme/components/Sidebar/SidebarSectionHeader.tsx
+++ b/packages/core/src/theme/components/Sidebar/SidebarSectionHeader.tsx
@@ -1,4 +1,4 @@
-import { renderInlineMarkdown, Tag } from '@theme';
+import { renderInlineMarkdown, Tag } from '@rspress/core/theme';
 import './SidebarSectionHeader.scss';
 
 export function SidebarSectionHeader({

--- a/packages/core/src/theme/components/SidebarMenu/index.tsx
+++ b/packages/core/src/theme/components/SidebarMenu/index.tsx
@@ -7,7 +7,7 @@ import {
   SvgWrapper,
   useActiveAnchor,
   useDynamicToc,
-} from '@theme';
+} from '@rspress/core/theme';
 import { forwardRef, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import './index.scss';

--- a/packages/core/src/theme/components/SocialLinks/index.tsx
+++ b/packages/core/src/theme/components/SocialLinks/index.tsx
@@ -1,6 +1,6 @@
 import type { SocialLink } from '@rspress/core';
 import { useSite } from '@rspress/core/runtime';
-import { IconArrowDown, SvgWrapper } from '@theme';
+import { IconArrowDown, SvgWrapper } from '@rspress/core/theme';
 import './index.scss';
 import { useHoverGroup } from '../HoverGroup/useHoverGroup';
 import { SocialLink as SocialLinkComp } from './SocialLink';

--- a/packages/core/src/theme/components/SourceCode/index.tsx
+++ b/packages/core/src/theme/components/SourceCode/index.tsx
@@ -1,5 +1,5 @@
 import { useI18n } from '@rspress/core/runtime';
-import { IconGithub, IconGitlab, SvgWrapper } from '@theme';
+import { IconGithub, IconGitlab, SvgWrapper } from '@rspress/core/theme';
 import './index.scss';
 
 export interface SourceCodeProps {

--- a/packages/core/src/theme/components/SvgWrapper/index.tsx
+++ b/packages/core/src/theme/components/SvgWrapper/index.tsx
@@ -1,5 +1,5 @@
 import { normalizeImagePath } from '@rspress/core/runtime';
-import { renderHtmlOrText } from '@theme';
+import { renderHtmlOrText } from '@rspress/core/theme';
 
 /**
  * Check if a string is a URL or file path

--- a/packages/core/src/theme/components/SwitchAppearance/index.tsx
+++ b/packages/core/src/theme/components/SwitchAppearance/index.tsx
@@ -1,5 +1,5 @@
 import { ThemeContext, useSite } from '@rspress/core/runtime';
-import { IconMoon, IconSun, SvgWrapper } from '@theme';
+import { IconMoon, IconSun, SvgWrapper } from '@rspress/core/theme';
 import { type MouseEvent, useContext } from 'react';
 import './global.scss';
 import './index.scss';

--- a/packages/core/src/theme/components/Tabs/index.tsx
+++ b/packages/core/src/theme/components/Tabs/index.tsx
@@ -1,4 +1,4 @@
-import { useStorageValue } from '@theme';
+import { useStorageValue } from '@rspress/core/theme';
 import clsx from 'clsx';
 import {
   Children,

--- a/packages/core/src/theme/components/Tag/index.tsx
+++ b/packages/core/src/theme/components/Tag/index.tsx
@@ -5,7 +5,7 @@ import {
   IconExperimental,
   SvgWrapper,
   Tag as WrappedTag,
-} from '@theme';
+} from '@rspress/core/theme';
 import { useMemo } from 'react';
 
 const BADGE_TAGS = {

--- a/packages/core/src/theme/components/Toc/TocItem.tsx
+++ b/packages/core/src/theme/components/Toc/TocItem.tsx
@@ -1,5 +1,9 @@
 import type { Header } from '@rspress/core';
-import { Link, parseInlineMarkdownText, renderInlineMarkdown } from '@theme';
+import {
+  Link,
+  parseInlineMarkdownText,
+  renderInlineMarkdown,
+} from '@rspress/core/theme';
 import clsx from 'clsx';
 import './TocItem.scss';
 import { useEffect, useRef } from 'react';

--- a/packages/core/src/theme/components/Toc/index.tsx
+++ b/packages/core/src/theme/components/Toc/index.tsx
@@ -1,4 +1,4 @@
-import { useActiveAnchor, useDynamicToc } from '@theme';
+import { useActiveAnchor, useDynamicToc } from '@rspress/core/theme';
 import { TocItem } from './TocItem';
 
 const baseHeaderLevel = 2;

--- a/packages/core/src/theme/env.d.ts
+++ b/packages/core/src/theme/env.d.ts
@@ -20,7 +20,7 @@ declare module 'virtual-search-hooks' {
     OnSearch,
     AfterSearch,
     RenderSearchFunction,
-  } from '@theme';
+  } from '@rspress/core/theme';
 
   export const beforeSearch: BeforeSearch;
   export const onSearch: OnSearch;

--- a/packages/core/src/theme/layout/DocLayout/index.tsx
+++ b/packages/core/src/theme/layout/DocLayout/index.tsx
@@ -6,7 +6,7 @@ import {
   Overview,
   Sidebar,
   useWatchToc,
-} from '@theme';
+} from '@rspress/core/theme';
 import clsx from 'clsx';
 import { useSidebarMenu } from '../../components/SidebarMenu/useSidebarMenu';
 import './index.scss';

--- a/packages/core/src/theme/layout/HomeLayout/index.tsx
+++ b/packages/core/src/theme/layout/HomeLayout/index.tsx
@@ -1,6 +1,11 @@
 import type { Feature, Hero } from '@rspress/core';
 import { useFrontmatter } from '@rspress/core/runtime';
-import { HomeBackground, HomeFeature, HomeFooter, HomeHero } from '@theme';
+import {
+  HomeBackground,
+  HomeFeature,
+  HomeFooter,
+  HomeHero,
+} from '@rspress/core/theme';
 
 export interface HomeLayoutProps {
   beforeHero?: React.ReactNode;

--- a/packages/core/src/theme/layout/Layout/index.tsx
+++ b/packages/core/src/theme/layout/Layout/index.tsx
@@ -6,7 +6,7 @@ import {
   usePage,
   useSite,
 } from '@rspress/core/runtime';
-import type { HomeLayoutProps } from '@theme';
+import type { HomeLayoutProps } from '@rspress/core/theme';
 import {
   HomeLayout as DefaultHomeLayout,
   NotFoundLayout as DefaultNotFoundLayout,
@@ -17,7 +17,7 @@ import {
   useRedirect4FirstVisit,
   useScrollReset,
   useSetup,
-} from '@theme';
+} from '@rspress/core/theme';
 import { Head, useHead } from '@unhead/react';
 import React, { memo, useMemo } from 'react';
 

--- a/packages/core/src/theme/layout/NotFountLayout/index.tsx
+++ b/packages/core/src/theme/layout/NotFountLayout/index.tsx
@@ -1,5 +1,5 @@
 import { useI18n, usePageData } from '@rspress/core/runtime';
-import { Link } from '@theme';
+import { Link } from '@rspress/core/theme';
 import './index.scss';
 
 export function NotFoundLayout() {


### PR DESCRIPTION
## Summary

<img width="993" height="351" alt="image" src="https://github.com/user-attachments/assets/b456bd45-73d1-4962-aabf-de701380923b" />


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

---

## AI Summary

This PR updates all internal imports within `packages/core/src/theme/` from `@theme` to `@rspress/core/theme`.

### What changed
- Replaced `from '@theme'` with `from '@rspress/core/theme'` across 61 files (65 import statements) in the theme directory, including components, layouts, and the `env.d.ts` type declaration file.

### Why
- The `@theme` alias is a virtual module resolved at build time, making it implicit and harder to trace. Using the explicit `@rspress/core/theme` path improves module resolution clarity and makes the dependency relationship between theme internals explicit.

### Notes
- This is a purely mechanical refactor with no behavioral changes.
- All affected files are internal to the `packages/core/src/theme/` directory.

This PR was written using [Vibe Kanban](https://vibekanban.com)

---