### PR TITLE
fix(theme/Steps): # for titles overlaps with the sequence number

### DIFF
--- a/packages/core/src/theme/components/DocContent/doc.scss
+++ b/packages/core/src/theme/components/DocContent/doc.scss
@@ -73,6 +73,8 @@
         transition:
           color 0.25s,
           opacity 0.25s;
+        border-bottom: 1px solid transparent;
+
         &:hover {
           border-bottom: 1px solid var(--rp-c-brand);
           opacity: 0.85;

--- a/packages/core/src/theme/components/Steps/index.scss
+++ b/packages/core/src/theme/components/Steps/index.scss
@@ -1,51 +1,54 @@
+:root {
+  --rp-steps-gap: 24px;
+  --rp-steps-size: 30px;
+}
+
 .rp-steps {
-  margin-left: 16px;
-  margin-bottom: 44px;
+  margin-left: 1rem;
+  margin-bottom: 2.5rem;
   border-left: 1px solid var(--rp-c-text-3);
-  padding-left: 24px;
+  padding-left: var(--rp-steps-gap);
   counter-reset: step;
 
   h3 {
     counter-increment: step;
-    margin-top: 3px;
+    margin-top: 0;
     position: relative;
+    display: flex;
+    align-items: center;
+    min-height: 30px;
 
     &::before {
+      // position
       content: counter(step);
       position: absolute;
-      left: -41px;
-      width: 30px;
-      height: 30px;
+      left: calc(-1 * var(--rp-steps-gap));
+      transform: translate(-50%, 0);
+
+      // size
+      width: var(--rp-steps-size);
+      height: var(--rp-steps-size);
+      line-height: var(--rp-steps-size);
+
+      // text
       display: flex;
       align-items: center;
       justify-content: center;
       font-size: 1.1rem;
-      font-weight: 400;
-      line-height: 30px;
+      font-weight: 500;
       color: var(--rp-c-text-1);
-      background-color: var(--rp-code-block-bg);
+
+      // style
+      background-color: var(--rp-c-bg);
+      outline: 6px solid var(--rp-c-bg);
       border: 1.5px solid var(--rp-c-text-3);
       border-radius: 50%;
     }
-  }
 
-  p {
-    color: var(--rp-c-text-1);
-  }
-
-  /* don't render anchor under the stepper component, render at the end */
-  .rp-toc-include:has(> .rp-header-anchor) {
-    display: flex;
-    gap: 1.5rem;
-
+    /* anchor link: move to the front and ensure it's clickable */
     .rp-header-anchor {
-      /* moves the anchor to the end of the line */
-      order: 2;
-
-      &:not(:hover) {
-        /* prevents odd pixel shift on hover */
-        border-bottom: 1px solid transparent;
-      }
+      position: absolute;
+      left: calc(-1 * var(--rp-steps-gap) - var(--rp-steps-size) / 2);
     }
   }
 }

--- a/packages/core/src/theme/components/Steps/index.scss
+++ b/packages/core/src/theme/components/Steps/index.scss
@@ -32,4 +32,20 @@
   p {
     color: var(--rp-c-text-1);
   }
+
+  /* don't render anchor under the stepper component, render at the end */
+  .rp-toc-include:has(> .rp-header-anchor) {
+    display: flex;
+    gap: 1.5rem;
+
+    .rp-header-anchor {
+      /* moves the anchor to the end of the line */
+      order: 2;
+
+      &:not(:hover) {
+        /* prevents odd pixel shift on hover */
+        border-bottom: 1px solid transparent;
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary

When inside a stepper component, the anchor link should render at the end of the header instead of at the beginning in order to avoid strange z-fighting.

### Before

https://github.com/user-attachments/assets/7ad3abfc-d1cc-4e8e-8f82-7dcc2102899b

### After

https://github.com/user-attachments/assets/8d437edd-df1d-4be7-9257-47d9166673e4


## Related Issue

N/A

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
