### PR TITLE
fix(theme): disable `text-autospace` in `<code>`, `<kbd>`, and `<samp>`

### DIFF
--- a/.changeset/beige-parrots-slide.md
+++ b/.changeset/beige-parrots-slide.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+fix(theme): disable `text-autospace` in `<code>`, `<kbd>`, and `<samp>`

--- a/packages/core/src/theme/styles/base.css
+++ b/packages/core/src/theme/styles/base.css
@@ -66,7 +66,10 @@ body {
   text-autospace: normal;
 }
 
-pre {
+pre,
+code,
+kbd,
+samp {
   text-autospace: no-autospace;
 }
 

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -10,6 +10,7 @@ atoyan
 atrules
 autohide
 autoreleasepool
+autospace
 bilibili
 biomejs
 Bluch


### PR DESCRIPTION
## Summary

I get Qiita (a Japanese large technical knowledge-sharing platform for programmers, similar to China's CSDN or Juejin but focused on short, practical coding articles) adopt `text-autospace` like Rspress, but I noticed that `text-autospace` is not so welcomed in not only `<pre>` but also `<code>`:

<img width="586" height="198" alt="image" src="https://github.com/user-attachments/assets/00442030-2e76-48a6-b7fa-75f51beeee86" />

<img width="958" height="400" alt="image" src="https://github.com/user-attachments/assets/1b40d9ca-1ec8-450a-bd40-048192d04324" />

https://github.com/increments/qiita-discussions/discussions/1049#discussioncomment-16185498 (Japanese)

These extra spaces cause the loss of cohesion between characters in the Japanese function name mixed with English <span lang=ja>`test_関数getRandomは1以上100以下の値を返す`</span> (meaning: <span lang=zh-Hans>`test_函数getRandom返回1到100之间的值`</span>).

VitePress has been turned off `text-autospace` in not only `<pre>` but also `<code>`, `<kbd>`, and `<samp>`: https://github.com/vuejs/vitepress/commit/21a5fb6a96549564fcf698d0e7256181eac3919b

In the first place, CSS also does not recommend us to apply `text-autospace` there: https://drafts.csswg.org/css-text-4/#default-stylesheet

```css
/* preserve character grid in preformatted text */
pre, code, kbd, samp, tt { text-spacing: none; }
```

Note: `<tt>` is deprecated. [`text-spacing` = `text-autospace` + `text-spacing-trim`](https://drafts.csswg.org/css-text-4/#text-spacing-property)

## Related Issue

<!--- Provide link of related issues -->

`<pre>`: #3110 https://github.com/web-infra-dev/rspress/pull/3131

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
