### PR TITLE
perf(deps): bundle tinyglobby and tinypool into core

### DIFF
--- a/.changeset/fair-buttons-sparkle.md
+++ b/.changeset/fair-buttons-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+Reduce install size by externalizing tinyglobby and tinypool from @rspress/core.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -98,8 +98,6 @@
     "remark-stringify": "^11.0.0",
     "scroll-into-view-if-needed": "^3.1.0",
     "shiki": "^4.0.2",
-    "tinyglobby": "^0.2.15",
-    "tinypool": "^1.1.1",
     "unified": "^11.0.5",
     "unist-util-remove": "^4.0.0",
     "unist-util-visit": "^5.1.0",
@@ -133,6 +131,8 @@
     "rsbuild-plugin-publint": "^0.3.4",
     "rsbuild-plugin-virtual-module": "0.4.1",
     "tailwindcss": "^3.4.19",
+    "tinyglobby": "^0.2.15",
+    "tinypool": "^1.1.1",
     "ts-json-schema-generator": "^2.9.0",
     "typescript": "^5.8.2",
     "vfile": "^6.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1056,12 +1056,6 @@ importers:
       shiki:
         specifier: ^4.0.2
         version: 4.0.2
-      tinyglobby:
-        specifier: ^0.2.15
-        version: 0.2.15
-      tinypool:
-        specifier: ^1.1.1
-        version: 1.1.1
       unified:
         specifier: ^11.0.5
         version: 11.0.5
@@ -1156,6 +1150,12 @@ importers:
       tailwindcss:
         specifier: ^3.4.19
         version: 3.4.19(yaml@2.8.3)
+      tinyglobby:
+        specifier: ^0.2.15
+        version: 0.2.15
+      tinypool:
+        specifier: ^1.1.1
+        version: 1.1.1
       ts-json-schema-generator:
         specifier: ^2.9.0
         version: 2.9.0


### PR DESCRIPTION
## Summary
- move `tinyglobby` and `tinypool` from `dependencies` to `devDependencies` in `@rspress/core`
- sync `pnpm-lock.yaml`
- add a changeset for the install size optimization

## Validation
- `pnpm install`
- `pnpm lint`
- `pnpm test:unit` (fails on existing baseline issues unrelated to this change, including multiple `__webpack_require__1.r is not a function` failures and dead image test failures)
- `pnpm --filter @rspress/core build` (fails on existing baseline type resolution for `@rspress/shared/lodash-es` declaration generation)
