### PR TITLE
chore(ci/rsdoctor): add auto-nav-sidebar baseline to Rsdoctor bundle diff analysis

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -45,9 +45,12 @@ jobs:
           pnpm install
           RSDOCTOR=1 pnpm run build
 
+      - name: Build auto-nav-sidebar Project
+        run: RSDOCTOR=1 pnpm --filter @rspress-fixture/auto-nav-sidebar run build
+
       - name: Report Compressed Size
         uses: web-infra-dev/rsdoctor-action@bce0934b887cddb56986d16c34a445bcce9a7d65 # main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          file_path: 'website/doc_build/diff-rsdoctor/**/rsdoctor-data.json'
+          file_path: '{website,e2e/fixtures/auto-nav-sidebar}/doc_build/diff-rsdoctor/**/rsdoctor-data.json'
           target_branch: 'main'

--- a/e2e/fixtures/auto-nav-sidebar/package.json
+++ b/e2e/fixtures/auto-nav-sidebar/package.json
@@ -12,6 +12,7 @@
     "@rspress/core": "workspace:*"
   },
   "devDependencies": {
+    "@rsdoctor/rspack-plugin": "1.6.0",
     "@types/node": "^22.8.1"
   }
 }

--- a/e2e/fixtures/auto-nav-sidebar/rspress.config.ts
+++ b/e2e/fixtures/auto-nav-sidebar/rspress.config.ts
@@ -1,6 +1,49 @@
 import * as path from 'node:path';
+import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 import { defineConfig } from '@rspress/core';
+
+const commonRsdoctorConfig = {
+  disableClientServer: true,
+  output: {
+    mode: 'brief' as const,
+    options: {
+      type: ['json'] as ('json' | 'html')[],
+    },
+  },
+};
+
+const getRsdoctorReportType = (environmentName?: string) => {
+  switch (environmentName) {
+    case 'node':
+      return 'html';
+    case 'node_md':
+      return 'md';
+    case 'web':
+      return 'js';
+    default:
+      return environmentName ?? 'unknown';
+  }
+};
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc'),
+  builderConfig: {
+    tools: {
+      rspack: config => {
+        if (process.env.RSDOCTOR) {
+          config.plugins ??= [];
+          config.plugins.push(
+            new RsdoctorRspackPlugin({
+              ...commonRsdoctorConfig,
+              output: {
+                ...commonRsdoctorConfig.output,
+                reportDir: `./doc_build/diff-rsdoctor/auto_nav_sidebar_${getRsdoctorReportType(config.name)}`,
+              },
+            }),
+          );
+        }
+        return config;
+      },
+    },
+  },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/core
     devDependencies:
+      '@rsdoctor/rspack-plugin':
+        specifier: 1.6.0
+        version: 1.6.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.6)(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)
       '@types/node':
         specifier: ^22.8.1
         version: 22.19.15

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -35,6 +35,19 @@ const commonRsdoctorConfig = {
   },
 };
 
+const getRsdoctorReportType = (environmentName?: string) => {
+  switch (environmentName) {
+    case 'node':
+      return 'html';
+    case 'node_md':
+      return 'md';
+    case 'web':
+      return 'js';
+    default:
+      return environmentName ?? 'unknown';
+  }
+};
+
 export default defineConfig({
   title: 'Rspress',
   description: 'Rsbuild based static site generator',
@@ -158,7 +171,7 @@ export default defineConfig({
               ...commonRsdoctorConfig,
               output: {
                 ...commonRsdoctorConfig.output,
-                reportDir: `./doc_build/diff-rsdoctor/${config.name}`,
+                reportDir: `./doc_build/diff-rsdoctor/website_${getRsdoctorReportType(config.name)}`,
               },
             }),
           );


### PR DESCRIPTION
## Summary

This PR adds `auto-nav-sidebar` as a distinct Rsdoctor bundle-diff baseline alongside the website build.

## What changed

- Register `@rsdoctor/rspack-plugin` through Rspress v2's `builderConfig.tools.rspack` hook.
- Initialize the Rspack plugin array and use deterministic `auto-nav-sidebar-*` report directories.
- Build the fixture with `RSDOCTOR=1` in the Diff workflow.
- Restrict artifact collection to the website and `auto-nav-sidebar` outputs.
- Upgrade `@rsdoctor/rspack-plugin` to `1.6.0` for both builds and refresh the lockfile.

## Root cause

The original implementation placed `tools.rspack` at the top level of the Rspress config. Rspress v2 reads this setting from `builderConfig`, so the hook was ignored and the fixture produced no Rsdoctor data. The old CI result therefore still contained only the website's `node`, `node_md`, and `web` projects.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `rslint --type-check`
- `pnpm run check-dependency-version`
- Prettier check for all changed source/config files
- Rsdoctor builds for both the website and fixture
- JSON validation for five distinct reports: `node`, `node_md`, `web`, `auto-nav-sidebar-node`, and `auto-nav-sidebar-web`

## Related Issue

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).