### PR TITLE
feat(search):  improve search index building, markdown -> plain text 

### DIFF
--- a/packages/core/src/node/route/extractPageData.test.ts
+++ b/packages/core/src/node/route/extractPageData.test.ts
@@ -180,14 +180,13 @@ describe('getPageIndexInfoByRoute', async () => {
 
       ",
         "_relativePath": "index.mdx",
-        "content": "## h2 Comp
+        "content": "h2 Comp
 
       Comp content
 
-      ## H2 comp in comp
+      H2 comp in comp
 
-      Comp in Comp content \`code\`
-      ",
+      Comp in Comp content code",
         "description": undefined,
         "frontmatter": {
           "__content": undefined,
@@ -203,7 +202,7 @@ describe('getPageIndexInfoByRoute', async () => {
             "text": "h2 Comp",
           },
           {
-            "charIndex": 26,
+            "charIndex": 23,
             "depth": 2,
             "id": "h2-comp-in-comp",
             "text": "H2 comp in comp",
@@ -248,10 +247,9 @@ describe('getPageIndexInfoByRoute', async () => {
 
       Some text after code.
 
-      ## Section two
+      Section two
 
-      More content here.
-      ",
+      More content here.",
         "description": "Some text before code. Some text after code.",
         "frontmatter": {
           "__content": undefined,
@@ -304,17 +302,14 @@ describe('getPageIndexInfoByRoute', async () => {
         "_relativePath": "with-code.mdx",
         "content": "Some text before code.
 
-      \`\`\`javascript
       const foo = 'bar';
       console.log(foo);
-      \`\`\`
 
       Some text after code.
 
-      ## Section two
+      Section two
 
-      More content here.
-      ",
+      More content here.",
         "description": "Some text before code. Some text after code.",
         "frontmatter": {
           "__content": undefined,
@@ -324,7 +319,7 @@ describe('getPageIndexInfoByRoute', async () => {
         "title": "Page with code",
         "toc": [
           {
-            "charIndex": 103,
+            "charIndex": 85,
             "depth": 2,
             "id": "section-two",
             "text": "Section two",
@@ -368,10 +363,9 @@ describe('getPageIndexInfoByRoute', async () => {
 
       And some text after.
 
-      ## Another section
+      Another section
 
-      Final text.
-      ",
+      Final text.",
         "description": "Here is an image: And some text after.",
         "frontmatter": {
           "__content": undefined,
@@ -419,16 +413,17 @@ describe('getPageIndexInfoByRoute', async () => {
       Visit [our docs](./docs/intro.md) for more info.
       ",
         "_relativePath": "with-links.mdx",
-        "content": "This is a [link to Google]() in text.
+        "content": "This is a link to Google in text.
 
-      ## Links section
+      Links section
 
-      - [First link]()
-      - [Second link]()
-      - Plain text item
+      First link
 
-      Visit [our docs]() for more info.
-      ",
+      Second link
+
+      Plain text item
+
+      Visit our docs for more info.",
         "description": "This is a link to Google in text.",
         "frontmatter": {
           "__content": undefined,
@@ -438,7 +433,7 @@ describe('getPageIndexInfoByRoute', async () => {
         "title": "Page with links",
         "toc": [
           {
-            "charIndex": 39,
+            "charIndex": 35,
             "depth": 2,
             "id": "links-section",
             "text": "Links section",
@@ -479,15 +474,13 @@ describe('getPageIndexInfoByRoute', async () => {
         "_relativePath": "with-table.mdx",
         "content": "Some intro text.
 
-      | Header 1 | Header 2 | Header 3 |
-      | -------- | -------- | -------- |
-      | Cell 1   | Cell 2   | Cell 3   |
-      | Cell 4   | Cell 5   | Cell 6   |
+      Header 1	Header 2	Header 3
+      Cell 1	Cell 2	Cell 3
+      Cell 4	Cell 5	Cell 6
 
-      ## After table
+      After table
 
-      More content.
-      ",
+      More content.",
         "description": "Some intro text.",
         "frontmatter": {
           "__content": undefined,
@@ -497,7 +490,7 @@ describe('getPageIndexInfoByRoute', async () => {
         "title": "Page with table",
         "toc": [
           {
-            "charIndex": 159,
+            "charIndex": 88,
             "depth": 2,
             "id": "after-table",
             "text": "After table",
@@ -534,10 +527,9 @@ describe('getPageIndexInfoByRoute', async () => {
         "_relativePath": "with-frontmatter.mdx",
         "content": "This page has frontmatter with a custom title.
 
-      ## Section
+      Section
 
-      More content here.
-      ",
+      More content here.",
         "description": "A page with frontmatter",
         "frontmatter": {
           "__content": undefined,

--- a/packages/core/src/node/route/extractPageData.ts
+++ b/packages/core/src/node/route/extractPageData.ts
@@ -8,14 +8,12 @@ import {
   type RouteMeta,
 } from '@rspress/shared';
 import { loadFrontMatter } from '@rspress/shared/node-utils';
-import type { Link, Node, Root } from 'mdast';
+import type { Node, Nodes, Root } from 'mdast';
 import remarkGFM from 'remark-gfm';
 import remarkParse from 'remark-parse';
-import remarkStringify from 'remark-stringify';
 import type { Plugin } from 'unified';
 import { unified } from 'unified';
 import { remove } from 'unist-util-remove';
-import { visit } from 'unist-util-visit';
 import { importStatementRegex } from '../constants';
 import { parseToc } from '../mdx/remarkPlugins/toc';
 import { flattenMdxContent } from '../utils';
@@ -73,18 +71,6 @@ const remarkRemoveImages: Plugin<[], Root> = () => {
 };
 
 /**
- * Remark plugin to strip link URLs, keeping only the link text
- * This mimics html-to-text's ignoreHref behavior
- */
-const remarkStripLinkUrls: Plugin<[], Root> = () => {
-  return tree => {
-    visit(tree, 'link', (node: Link) => {
-      node.url = '';
-    });
-  };
-};
-
-/**
  * Cached processor instances for performance optimization
  * Reusing processors avoids the overhead of creating new instances for each file
  */
@@ -93,12 +79,7 @@ const createProcessor = (searchCodeBlocks: boolean) =>
     .use(remarkParse)
     .use(remarkGFM)
     .use(remarkRemoveImages)
-    .use(remarkStripLinkUrls)
-    .use(searchCodeBlocks ? [] : [remarkRemoveCodeBlocks])
-    .use(remarkStringify, {
-      bullet: '-',
-      listItemIndent: 'one',
-    });
+    .use(searchCodeBlocks ? [] : [remarkRemoveCodeBlocks]);
 
 const processorWithCode = createProcessor(true);
 const processorWithoutCode = createProcessor(false);
@@ -114,6 +95,134 @@ function extractTextFromNode(node: Node): string {
     return node.children.map(extractTextFromNode).join('');
   }
   return '';
+}
+
+/**
+ * Nodes that we should just ignore for search indexing
+ */
+const SEARCH_SKIP_TYPES = new Set([
+  'image',
+  'imageReference',
+  'definition',
+  'footnoteDefinition',
+  'footnoteReference',
+  'html',
+  'thematicBreak',
+  'mdxJsxFlowElement',
+  'mdxJsxTextElement',
+  'mdxFlowExpression',
+  'mdxTextExpression',
+  'mdxjsEsm',
+]);
+
+/**
+ * Block level nodes that should have a trailing newline or are separated naturally in the markdown already.
+ */
+const SEARCH_BLOCK_TYPES = new Set([
+  'paragraph',
+  'heading',
+  'listItem',
+  'tableRow',
+]);
+
+/**
+ * Recursively extract raw text from the mdast
+ */
+function extractSearchText(node: Nodes, codeblocks: boolean): string {
+  const { type } = node;
+
+  // Return an empty string for any kind of "non-content" node
+  if (SEARCH_SKIP_TYPES.has(type)) {
+    return '';
+  }
+
+  // If we are excluding code blocks then return an empty string for them
+  if (type === 'code' && !codeblocks) {
+    return '';
+  }
+
+  if (type === 'break') {
+    return '\n';
+  }
+
+  // If we are text or inline code then just return that nodes value, for example `**test**` becomes `test`
+  if (type === 'text' || type === 'inlineCode') {
+    return node.value;
+  }
+  // multiline code blocks are prefixed and suffixed with newlines
+  if (type === 'code') {
+    return `\n${node.value}\n`;
+  }
+
+  let result = '';
+  if ('children' in node) {
+    for (const child of node.children) {
+      result += extractSearchText(child as Nodes, codeblocks);
+    }
+  }
+
+  // Add a new line for any element thats like a block of something, such as a heading or paragraph
+  if (SEARCH_BLOCK_TYPES.has(type)) {
+    result += '\n';
+  }
+
+  // table cells are separated by tabs instead of `|`
+  if (type === 'tableCell') {
+    result += '\t';
+  }
+
+  // \t\n replace so we don't have trailing whitespace on table rows that aren't at the end of the text
+  return result.replaceAll('\t\n', '\n');
+}
+
+/**
+ * Walk the AST to build plain text search content. Tracks charIndex positions
+ * for each TOC heading so the search UI can link results to the right section.
+ */
+function buildSearchContent(
+  tree: Root,
+  rawToc: Array<{ id: string; text: string; depth: number }>,
+  codeblocks: boolean,
+): { content: string; toc: Header[] } {
+  const parts: string[] = [];
+  const headingCharIndexes: number[] = [];
+  let tocIndex = 0;
+  let contentLength = 0;
+
+  for (const node of tree.children) {
+    if (node.type === 'heading' && node.depth === 1) {
+      continue;
+    }
+
+    const text = extractSearchText(node, codeblocks).trim();
+    if (!text) {
+      continue;
+    }
+
+    if (parts.length > 0) {
+      contentLength += 2; // \n\n separator, account for it before we do heading nodes!
+    }
+
+    // parseToc collects h2-h4 in document order, so we can match them by index
+    if (node.type === 'heading' && node.depth >= 2 && node.depth < 5) {
+      if (tocIndex < rawToc.length) {
+        headingCharIndexes.push(contentLength);
+        tocIndex++;
+      }
+    }
+
+    contentLength += text.length;
+    parts.push(text);
+  }
+
+  return {
+    content: parts.join('\n\n'),
+    toc: rawToc.map((item, index) => ({
+      ...item,
+      charIndex:
+        index < headingCharIndexes.length ? headingCharIndexes[index] : -1,
+    })),
+  };
 }
 
 /**
@@ -306,41 +415,13 @@ async function getPageIndexInfoByRoute(
 
   // Run plugins and stringify to markdown for search content
   const processedTree = await processor.run(tree);
-  let processedContent = String(processor.stringify(processedTree as Root));
 
-  // Remove the title from the content if it appears at the start
-  if (processedContent.startsWith(`# ${title}`)) {
-    processedContent = processedContent.slice(`# ${title}`.length).trimStart();
-  }
-
-  // Calculate character index positions for each toc item
-  const toc: Header[] = rawToc.map(item => {
-    const match = item.id.match(/-(\d+)$/);
-    // Find the heading in content (## for h2, ### for h3, etc.)
-    const headingPrefix = '#'.repeat(item.depth);
-    let position = -1;
-    if (match) {
-      for (let i = 0; i < Number(match[1]); i++) {
-        // When text is repeated, the position needs to be determined based on -number
-        position = processedContent.indexOf(
-          `${headingPrefix} ${item.text}`,
-          position + 1,
-        );
-
-        // If the positions don't match, it means the text itself may exist -number
-        if (position === -1) {
-          break;
-        }
-      }
-    }
-    return {
-      ...item,
-      charIndex: processedContent.indexOf(
-        `${headingPrefix} ${item.text}`,
-        position + 1,
-      ),
-    };
-  });
+  // Walk the AST to extract plain text content and compute heading positions
+  const { content: processedContent, toc } = buildSearchContent(
+    processedTree as Root,
+    rawToc,
+    searchCodeBlocks,
+  );
 
   return {
     ...defaultIndexInfo,

--- a/packages/core/src/node/route/extractPageData.ts
+++ b/packages/core/src/node/route/extractPageData.ts
@@ -176,8 +176,8 @@ function extractSearchText(node: Nodes, codeblocks: boolean): string {
 }
 
 /**
- * Walk the AST to build plain text search content. Tracks charIndex positions
- * for each TOC heading so the search UI can link results to the right section.
+ * Walk the AST to build plain text search content. Tracks charIndex positions for each TOC heading so the search UI can
+ * link results to the right section.
  */
 function buildSearchContent(
   tree: Root,
@@ -189,8 +189,13 @@ function buildSearchContent(
   let tocIndex = 0;
   let contentLength = 0;
 
+  // Keep track of whether we have seen the first heading, the first one does not get included in the table of contents.
+  let skippedFirstH1 = false;
+
   for (const node of tree.children) {
-    if (node.type === 'heading' && node.depth === 1) {
+    // Only skip the first one, subsequent H1 headings we can keep.
+    if (node.type === 'heading' && node.depth === 1 && !skippedFirstH1) {
+      skippedFirstH1 = true;
       continue;
     }
 

--- a/packages/core/src/node/route/extractPageData.ts
+++ b/packages/core/src/node/route/extractPageData.ts
@@ -128,51 +128,50 @@ const SEARCH_BLOCK_TYPES = new Set([
 /**
  * Recursively extract raw text from the mdast
  */
-function extractSearchText(node: Nodes, codeblocks: boolean): string {
+function extractSearchText(node: Nodes, codeblocks: boolean): Array<string> {
   const { type } = node;
 
   // Return an empty string for any kind of "non-content" node
   if (SEARCH_SKIP_TYPES.has(type)) {
-    return '';
+    return [];
   }
 
   // If we are excluding code blocks then return an empty string for them
   if (type === 'code' && !codeblocks) {
-    return '';
+    return [];
   }
 
   if (type === 'break') {
-    return '\n';
+    return ['\n'];
   }
 
   // If we are text or inline code then just return that nodes value, for example `**test**` becomes `test`
   if (type === 'text' || type === 'inlineCode') {
-    return node.value;
+    return [node.value];
   }
   // multiline code blocks are prefixed and suffixed with newlines
   if (type === 'code') {
-    return `\n${node.value}\n`;
+    return [`\n${node.value}\n`];
   }
 
-  let result = '';
+  const result: Array<string> = [];
   if ('children' in node) {
     for (const child of node.children) {
-      result += extractSearchText(child as Nodes, codeblocks);
+      result.push(...extractSearchText(child as Nodes, codeblocks));
     }
   }
 
   // Add a new line for any element thats like a block of something, such as a heading or paragraph
   if (SEARCH_BLOCK_TYPES.has(type)) {
-    result += '\n';
+    result.push('\n');
   }
 
   // table cells are separated by tabs instead of `|`
   if (type === 'tableCell') {
-    result += '\t';
+    result.push('\t');
   }
 
-  // \t\n replace so we don't have trailing whitespace on table rows that aren't at the end of the text
-  return result.replaceAll('\t\n', '\n');
+  return result;
 }
 
 /**
@@ -199,7 +198,11 @@ function buildSearchContent(
       continue;
     }
 
-    const text = extractSearchText(node, codeblocks).trim();
+    const text = extractSearchText(node, codeblocks)
+      .join('')
+      // \t\n replace so we don't have trailing whitespace on table rows that aren't at the end of the text
+      .replaceAll('\t\n', '\n')
+      .trim();
     if (!text) {
       continue;
     }


### PR DESCRIPTION
## Summary

(if I am opening up too many PRs please let me know and I will slow down, currently working on https://github.com/monetr/monetr/pull/3081 so I'm trying to fix whatever I find)

This improves how the search index is built by changing how certain elements of the markdown content are stripped from the search index. For example, right now some markdown syntax like tables or links are not always completely stripped from the search index. Or things like inline code retains its backtick surrounding marks. Or bold text includes the double star in the search index.

This instead uses the mdast to extract the plain text value of the markdown text and throw out AST nodes that arent meaningful to include in the actual final search index.

### Before

If you apply this patch to the website and then run it locally you can see these behaviors:

```diff
diff --git a/website/rspress.config.ts b/website/rspress.config.ts
index 4fba6128..6e18ea8b 100644
--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -96,9 +96,9 @@ export default defineConfig({
     pluginSitemap({
       siteUrl,
     }),
-    pluginAlgolia({
-      verificationContent: '8F5BFE50E65777F1',
-    }),
+    // pluginAlgolia({
+    //   verificationContent: '8F5BFE50E65777F1',
+    // }),
     pluginFileTree(),
     pluginOg({
       domain: 'https://rspress.rs',
diff --git a/website/theme/index.tsx b/website/theme/index.tsx
index 6ba0e498..4e883efb 100644
--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -91,22 +91,22 @@ const DocLayout = (props: DocLayoutProps) => {
   );
 };
 
-const Search = () => {
-  const lang = useLang();
-  return (
-    <PluginAlgoliaSearch
-      docSearchProps={{
-        appId: 'DIDX9ZTSBM', // cspell:disable-line
-        apiKey: 'd33cfed9ffae0e79412cfc3785d3a67f', // cspell:disable-line
-        indexName: 'rspress-v2-crawler-doc_search_rspress_v2_pages',
-        searchParameters: {
-          facetFilters: [`lang:${lang}`],
-        },
-      }}
-      locales={ZH_LOCALES}
-    />
-  );
-};
+// const Search = () => {
+//   const lang = useLang();
+//   return (
+//     <PluginAlgoliaSearch
+//       docSearchProps={{
+//         appId: 'DIDX9ZTSBM', // cspell:disable-line
+//         apiKey: 'd33cfed9ffae0e79412cfc3785d3a67f', // cspell:disable-line
+//         indexName: 'rspress-v2-crawler-doc_search_rspress_v2_pages',
+//         searchParameters: {
+//           facetFilters: [`lang:${lang}`],
+//         },
+//       }}
+//       locales={ZH_LOCALES}
+//     />
+//   );
+// };
 
 function getCustomMDXComponent() {
   const { h1: H1, ...components } = basicGetCustomMDXComponent();
@@ -169,6 +169,6 @@ export {
   HomeHero,
   HomeLayout,
   Layout,
-  Search,
+  // Search,
   Tag,
 };
```

Then run the website and go to the search and type in:

> no meta

You'll get this:

<img width="642" height="252" alt="image" src="https://github.com/user-attachments/assets/e2909413-9add-49a4-bf79-7faa845cd4bf" />

Which is coming from: https://github.com/web-infra-dev/rspress/blob/70ac277d23fe4a73f63c1945ca7232b7aab2359f/website/docs/en/guide/use-mdx/code-blocks.mdx#L279-L279

### After

With the changes I've made here you now get this instead:

<img width="631" height="234" alt="image" src="https://github.com/user-attachments/assets/c7a5f747-4329-4fac-ad6e-d6f09e4b12ba" />

No residual markdown syntax.

## Related Issue

I don't see any about this specific issue/nuance

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
