### PR TITLE
chore(deps): update pnpm-plugin-skills to 0.5.0

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 configDependencies:
-  pnpm-plugin-skills: 0.3.0+sha512-grriFBSg98JI0lmNkuDg1a72JK+HVFlA5QRPjwN8dqH2me1Y+uapYq+uIJ3g8I3BlkdZ+SVJHyt4uknoKrUKwQ==
+  pnpm-plugin-skills: 0.5.0+sha512-wgwqHeVDNe7KQ7sHuM1uL+/tmR7FmDJJBZNR6sHu3KTCO9K8OGdYGoPQzJSA8d2KxigjccFc7uPMSPfZ5WXbCg==
 
 packages:
   - scripts/config


### PR DESCRIPTION
## Summary

This PR updates the pnpm config dependency "pnpm-plugin-skills" from 0.3.0 to 0.5.0.

## Related Issue

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).