### PR TITLE
fix(core): log message include json file path in auto-nav-sidebar errors

### DIFF
--- a/.changeset/fair-pets-grab.md
+++ b/.changeset/fair-pets-grab.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+Improve auto-nav-sidebar JSON parse errors by including the source file path.

--- a/packages/core/src/node/auto-nav-sidebar/utils.ts
+++ b/packages/core/src/node/auto-nav-sidebar/utils.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { extractTextAndId, loadFrontMatter } from '@rspress/shared/node-utils';
+import { createError } from '../utils';
 
 export async function pathExists(path: string): Promise<boolean> {
   try {
@@ -13,7 +14,16 @@ export async function pathExists(path: string): Promise<boolean> {
 
 export async function readJson<T = unknown>(path: string): Promise<T> {
   const raw = await fs.readFile(path, 'utf8');
-  return JSON.parse(raw);
+
+  try {
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    const detail =
+      error instanceof Error ? error.message : 'Unknown JSON parse error';
+    throw createError(
+      `[auto-nav-sidebar] Failed to parse JSON file "${path}": ${detail}`,
+    );
+  }
 }
 
 export async function extractInfoFromFrontmatterWithAbsolutePath(

--- a/packages/core/src/node/auto-nav-sidebar/walk.test.ts
+++ b/packages/core/src/node/auto-nav-sidebar/walk.test.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import { DEFAULT_PAGE_EXTENSIONS } from '@rspress/shared/constants';
 import { afterEach, describe, expect, it } from '@rstest/core';
@@ -478,5 +480,31 @@ describe('walk', () => {
       <ROOT>/packages/core/src/node/auto-nav-sidebar/fixtures/docs-custom-link-group/guide/_meta.json"
     `);
     expect(orderStringSet(mdFileSet)).toMatchInlineSnapshot(`""`);
+  });
+
+  it('should include invalid json file path in error message', async () => {
+    const docsDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'rspress-auto-nav-invalid-json-'),
+    );
+    const guideDir = path.join(docsDir, 'guide');
+    const invalidMetaPath = path.join(guideDir, '_meta.json');
+
+    await fs.mkdir(guideDir, { recursive: true });
+    await fs.writeFile(
+      invalidMetaPath,
+      '[\n  {\n    name: "a.md"\n  }\n]\n',
+      'utf8',
+    );
+
+    const metaFileSet = new Set<string>();
+    const mdFileSet = new Set<string>();
+
+    try {
+      await expect(
+        walk(docsDir, docsDir, DEFAULT_PAGE_EXTENSIONS, metaFileSet, mdFileSet),
+      ).rejects.toThrow(`Failed to parse JSON file "${invalidMetaPath}"`);
+    } finally {
+      await fs.rm(docsDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/core/src/node/auto-nav-sidebar/walk.ts
+++ b/packages/core/src/node/auto-nav-sidebar/walk.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { isExternalUrl, type NavItem, type Sidebar } from '@rspress/shared';
 import { hintNavJsonChangeThenPanic } from '../logger/hint';
 import { addRoutePrefix } from '../route/RoutePage';
-import { createError, pathExists } from '../utils';
+import { pathExists } from '../utils';
 import { scanSideMeta } from './normalize';
 import { readJson } from './utils';
 
@@ -18,16 +18,7 @@ async function scanNav(
   if (isRootNavJsonExist) {
     metaFileSet.add(rootNavJson);
     // Get the nav config from the `_meta.json` file
-    try {
-      navConfig = await readJson<NavItem[]>(rootNavJson);
-    } catch (e) {
-      if (e instanceof Error) {
-        throw createError(
-          `[auto-nav-sidebar] Generate nav meta error: ${rootNavJson} failed, original error is (${e.message})`,
-        );
-      }
-      throw e;
-    }
+    navConfig = await readJson<NavItem[]>(rootNavJson);
   } else {
     navConfig = [];
   }


### PR DESCRIPTION
## Summary

- include the offending `_nav.json` or `_meta.json` path in auto-nav-sidebar JSON parse errors
- centralize the error message in `readJson()` so both nav and sidebar paths are covered
- add a regression test for invalid `_meta.json` parsing and a patch changeset for `@rspress/core`

## Related Issue

<!--- Provide link of related issues -->

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).

## Verification

- `pnpm exec biome check packages/core/src/node/auto-nav-sidebar/utils.ts packages/core/src/node/auto-nav-sidebar/walk.ts packages/core/src/node/auto-nav-sidebar/walk.test.ts`
- `pnpm --filter @rspress/shared build`
- `pnpm exec rstest run packages/core/src/node/auto-nav-sidebar/walk.test.ts`
