### PR TITLE
docs: add rspress-plugin-comments to community plugins

### DIFF
--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -182,3 +182,4 @@ zeabur
 zhihu
 zhong
 Zovn
+Gitea

--- a/website/docs/en/plugin/community-plugins/overview.mdx
+++ b/website/docs/en/plugin/community-plugins/overview.mdx
@@ -27,6 +27,7 @@ Here are some community plugins:
 - [rspress-plugin-auto-sidebar](https://github.com/buyfakett/rspress-plugin-auto-sidebar.git): Automatically generate the sidebar from the navbar configuration.
 - [rspress-plugin-giscus](https://github.com/buyfakett/rspress-plugin-giscus.git): Integrate [giscus](https://github.com/giscus/giscus) into Rspress, a comment system powered by GitHub Discussions.
 - [rspress-plugin-blog-list](https://github.com/buyfakett/rspress-plugin-blog-list.git): Integrate blog list into Rspress.
+- [rspress-plugin-comments](https://github.com/kalicyh/rspress-plugin-comments): Provide page comments and text selection comments for Rspress, with support for a self-hosted backend and optional Gitea OAuth login.
 
 ## Contributing community plugins
 

--- a/website/docs/zh/plugin/community-plugins/overview.mdx
+++ b/website/docs/zh/plugin/community-plugins/overview.mdx
@@ -27,6 +27,7 @@
 - [rspress-plugin-auto-sidebar](https://github.com/buyfakett/rspress-plugin-auto-sidebar.git): 通过 navbar 自动生成生成 sidebar。
 - [rspress-plugin-giscus](https://github.com/buyfakett/rspress-plugin-giscus.git): 集成 [giscus](https://github.com/giscus/giscus) 到 Rspress，一个基于 GitHub Discussions 的评论系统。
 - [rspress-plugin-blog-list](https://github.com/buyfakett/rspress-plugin-blog-list.git): 集成博客列表到 Rspress。
+- [rspress-plugin-comments](https://github.com/kalicyh/rspress-plugin-comments): 为 Rspress 提供页面评论与文本选区评论，支持自托管后端和可选的 Gitea OAuth 登录。
 
 ## 贡献社区插件
 


### PR DESCRIPTION
## Summary

Add `rspress-plugin-comments` to the community plugins list.

## Plugin Info

- Package: `rspress-plugin-comments`
- Repository: `https://github.com/kalicyh/rspress-plugin-comments`
- Description: A self-hosted comments plugin for Rspress, supporting page-level comments, text-selection comments, and optional Gitea OAuth integration.