### PR TITLE
fix(core): Fixed async page data loading

### DIFF
--- a/packages/core/src/runtime/App.tsx
+++ b/packages/core/src/runtime/App.tsx
@@ -2,7 +2,7 @@ import { PageContext, useLocation } from '@rspress/core/runtime';
 import { Layout, Root } from '@theme';
 import React, { useContext, useLayoutEffect } from 'react';
 import globalComponents from 'virtual-global-components';
-import { initPageData } from './initPageData';
+import { getCachedPageData, initPageData } from './initPageData';
 
 enum QueryStatus {
   Show = '1',
@@ -13,6 +13,11 @@ export function App() {
   const { setData: setPageData, data } = useContext(PageContext);
   const { pathname, search } = useLocation();
   useLayoutEffect(() => {
+    const cached = getCachedPageData(pathname);
+    if (cached) {
+      setPageData?.(cached);
+      return;
+    }
     async function refetchData() {
       try {
         const pageData = await initPageData(pathname);

--- a/packages/core/src/runtime/App.tsx
+++ b/packages/core/src/runtime/App.tsx
@@ -2,7 +2,11 @@ import { PageContext, useLocation } from '@rspress/core/runtime';
 import { Layout, Root } from '@theme';
 import React, { useContext, useLayoutEffect } from 'react';
 import globalComponents from 'virtual-global-components';
-import { getCachedPageData, initPageData } from './initPageData';
+import {
+  consumeCachedPageData,
+  initPageData,
+  setCurrentPageData,
+} from './initPageData';
 
 enum QueryStatus {
   Show = '1',
@@ -13,7 +17,7 @@ export function App() {
   const { setData: setPageData, data } = useContext(PageContext);
   const { pathname, search } = useLocation();
   useLayoutEffect(() => {
-    const cached = getCachedPageData(pathname);
+    const cached = consumeCachedPageData(pathname);
     if (cached) {
       setPageData?.(cached);
       return;
@@ -21,6 +25,7 @@ export function App() {
     async function refetchData() {
       try {
         const pageData = await initPageData(pathname);
+        setCurrentPageData(pathname, pageData);
         setPageData?.(pageData);
       } catch (e) {
         console.log(e);

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -26,7 +26,7 @@ export {
 export { useSite } from './hooks/useSite';
 export { useVersion } from './hooks/useVersion';
 export { useWindowSize } from './hooks/useWindowSize';
-export { initPageData } from './initPageData';
+export { initPageData, warmPageData } from './initPageData';
 export { NoSSR } from './NoSSR';
 export { isActive, pathnameToRouteService, preloadLink } from './route';
 export {

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -26,6 +26,7 @@ export {
 export { useSite } from './hooks/useSite';
 export { useVersion } from './hooks/useVersion';
 export { useWindowSize } from './hooks/useWindowSize';
+export { initPageData } from './initPageData';
 export { NoSSR } from './NoSSR';
 export { isActive, pathnameToRouteService, preloadLink } from './route';
 export {

--- a/packages/core/src/runtime/initPageData.ts
+++ b/packages/core/src/runtime/initPageData.ts
@@ -121,7 +121,7 @@ export async function initPageData(routePath: string): Promise<Page> {
     } = MDX_OR_MD_REGEXP.test(matchedRoute.filePath)
       ? meta
       : (mod as unknown as PageMeta);
-    const result: Page = {
+    return {
       ...rest,
       pagePath,
       ...extractPageInfo,
@@ -130,7 +130,6 @@ export async function initPageData(routePath: string): Promise<Page> {
       frontmatter,
       toc,
     };
-    return result;
   }
 
   let lang = siteData.lang || '';
@@ -162,7 +161,7 @@ export async function initPageData(routePath: string): Promise<Page> {
   }
 
   // 404 Page
-  const result: Page = {
+  return {
     pagePath: '',
     pageType: '404',
     routePath: '/404',
@@ -174,5 +173,4 @@ export async function initPageData(routePath: string): Promise<Page> {
     _filepath: '',
     _relativePath: '',
   };
-  return result;
 }

--- a/packages/core/src/runtime/initPageData.ts
+++ b/packages/core/src/runtime/initPageData.ts
@@ -19,6 +19,12 @@ type PageMeta = {
 
 export type Page = PageDataLegacy['page'];
 
+const pageDataCache = new Map<string, Page>();
+
+export function getCachedPageData(routePath: string): Page | undefined {
+  return pageDataCache.get(routePath);
+}
+
 export async function initPageData(routePath: string): Promise<Page> {
   const matchedRoute = pathnameToRouteService(routePath);
   if (matchedRoute) {
@@ -51,7 +57,7 @@ export async function initPageData(routePath: string): Promise<Page> {
     } = MDX_OR_MD_REGEXP.test(matchedRoute.filePath)
       ? meta
       : (mod as unknown as PageMeta);
-    return {
+    const result: Page = {
       ...rest,
       pagePath,
       ...extractPageInfo,
@@ -60,6 +66,8 @@ export async function initPageData(routePath: string): Promise<Page> {
       frontmatter,
       toc,
     };
+    pageDataCache.set(routePath, result);
+    return result;
   }
 
   let lang = siteData.lang || '';
@@ -91,7 +99,7 @@ export async function initPageData(routePath: string): Promise<Page> {
   }
 
   // 404 Page
-  return {
+  const result: Page = {
     pagePath: '',
     pageType: '404',
     routePath: '/404',
@@ -103,4 +111,6 @@ export async function initPageData(routePath: string): Promise<Page> {
     _filepath: '',
     _relativePath: '',
   };
+  pageDataCache.set(routePath, result);
+  return result;
 }

--- a/packages/core/src/runtime/initPageData.ts
+++ b/packages/core/src/runtime/initPageData.ts
@@ -1,4 +1,3 @@
-import { isEqualPath, pathnameToRouteService } from '@rspress/core/runtime';
 import {
   type BaseRuntimePageInfo,
   cleanUrl,
@@ -9,6 +8,8 @@ import {
 } from '@rspress/shared';
 import { pageData } from 'virtual-page-data';
 import siteData from 'virtual-site-data';
+import { pathnameToRouteService } from './route';
+import { isEqualPath } from './utils';
 
 type PageMeta = {
   title: string;
@@ -111,6 +112,5 @@ export async function initPageData(routePath: string): Promise<Page> {
     _filepath: '',
     _relativePath: '',
   };
-  pageDataCache.set(routePath, result);
   return result;
 }

--- a/packages/core/src/runtime/initPageData.ts
+++ b/packages/core/src/runtime/initPageData.ts
@@ -20,10 +20,73 @@ type PageMeta = {
 
 export type Page = PageDataLegacy['page'];
 
-const pageDataCache = new Map<string, Page>();
+type CacheSlot = { routePath: string; data: Page } | undefined;
 
-export function getCachedPageData(routePath: string): Page | undefined {
-  return pageDataCache.get(routePath);
+// Fixed 3-slot cache for navigation page data. Only slot 0 is explicitly warmed (by useLinkNavigate before calling
+// navigate()). Slot 2 is populated implicitly when the forward shift moves the old current page (slot 1) down. This
+// means back navigation gets a cache hit for free without any explicit warming the previous page's data is already in
+// slot 2 from the last forward navigation.
+//
+// Example flow:
+//   1. User is on page A.             Slots: [undefined, A, undefined]
+//   2. User clicks link to B.
+//      useLinkNavigate warms slot 0.  Slots: [B, A, undefined]
+//   3. consumeCachedPageData(B) fires.
+//      Slot 0 matches -> forward shift. Slots: [undefined, B, A]
+//   4. User presses browser back.
+//      consumeCachedPageData(A) fires.
+//      Slot 0 empty, slot 2 matches
+//      -> backward shift.              Slots: [B, A, undefined]
+//      A's data returned synchronously, no flash.
+//
+// Cache misses (e.g. back 2+ pages) fall through to async initPageData, which is cheap since the browser's module cache
+// retains loaded chunks.
+//
+//   [0] = next page (warmed by link click before navigate())
+//   [1] = current page
+//   [2] = previous page
+const slots: [CacheSlot, CacheSlot, CacheSlot] = [
+  undefined,
+  undefined,
+  undefined,
+];
+
+// Warm slot 0 with the target page's data before navigation.
+export function warmPageData(routePath: string, data: Page): void {
+  // Trample whatever the current "next" page will be in our cache.
+  slots[0] = { routePath, data };
+}
+
+// Check the cache on route change. Direction is implicit: a slot 0 match means forward navigation (the page was
+// explicitly warmed by useLinkNavigate), a slot 2 match means backward navigation (the page was retained from a prior
+// forward shift). On match, slots are shifted to reflect the new navigation position.
+export function consumeCachedPageData(routePath: string): Page | undefined {
+  if (slots[0]?.routePath === routePath) {
+    // Forward navigation: next becomes current, current becomes previous
+    const data = slots[0].data;
+    slots[2] = slots[1];
+    slots[1] = slots[0];
+    slots[0] = undefined;
+    return data;
+  }
+  if (slots[2]?.routePath === routePath) {
+    // Backward navigation: previous becomes current, current becomes next
+    const data = slots[2].data;
+    slots[0] = slots[1];
+    slots[1] = slots[2];
+    slots[2] = undefined;
+    return data;
+  }
+  // Anything besides that is a cache miss, which would follow the async code path that existed before this code was
+  // introduced.
+  return undefined;
+}
+
+// Set slot 1 directly on cache miss or SSR hydration. Shifts the old current page to slot 2 (previous). Leaves slot 0
+// alone it may be warming an unrelated page.
+export function setCurrentPageData(routePath: string, data: Page): void {
+  slots[2] = slots[1];
+  slots[1] = { routePath, data };
 }
 
 export async function initPageData(routePath: string): Promise<Page> {
@@ -67,7 +130,6 @@ export async function initPageData(routePath: string): Promise<Page> {
       frontmatter,
       toc,
     };
-    pageDataCache.set(routePath, result);
     return result;
   }
 

--- a/packages/core/src/runtime/ssrClientEntry.tsx
+++ b/packages/core/src/runtime/ssrClientEntry.tsx
@@ -2,7 +2,7 @@ import { removeBase } from '@rspress/core/runtime';
 import { startTransition } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 import { ClientApp } from './ClientApp';
-import { initPageData } from './initPageData';
+import { initPageData, setCurrentPageData } from './initPageData';
 
 // difference from csrClientEntry.tsx
 // 1. use hydrate instead of createRoot().render()
@@ -11,9 +11,9 @@ import { initPageData } from './initPageData';
 
 async function renderInBrowser() {
   const container = document.getElementById('__rspress_root')!;
-  const initialPageData = await initPageData(
-    removeBase(window.location.pathname),
-  );
+  const pathname = removeBase(window.location.pathname);
+  const initialPageData = await initPageData(pathname);
+  setCurrentPageData(pathname, initialPageData);
   // why startTransition?
   // https://github.com/facebook/docusaurus/pull/9051
   startTransition(() => {

--- a/packages/core/src/theme/components/Link/useLinkNavigate.ts
+++ b/packages/core/src/theme/components/Link/useLinkNavigate.ts
@@ -1,5 +1,6 @@
 import {
   cleanUrlByConfig,
+  initPageData,
   isActive,
   isExternalUrl,
   pathnameToRouteService,
@@ -89,6 +90,7 @@ export function useLinkNavigate(
               nprogress.start();
             }, 200);
             await matchedRoute.preload();
+            await initPageData(removeBaseHref);
             clearTimeout(timer);
             nprogress.done();
           } else {

--- a/packages/core/src/theme/components/Link/useLinkNavigate.ts
+++ b/packages/core/src/theme/components/Link/useLinkNavigate.ts
@@ -90,7 +90,6 @@ export function useLinkNavigate(
             const timer = setTimeout(() => {
               nprogress.start();
             }, 200);
-            await matchedRoute.preload();
             const data = await initPageData(removeBaseHref);
             warmPageData(removeBaseHref, data);
             clearTimeout(timer);

--- a/packages/core/src/theme/components/Link/useLinkNavigate.ts
+++ b/packages/core/src/theme/components/Link/useLinkNavigate.ts
@@ -7,6 +7,7 @@ import {
   removeBase,
   useLocation,
   useNavigate as useNavigateInner,
+  warmPageData,
   withBase,
 } from '@rspress/core/runtime';
 import nprogress from 'nprogress';
@@ -90,7 +91,8 @@ export function useLinkNavigate(
               nprogress.start();
             }, 200);
             await matchedRoute.preload();
-            await initPageData(removeBaseHref);
+            const data = await initPageData(removeBaseHref);
+            warmPageData(removeBaseHref, data);
             clearTimeout(timer);
             nprogress.done();
           } else {


### PR DESCRIPTION
## Summary

Page data is now cached immediately after being lazy loaded, this way upon navigation we can try to set page data on the context using the information from the cache itself. This should remove a flash of content being odd because of stale pagedata caching.

This solution is a huge hack though, and I think I'd prefer to find a way to simply make this data available synchronously somehow. Or somehow tie it to the navigation in such a way that it is swapped in and out at the same time as the actual page content is.

### Before

https://github.com/user-attachments/assets/cea668e6-4fba-44f0-9dc6-defe81030081

### After

https://github.com/user-attachments/assets/ef90b20a-8f5c-4395-b453-1f5f13d4f4c3

## Related Issue

https://github.com/web-infra-dev/rspress/issues/3277

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).

I haven't updated tests because I genuinely have no idea how I'd even test this. Happy to take suggestions
