### PR TITLE
feat(theme)!: support `sidebar: false` and `sidebar: placeholder` mode

### DIFF
--- a/.changeset/quiet-sidebars-walk.md
+++ b/.changeset/quiet-sidebars-walk.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': minor
+---
+
+Support `sidebar: 'placeholder'` and adjust `sidebar: false` to keep a smaller left placeholder.

--- a/packages/core/src/theme/components/SidebarMenu/index.tsx
+++ b/packages/core/src/theme/components/SidebarMenu/index.tsx
@@ -37,8 +37,12 @@ export const SidebarMenu = forwardRef(
     const { scrolledHeader } = useActiveAnchor(headers);
 
     const {
-      frontmatter: { sidebar: showSidebar = true, outline: showOutline = true },
+      frontmatter: {
+        sidebar: sidebarConfig = true,
+        outline: showOutline = true,
+      },
     } = useFrontmatter();
+    const showSidebar = sidebarConfig === true;
 
     function openSidebar() {
       onIsSidebarOpenChange(true);

--- a/packages/core/src/theme/layout/DocLayout/index.scss
+++ b/packages/core/src/theme/layout/DocLayout/index.scss
@@ -150,8 +150,11 @@
     margin-left: var(--rp-sidebar-margin-left);
   }
   .rp-doc-layout__sidebar-placeholder {
-    width: var(--rp-sidebar-width);
+    width: 12vw;
     margin-left: var(--rp-sidebar-margin-left);
+  }
+  .rp-doc-layout__sidebar-placeholder--legacy {
+    width: var(--rp-sidebar-width);
   }
   .rp-doc-layout__outline {
     margin-right: var(--rp-outline-margin-right);

--- a/packages/core/src/theme/layout/DocLayout/index.tsx
+++ b/packages/core/src/theme/layout/DocLayout/index.tsx
@@ -44,8 +44,12 @@ export function DocLayout(props: DocLayoutProps) {
 
   const isOverviewPage = frontmatter?.overview ?? false;
 
+  const sidebar = frontmatter?.sidebar ?? true;
+  const showSidebar = sidebar === true;
+  const showSidebarPlaceholder = sidebar === false || sidebar === 'placeholder';
+  const isLegacyPlaceholder = sidebar === 'placeholder';
+
   const {
-    sidebar: showSidebar = true,
     outline: showOutline = true,
     footer: showDocFooter = true,
     pageType,
@@ -96,12 +100,16 @@ export function DocLayout(props: DocLayoutProps) {
             <Sidebar />
             {afterSidebar}
           </aside>
-        ) : (
+        ) : showSidebarPlaceholder ? (
           <aside
-            className="rp-doc-layout__sidebar-placeholder"
+            className={clsx(
+              'rp-doc-layout__sidebar-placeholder',
+              isLegacyPlaceholder &&
+                'rp-doc-layout__sidebar-placeholder--legacy',
+            )}
             style={isDocWide ? { width: '0' } : {}}
           ></aside>
-        )}
+        ) : null}
 
         {/* Main document content */}
         {isOverviewPage ? (

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -446,7 +446,7 @@ export interface FrontMatterMeta {
 
   // ui
   navbar?: boolean;
-  sidebar?: boolean;
+  sidebar?: boolean | 'placeholder';
   outline?: boolean;
   footer?: boolean;
 

--- a/website/docs/en/api/config/config-frontmatter.mdx
+++ b/website/docs/en/api/config/config-frontmatter.mdx
@@ -81,6 +81,9 @@ titleSuffix: '| Rsbuild-based Static Site Generator'
 
 ## sidebar
 
+- **Type**: `boolean | 'placeholder'`
+- **Default**: `true`
+
 Whether to show the sidebar on the left. By default, the `doc` page will display the sidebar on the left. If you want to hide the sidebar on the left, you can use the following front matter config:
 
 ```yaml
@@ -90,7 +93,7 @@ sidebar: false
 ```
 
 :::tip
-`sidebar: false` only hides the sidebar, but the space originally occupied by the sidebar is still reserved. If you want the main content to occupy a wider screen space, you can use [`pageType: doc-wide`](#pagetype) with `sidebar: false`:
+`sidebar: false` hides the sidebar and keeps a `12vw` placeholder on the left to keep the content visually centered on large screens. If you want the main content to occupy a wider screen space, you can use [`pageType: doc-wide`](#pagetype) with `sidebar: false`:
 
 ```yaml
 ---
@@ -100,6 +103,15 @@ sidebar: false
 ```
 
 This way, the main content area will automatically expand to occupy the space originally used by the sidebar.
+
+If you want to keep the blank space for the left sidebar, use `sidebar: 'placeholder'`:
+
+```yaml
+---
+sidebar: 'placeholder'
+---
+```
+
 :::
 
 ## outline

--- a/website/docs/zh/api/config/config-frontmatter.mdx
+++ b/website/docs/zh/api/config/config-frontmatter.mdx
@@ -81,6 +81,9 @@ titleSuffix: '| 基于 Rsbuild 的静态站点生成器'
 
 ## sidebar
 
+- **类型**： `boolean | 'placeholder'`
+- **默认值**： `true`
+
 是否展示左侧的目录栏。默认情况下，`doc` 页面会展示左侧的目录栏。但是如果你想隐藏左侧的目录栏，你可以使用以下 front matter 来配置：
 
 ```yaml
@@ -90,7 +93,7 @@ sidebar: false
 ```
 
 :::tip 提示
-`sidebar: false` 仅隐藏侧边栏，但原本侧边栏占据的空间仍然保留。如果你想让正文内容占据更宽的屏幕空间，可以使用 [`pageType: doc-wide`](#pagetype) 配合 `sidebar: false`：
+`sidebar: false` 会隐藏侧边栏，并在左侧保留 `12vw` 的占位，使正文内容在大屏下保持视觉居中。如果你想让正文内容占据更宽的屏幕空间，可以使用 [`pageType: doc-wide`](#pagetype) 配合 `sidebar: false`：
 
 ```yaml
 ---
@@ -100,6 +103,15 @@ sidebar: false
 ```
 
 这样正文内容区域会自动扩展，占据原本侧边栏的空间。
+
+如果你想保留左侧 sidebar 的空白，可以使用 `sidebar: 'placeholder'`：
+
+```yaml
+---
+sidebar: 'placeholder'
+---
+```
+
 :::
 
 ## outline

--- a/website/theme/index.css
+++ b/website/theme/index.css
@@ -1,11 +1,3 @@
-/* Simulate the centering behavior when sidebar: false  */
-/* Avoid having the visual center too far to the right */
-@media (min-width: 1280px) {
-  .rp-doc-layout__sidebar-placeholder {
-    width: 12vw !important;
-  }
-}
-
 .blog-back-button {
   margin-bottom: 1rem;
 }


### PR DESCRIPTION
## Summary

Support a new `sidebar: 'placeholder'` frontmatter mode for preserving the legacy full sidebar placeholder width, while `sidebar: false` now hides the sidebar with a smaller left placeholder for better visual centering. This also updates the English and Chinese frontmatter docs and adds a changeset.

<img width="1491" height="993" alt="image" src="https://github.com/user-attachments/assets/0836b84b-ee3a-4275-af4f-50fe9a387b80" />


## Related Issue

None

## Checklist

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).