### PR TITLE
fix(theme/table): polish table styles to fix too narrow col case

### DIFF
--- a/e2e/fixtures/theme-css/doc/prose/index.mdx
+++ b/e2e/fixtures/theme-css/doc/prose/index.mdx
@@ -49,26 +49,56 @@ In Rspress, in addition to declaring [nav](https://rspress.rs/api/config/config-
 
 ## Table
 
-| Header 1 | Header 2 |
-| -------- | -------- |
-| Data 1   | Data 2   |
-| Data 1   | Data 2   |
+| package              | v1  | v2  |
+| -------------------- | --- | --- |
+| `@rspack/core`       | 8   | 1   |
+| `@rspack/cli`        | 210 | 0   |
+| `@rspack/dev-server` | 192 | 1   |
+| `@rsbuild/core`      | 13  | 4   |
+
+| package              | v1  | v2  | v3  | v4  |
+| -------------------- | --- | --- | --- | --- |
+| `@rspack/core`       | 8   | 1   | 1   | 1   |
+| `@rspack/cli`        | 210 | 0   | 1   | 1   |
+| `@rspack/dev-server` | 192 | 1   | 1   | 1   |
+| `@rsbuild/core`      | 13  | 4   | 1   | 1   |
 
 <table>
   <thead>
     <tr>
-      <th>Header 1</th>
-      <th>Header 2</th>
+      <th>package</th>
+      <th>v1</th>
+      <th>v2</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td>Data 1</td>
-      <td>Data 2</td>
+      <td>
+        <code>@rspack/core</code>
+      </td>
+      <td>8</td>
+      <td>1</td>
     </tr>
     <tr>
-      <td>Data 1</td>
-      <td>Data 2</td>
+      <td>
+        <code>@rspack/cli</code>
+      </td>
+      <td>210</td>
+      <td>0</td>
+    </tr>
+    <tr>
+      <td>
+        <code>@rspack/dev-server</code>
+      </td>
+      <td>192</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <td>
+        <code>@rsbuild/core</code>
+      </td>
+      <td>13</td>
+      <td>4</td>
     </tr>
   </tbody>
 </table>
@@ -77,19 +107,36 @@ In Rspress, in addition to declaring [nav](https://rspress.rs/api/config/config-
   <table>
     <thead>
       <tr>
-        <th>Header 1</th>
-        <th>Header 2</th>
+        <th>package</th>
+        <th>v1</th>
+        <th>v2</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <td>Data 1</td>
-        <td>Data 2</td>
+        <td>
+          <code>@rspack/core</code>
+        </td>
+        <td>8</td>
+        <td>1</td>
       </tr>
       <tr>
-        <td>Data 1</td>
-        <td>Data 2</td>
+        <td>
+          <code>@rspack/cli</code>
+        </td>
+        <td>210</td>
+        <td>0</td>
       </tr>
     </tbody>
   </table>
 </div>
+
+## Long table
+
+| Skill                       | Package              | CLI command              | Description                                                                                                                                  |
+| --------------------------- | -------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Browser Automation          | `@midscene/web`      | `npx @midscene/web`      | Browser automation with three modes: default Puppeteer headless, `--bridge` to use your own Chrome, `--cdp <ws-endpoint>` to connect via CDP |
+| Desktop Computer Automation | `@midscene/computer` | `npx @midscene/computer` | macOS, Windows, Linux desktop control                                                                                                        |
+| Android Device Automation   | `@midscene/android`  | `npx @midscene/android`  | Android device control via ADB                                                                                                               |
+| iOS Device Automation       | `@midscene/ios`      | `npx @midscene/ios`      | iOS device control via WebDriverAgent                                                                                                        |
+| HarmonyOS Device Automation | `@midscene/harmony`  | `npx @midscene/harmony`  | HarmonyOS device control via HDC                                                                                                             |

--- a/packages/core/src/theme/components/DocContent/doc.scss
+++ b/packages/core/src/theme/components/DocContent/doc.scss
@@ -177,30 +177,24 @@
     /* table */
     /* #region */
     &:where(.rp-table-scroll-container) {
+      margin: 1.5rem 0;
       overflow-x: auto;
+      overscroll-behavior-x: contain;
     }
+
     &:where(table) {
       width: 100%;
-
+      min-width: 100%;
       table-layout: auto;
       border-collapse: separate;
       border-spacing: 0;
-
       border: var(--rp-code-block-border);
       border-radius: var(--rp-radius);
       overflow: hidden;
+    }
 
-      &::-webkit-scrollbar {
-        height: 5px;
-        width: 5px;
-      }
-      &::-webkit-scrollbar-corner {
-        display: none;
-      }
-      &::-webkit-scrollbar-thumb {
-        background-color: rgba(0, 0, 0, 0.05);
-        border-radius: 10px;
-      }
+    &:where(table:not(.rp-table-scroll-container > table)) {
+      margin: 1.5rem 0;
     }
 
     /* thead */
@@ -210,7 +204,8 @@
     }
 
     &:where(th) {
-      padding: 0.75rem 1.25rem;
+      min-width: 8rem;
+      padding: 0.75rem 1rem;
       font-weight: 600;
       font-size: 0.875rem;
       text-align: left;
@@ -224,14 +219,15 @@
     }
 
     &:where(td) {
-      padding: 0.75rem 1.25rem;
+      min-width: 8rem;
+      padding: 0.75rem 1rem;
       border-bottom: 1px solid var(--rp-c-divider-light);
-
       font-size: 0.875rem;
+      color: var(--rp-c-text-1);
     }
 
-    &:where(tr) {
-      transition: background-color 0.2s ease;
+    &:where(tbody tr) {
+      transition: background-color 0.2s ease-out;
 
       &:hover {
         background: var(--rp-c-bg-soft);
@@ -279,29 +275,6 @@
       &:hover {
         background-color: var(--rp-c-bg-mute);
       }
-    }
-  }
-}
-
-/* Dark mode styles */
-:where(.rp-dark) .rp-doc {
-  :not(:where(.rp-not-doc, .rp-not-doc *)) {
-    /* table */
-    /* #region */
-    &:where(table) {
-      border-color: var(--rp-c-divider);
-    }
-
-    &:where(table tr) {
-      border-color: var(--rp-c-divider);
-    }
-
-    &:where(table td) {
-      border-color: var(--rp-c-divider);
-    }
-
-    &:where(table th) {
-      border-color: var(--rp-c-divider);
     }
   }
 }

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -87,6 +87,7 @@ mdxrs
 menlo
 metastring
 microhei
+midscene
 modularly
 napi
 networkidle


### PR DESCRIPTION
## Summary

This PR polishes the default theme table styles with better spacing, rounded corners, and improved dark mode appearance. It also updates the E2E fixture to include more realistic table examples.

### before

<img width="995" height="941" alt="image" src="https://github.com/user-attachments/assets/eb7c154f-d7ef-4a8a-acde-0322594b5eef" />

### after

<img width="963" height="889" alt="image" src="https://github.com/user-attachments/assets/e8ab06b5-0b2a-4182-b614-dc3e0e96a80c" />


## Related Issue

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).