### PR TITLE
fix(theme/outline): reduce outline toc mask spacing

### DIFF
--- a/packages/core/src/theme/components/Outline/index.scss
+++ b/packages/core/src/theme/components/Outline/index.scss
@@ -48,7 +48,7 @@
     overflow: auto scroll;
     scrollbar-width: none;
 
-    mask-image: linear-gradient(#0000, #fff 12px calc(100% - 12px), #0000);
+    mask-image: linear-gradient(#0000, #fff 8px calc(100% - 8px), #0000);
 
     // limit height on mobile where outline is a floating panel
     @media (max-width: 1280px) {


### PR DESCRIPTION
## Summary

Reduce the outline table-of-contents mask fade spacing from 12px to 8px so the visible scroll area has a smaller fade at the top and bottom.

<img width="327" height="416" alt="image" src="https://github.com/user-attachments/assets/2e9f1a58-40e5-4e7d-983f-eb4e3f2eb404" />


## Related Issue

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).