### PR TITLE
feat(theme): add maxHeight support for collapsible code blocks

### DIFF
--- a/packages/core/src/node/mdx/options.ts
+++ b/packages/core/src/node/mdx/options.ts
@@ -48,6 +48,7 @@ export async function createMDXOptions(options: {
     globalComponents: globalComponentsFromConfig = [],
     showLineNumbers = false,
     defaultWrapCode = false,
+    defaultMaxHeight,
     shiki,
     cjkFriendlyEmphasis = true,
   } = config?.markdown || {};
@@ -131,7 +132,12 @@ export async function createMDXOptions(options: {
               : []),
             [
               rehypeShiki,
-              createRehypeShikiOptions(showLineNumbers, defaultWrapCode, shiki),
+              createRehypeShikiOptions(
+                showLineNumbers,
+                defaultWrapCode,
+                defaultMaxHeight,
+                shiki,
+              ),
             ],
             [
               rehypeExternalLinks,

--- a/packages/core/src/node/mdx/rehypePlugins/shiki.ts
+++ b/packages/core/src/node/mdx/rehypePlugins/shiki.ts
@@ -19,6 +19,7 @@ const cssVariablesTheme = createCssVariablesTheme({
 function createRehypeShikiOptions(
   showLineNumbers: boolean,
   defaultWrapCode: boolean,
+  defaultMaxHeight: number | undefined,
   options?: Partial<RehypeShikiOptions>,
 ): RehypeShikiOptions {
   const { transformers = [], ...restOptions } = options || {};
@@ -28,7 +29,7 @@ function createRehypeShikiOptions(
     transformerAddLang(),
     transformerAddLineNumbers({ defaultShowLineNumbers: showLineNumbers }),
     transformerAddWrapCode({ defaultWrapCode }),
-    transformerAddFold(),
+    transformerAddFold({ defaultMaxHeight }),
     ...transformers,
   ];
 

--- a/packages/core/src/node/mdx/rehypePlugins/transformers/add-fold.test.ts
+++ b/packages/core/src/node/mdx/rehypePlugins/transformers/add-fold.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from '@rstest/core';
+import type { Element } from 'hast';
+import { transformerAddFold } from './add-fold';
+
+function createPreElement(): Element {
+  return {
+    type: 'element',
+    tagName: 'pre',
+    properties: {},
+    children: [],
+  };
+}
+
+function callTransformerPre(
+  transformer: ReturnType<typeof transformerAddFold>,
+  pre: Element,
+  rawMeta?: string,
+): Element {
+  const context = {
+    options: {
+      meta: rawMeta !== undefined ? { __raw: rawMeta } : undefined,
+    },
+  };
+  return transformer.pre!.call(context as any, pre) as Element;
+}
+
+describe('transformerAddFold', () => {
+  describe('legacy fold API', () => {
+    it('should enable fold with default height when meta has fold', () => {
+      const transformer = transformerAddFold();
+      const pre = createPreElement();
+      const result = callTransformerPre(transformer, pre, 'fold');
+      expect(result.properties.fold).toBe(true);
+      expect(result.properties.height).toBe(300);
+    });
+
+    it('should enable fold with custom height', () => {
+      const transformer = transformerAddFold();
+      const pre = createPreElement();
+      const result = callTransformerPre(transformer, pre, 'fold height="200"');
+      expect(result.properties.fold).toBe(true);
+      expect(result.properties.height).toBe(200);
+    });
+
+    it('should not fold when fold=false', () => {
+      const transformer = transformerAddFold();
+      const pre = createPreElement();
+      const result = callTransformerPre(transformer, pre, 'fold=false');
+      expect(result.properties.fold).toBeUndefined();
+    });
+
+    it('should not fold when no fold keyword', () => {
+      const transformer = transformerAddFold();
+      const pre = createPreElement();
+      const result = callTransformerPre(transformer, pre, 'title="foo.js"');
+      expect(result.properties.fold).toBeUndefined();
+    });
+  });
+
+  describe('maxHeight API', () => {
+    it('should auto-enable fold when maxHeight is in meta', () => {
+      const transformer = transformerAddFold();
+      const pre = createPreElement();
+      const result = callTransformerPre(transformer, pre, 'maxHeight="200"');
+      expect(result.properties.fold).toBe(true);
+      expect(result.properties.height).toBe(200);
+    });
+
+    it('should respect fold=false even with maxHeight', () => {
+      const transformer = transformerAddFold();
+      const pre = createPreElement();
+      const result = callTransformerPre(
+        transformer,
+        pre,
+        'fold=false maxHeight="200"',
+      );
+      expect(result.properties.fold).toBeUndefined();
+    });
+
+    it('maxHeight should take priority over height', () => {
+      const transformer = transformerAddFold();
+      const pre = createPreElement();
+      const result = callTransformerPre(
+        transformer,
+        pre,
+        'fold maxHeight="150" height="400"',
+      );
+      expect(result.properties.fold).toBe(true);
+      expect(result.properties.height).toBe(150);
+    });
+  });
+
+  describe('defaultMaxHeight config', () => {
+    it('should auto-enable fold when defaultMaxHeight is set', () => {
+      const transformer = transformerAddFold({ defaultMaxHeight: 250 });
+      const pre = createPreElement();
+      const result = callTransformerPre(transformer, pre, 'title="foo.js"');
+      expect(result.properties.fold).toBe(true);
+      expect(result.properties.height).toBe(250);
+    });
+
+    it('should auto-enable fold when meta is undefined', () => {
+      const transformer = transformerAddFold({ defaultMaxHeight: 250 });
+      const pre = createPreElement();
+      const result = callTransformerPre(transformer, pre, undefined);
+      expect(result.properties.fold).toBe(true);
+      expect(result.properties.height).toBe(250);
+    });
+
+    it('should respect fold=false to override defaultMaxHeight', () => {
+      const transformer = transformerAddFold({ defaultMaxHeight: 250 });
+      const pre = createPreElement();
+      const result = callTransformerPre(transformer, pre, 'fold=false');
+      expect(result.properties.fold).toBeUndefined();
+    });
+
+    it('maxHeight in meta should override defaultMaxHeight', () => {
+      const transformer = transformerAddFold({ defaultMaxHeight: 250 });
+      const pre = createPreElement();
+      const result = callTransformerPre(transformer, pre, 'maxHeight="400"');
+      expect(result.properties.fold).toBe(true);
+      expect(result.properties.height).toBe(400);
+    });
+
+    it('should not fold without defaultMaxHeight or fold keyword', () => {
+      const transformer = transformerAddFold();
+      const pre = createPreElement();
+      const result = callTransformerPre(transformer, pre, undefined);
+      expect(result.properties.fold).toBeUndefined();
+    });
+  });
+});

--- a/packages/core/src/node/mdx/rehypePlugins/transformers/add-fold.ts
+++ b/packages/core/src/node/mdx/rehypePlugins/transformers/add-fold.ts
@@ -4,6 +4,15 @@ export const SHIKI_TRANSFORMER_ADD_FOLD = 'shiki-transformer:add-fold';
 
 const DEFAULT_FOLD_HEIGHT = 300;
 
+export interface ITransformerFoldOptions {
+  /**
+   * Default max height (in px) for code blocks.
+   * When set, code blocks taller than this value will be collapsible.
+   * Can be overridden per block with `maxHeight="..."` or `fold=false` in the meta string.
+   */
+  defaultMaxHeight?: number;
+}
+
 function hasFoldInMeta(meta: string | undefined): boolean | undefined {
   if (!meta) {
     return undefined;
@@ -18,14 +27,17 @@ function hasFoldInMeta(meta: string | undefined): boolean | undefined {
   return undefined;
 }
 
-function parseHeightFromMeta(meta: string | undefined): number | undefined {
+function parseNumericFromMeta(
+  meta: string | undefined,
+  key: string,
+): number | undefined {
   if (!meta) {
     return undefined;
   }
   const kvList = meta.split(' ').filter(Boolean);
   for (const item of kvList) {
     const [k, v = ''] = item.split('=').filter(Boolean);
-    if (k === 'height' && v.length > 0) {
+    if (k === key && v.length > 0) {
       const num = Number(v.replace(/["'`]/g, ''));
       if (!Number.isNaN(num) && num > 0) {
         return num;
@@ -38,19 +50,47 @@ function parseHeightFromMeta(meta: string | undefined): number | undefined {
 /**
  * @private compile-time only
  */
-export function transformerAddFold(): ShikiTransformer {
+export function transformerAddFold(
+  options: ITransformerFoldOptions = {},
+): ShikiTransformer {
+  const { defaultMaxHeight } = options;
+
   return {
     name: SHIKI_TRANSFORMER_ADD_FOLD,
     pre(pre) {
       const meta = this.options.meta?.__raw;
-      const shouldFold = hasFoldInMeta(meta);
+      const foldInMeta = hasFoldInMeta(meta);
+      const maxHeightInMeta = parseNumericFromMeta(meta, 'maxHeight');
+      const heightInMeta = parseNumericFromMeta(meta, 'height');
+
+      // Determine the effective height:
+      // 1. maxHeight in meta takes priority (new API)
+      // 2. height in meta (legacy API, used with fold)
+      // 3. defaultMaxHeight from config
+      // 4. DEFAULT_FOLD_HEIGHT as final fallback
+      const effectiveHeight =
+        maxHeightInMeta ??
+        heightInMeta ??
+        defaultMaxHeight ??
+        DEFAULT_FOLD_HEIGHT;
+
+      // Determine whether fold should be enabled:
+      // - fold=false in meta always disables
+      // - fold or fold=true in meta always enables
+      // - maxHeight in meta auto-enables fold
+      // - defaultMaxHeight from config auto-enables fold (unless fold=false)
+      const shouldFold =
+        foldInMeta === false
+          ? false
+          : foldInMeta === true ||
+            maxHeightInMeta !== undefined ||
+            (defaultMaxHeight !== undefined && foldInMeta !== false);
 
       if (shouldFold) {
-        const height = parseHeightFromMeta(meta) ?? DEFAULT_FOLD_HEIGHT;
         pre.properties = {
           ...pre.properties,
           fold: true,
-          height,
+          height: effectiveHeight,
         };
       }
       return pre;

--- a/packages/core/src/theme/components/CodeBlock/index.scss
+++ b/packages/core/src/theme/components/CodeBlock/index.scss
@@ -89,9 +89,9 @@
   }
 
   &--fold {
-    overflow: hidden;
     position: relative;
 
+    // Gradient overlay on the non-scrolling parent, stays fixed at bottom
     &::after {
       content: '';
       position: absolute;
@@ -106,6 +106,11 @@
       );
       pointer-events: none;
       z-index: 2;
+    }
+
+    // Scroll container becomes scrollable with constrained height
+    .rp-codeblock__content__scroll-container {
+      overflow-y: auto;
     }
   }
 }

--- a/packages/core/src/theme/components/CodeBlock/index.tsx
+++ b/packages/core/src/theme/components/CodeBlock/index.tsx
@@ -94,14 +94,13 @@ export function CodeBlock({
   const [expanded, setExpanded] = useState(false);
   const [needFold, setNeedFold] = useState(false);
   const codeBlockRef = useRef<HTMLDivElement>(null);
-  const contentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!fold || !contentRef.current) {
+    if (!fold || !copyElementRef.current) {
       setNeedFold(false);
       return;
     }
-    const realHeight = contentRef.current.scrollHeight;
+    const realHeight = copyElementRef.current.scrollHeight;
     setNeedFold(realHeight > height);
   }, [fold, height]);
 
@@ -124,6 +123,8 @@ export function CodeBlock({
     }
   }, [expanded]);
 
+  const isFolded = needFold && !expanded;
+
   return (
     <div
       className={clsx(
@@ -139,14 +140,13 @@ export function CodeBlock({
           'rp-codeblock__content',
           wrapCodeState && 'rp-codeblock__content--wrap-code',
           lineNumbersProp && 'rp-codeblock__content--line-numbers',
-          needFold && !expanded && 'rp-codeblock__content--fold',
+          isFolded && 'rp-codeblock__content--fold',
         )}
-        style={needFold && !expanded ? { maxHeight: `${height}px` } : undefined}
-        ref={contentRef}
       >
         <div
           className="rp-codeblock__content__scroll-container rp-scrollbar rp-scrollbar--always"
           ref={copyElementRef}
+          style={isFolded ? { maxHeight: `${height}px` } : undefined}
         >
           {children}
         </div>

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -535,6 +535,12 @@ export interface MarkdownOptions {
    */
   defaultWrapCode?: boolean;
   /**
+   * Default max height (in px) for code blocks.
+   * When set, code blocks taller than this value will be collapsible with a scrollable area and expand/collapse toggle.
+   * Can be overridden per block with `maxHeight="..."` or disabled with `fold=false` in the meta string.
+   */
+  defaultMaxHeight?: number;
+  /**
    * Register global components in mdx files
    */
   globalComponents?: string[];


### PR DESCRIPTION
## Motivation

We built a custom `CodeFold` wrapper component for [lynxjs.org](https://lynxjs.org) to add collapsible code blocks (see [lynx-family/lynx-website#862](https://github.com/lynx-family/lynx-website/pull/862)). It works, but wrapping code blocks from the outside creates problems — double-nesting with mismatched borders/shadows inside `<Tabs>`, and styling conflicts with the existing code block chrome.

We realized this should be a first-class Rspress feature: the collapsible/scrollable behavior belongs *inside* the code block component, not wrapped around it. This PR upstreams that idea.

## What this PR does

**New `maxHeight` meta attribute** — a simpler alternative to `fold` that auto-enables collapsible behavior:

~~~md
```tsx maxHeight="200" title="example.tsx"
// code taller than 200px becomes scrollable with expand/collapse
```
~~~

**New `markdown.defaultMaxHeight` config** — apply collapsible behavior to all code blocks globally:

```ts
// rspress.config.ts
export default defineConfig({
  markdown: {
    defaultMaxHeight: 400,
  },
});
```

Individual blocks can opt out with `fold=false`. The existing `fold` + `height="..."` API continues to work unchanged.

**Scrollable collapsed state** — the collapsed area is now scrollable (`overflow-y: auto`) instead of clipped (`overflow: hidden`). A gradient overlay at the bottom hints at more content. This is a UX improvement over the previous `fold` behavior: users can peek at the code by scrolling before deciding to expand.

## Changes

| File | Change |
|------|--------|
| `packages/shared/src/types/index.ts` | Add `defaultMaxHeight` to `MarkdownOptions` |
| `packages/core/.../transformers/add-fold.ts` | Parse `maxHeight` from meta, accept `defaultMaxHeight` config, auto-enable fold |
| `packages/core/.../shiki.ts` + `options.ts` | Wire config through to transformer |
| `packages/core/.../CodeBlock/index.tsx` | Move height constraint to scroll container so collapsed state is scrollable |
| `packages/core/.../CodeBlock/index.scss` | Scrollable scroll container + fixed gradient overlay |
| `packages/core/.../add-fold.test.ts` | 12 new tests covering legacy fold, maxHeight, and defaultMaxHeight |

## Test plan

- [x] 12 new transformer tests pass
- [x] All existing unit tests pass (224/224)
- [x] `@rspress/shared` and `@rspress/core` build successfully
- [ ] Manual: scrollable collapsed code block standalone
- [ ] Manual: inside `<Tabs>` — no double-nesting, gradient + scroll work correctly
- [ ] Manual: `fold=false` disables collapsing when `defaultMaxHeight` is set