### PR TITLE
fix(theme/Prompt): address review follow-ups

### DIFF
--- a/.changeset/prompt-review-followups.md
+++ b/.changeset/prompt-review-followups.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+Fix Prompt follow-up issues around copy events, collapsed content accessibility, and theme exports.

--- a/packages/core/src/node/runtimeModule/DEFAULT_I18N_TEXT.ts
+++ b/packages/core/src/node/runtimeModule/DEFAULT_I18N_TEXT.ts
@@ -185,13 +185,6 @@ export const DEFAULT_I18N_TEXT = {
     ko: '복사됨',
     ru: 'Скопировано',
   },
-  promptCopyTitleText: {
-    en: 'Copy prompt',
-    zh: '复制 prompt',
-    ja: 'Prompt をコピー',
-    ko: '프롬프트 복사',
-    ru: 'Скопировать prompt',
-  },
   promptExpandText: {
     en: 'Expand',
     zh: '展开',

--- a/packages/core/src/theme/components/Prompt/index.scss
+++ b/packages/core/src/theme/components/Prompt/index.scss
@@ -13,11 +13,6 @@
   );
   transition: background 0.3s ease;
 
-  // &:hover {
-  // transform: translate(0, -1px);
-  // transition: transform 0.15s ease;
-  // }
-
   &:active {
     transform: scale(0.996);
     transition: transform 0.15s ease;
@@ -129,12 +124,6 @@
   gap: 0.5rem;
   padding: 0.25rem 0.5rem 0.25rem 0.625rem;
   border-radius: 999px;
-  // border: 1px solid
-  //   color-mix(
-  //     in srgb,
-  //     var(--rp-prompt-accent, var(--rp-c-brand-light)) 28%,
-  //     transparent
-  //   );
   background: color-mix(
     in srgb,
     var(--rp-prompt-accent, var(--rp-c-brand-light)) 12%,
@@ -256,13 +245,11 @@
   color: var(--rp-c-text-1);
   cursor: pointer;
   transition:
-    transform 0.15s ease,
     border-color 0.2s ease,
     background-color 0.2s ease,
     color 0.2s ease;
 
   &:hover {
-    transform: translateY(-1px);
     border-color: color-mix(
       in srgb,
       var(--rp-prompt-accent, var(--rp-c-brand-light)) 50%,
@@ -276,7 +263,7 @@
   }
 
   &:active {
-    transform: translateY(0) scale(0.97);
+    transform: none;
   }
 
   &:focus-visible {

--- a/packages/core/src/theme/components/Prompt/index.tsx
+++ b/packages/core/src/theme/components/Prompt/index.tsx
@@ -1,3 +1,4 @@
+import { useI18n } from '@rspress/core/runtime';
 import {
   copyToClipboard,
   IconArrowDown,
@@ -5,10 +6,9 @@ import {
   IconSuccess,
   renderInlineMarkdown,
   SvgWrapper,
-  useI18n,
 } from '@rspress/core/theme';
 import clsx from 'clsx';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { AGENT_ICONS } from './icons';
 import './index.scss';
 
@@ -125,12 +125,14 @@ function CopyablePrompt({
   defaultCollapsed = true,
   description,
   eyebrow = 'For your Agent',
+  onClick,
   prompt,
   style,
   title = 'Agent Prompt',
   ...props
 }: PromptProps) {
   const t = useI18n();
+  const contentId = useId();
   const [collapsed, setCollapsed] = useState(defaultCollapsed);
   const [copied, setCopied] = useState(false);
   const { fading, iconIndex } = useRotatingIcon();
@@ -172,14 +174,10 @@ function CopyablePrompt({
   }, [prompt]);
 
   const handleCardActivate = useCallback(
-    (
-      e: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>,
-    ) => {
-      if ('key' in e && e.key !== 'Enter' && e.key !== ' ') {
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      onClick?.(e);
+      if (e.defaultPrevented) {
         return;
-      }
-      if ('key' in e) {
-        e.preventDefault();
       }
 
       if (window.getSelection()?.toString()) {
@@ -201,21 +199,19 @@ function CopyablePrompt({
       }
 
       const id = Date.now() + Math.random();
-      if ('clientX' in e) {
-        setRipples(prev => [
-          ...prev,
-          { id, x: e.clientX - rect.left, y: e.clientY - rect.top },
-        ]);
-      }
+      setRipples(prev => [
+        ...prev,
+        { id, x: e.clientX - rect.left, y: e.clientY - rect.top },
+      ]);
       const timer = setTimeout(() => {
         setRipples(prev => prev.filter(r => r.id !== id));
         rippleTimersRef.current.delete(timer);
       }, 600);
       rippleTimersRef.current.add(timer);
 
-      handleCopy();
+      void handleCopy();
     },
-    [handleCopy],
+    [handleCopy, onClick],
   );
 
   return (
@@ -273,9 +269,9 @@ function CopyablePrompt({
                 )}
                 onClick={e => {
                   e.stopPropagation();
-                  handleCopy();
+                  void handleCopy();
                 }}
-                title={t('promptCopyTitleText')}
+                title={t('promptCopyText')}
               >
                 <SvgWrapper
                   icon={copied ? IconSuccess : IconCopy}
@@ -292,6 +288,7 @@ function CopyablePrompt({
                   e.stopPropagation();
                   setCollapsed(value => !value);
                 }}
+                aria-controls={contentId}
                 aria-expanded={!collapsed}
                 title={
                   collapsed ? t('promptExpandText') : t('promptCollapseText')
@@ -310,10 +307,12 @@ function CopyablePrompt({
         </div>
 
         <div
+          id={contentId}
           className={clsx(
             'rp-prompt__content',
             collapsed && 'rp-prompt__content--collapsed',
           )}
+          aria-hidden={collapsed}
         >
           <div className="rp-prompt__content-inner">
             <div

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -1,6 +1,5 @@
 // components
 
-export { useI18n } from '../runtime/hooks/useI18n';
 export { Badge, type BadgeProps } from './components/Badge/index';
 export { Banner, type BannerProps } from './components/Banner/index';
 export { Button, type ButtonProps } from './components/Button/index';

--- a/packages/core/src/theme/logic/getCopyableText.ts
+++ b/packages/core/src/theme/logic/getCopyableText.ts
@@ -40,6 +40,14 @@ export function getCopyableText(
       const currentBlock = getBlockElement(parentElement, element);
 
       if (
+        (node.previousSibling?.nodeName === 'BR' ||
+          parentElement.previousSibling?.nodeName === 'BR') &&
+        !text.endsWith('\n')
+      ) {
+        text += '\n';
+      }
+
+      if (
         currentBlock &&
         previousBlock &&
         currentBlock !== previousBlock &&
@@ -79,8 +87,9 @@ interface MarkdownState {
 }
 
 // This is a lightweight markdown adapter for DOM-based copy text extraction.
-// We currently only cover the minimum node types needed by Prompt copy.
-// If Prompt copy needs broader markdown fidelity in the future, replace this
+// We currently only cover the minimum node types needed by current callers
+// of getCopyableText, such as code block copy flows.
+// If those callers need broader markdown fidelity in the future, replace this
 // with a dedicated renderToMarkdownString-style conversion instead of growing
 // ad-hoc rules here indefinitely.
 function toMarkdown(node: Node, state: MarkdownState) {
@@ -94,10 +103,6 @@ function toMarkdown(node: Node, state: MarkdownState) {
   if (listItem && !state.seenNodes.has(listItem)) {
     state.seenNodes.add(listItem);
     return toMarkdownListItem(listItem);
-  }
-
-  if (element.tagName === 'BR') {
-    return '\n';
   }
 
   return '';

--- a/packages/shared/src/types/theme/i18nText.ts
+++ b/packages/shared/src/types/theme/i18nText.ts
@@ -48,7 +48,6 @@ export interface I18nText {
   // prompt
   promptCopyText?: I18nTextValue;
   promptCopiedText?: I18nTextValue;
-  promptCopyTitleText?: I18nTextValue;
   promptExpandText?: I18nTextValue;
   promptCollapseText?: I18nTextValue;
 }


### PR DESCRIPTION
## Summary

This PR cherry-picks follow-up fixes for the Prompt component after #3325: it keeps collapsed prompt content out of the accessibility tree, preserves consumer `onClick` handlers while retaining built-in copy behavior, removes the temporary theme re-export of `useI18n`, fixes copy text extraction around `<br>` nodes, and adds the missing changeset.

## Related Issue

Follow-up to https://github.com/web-infra-dev/rspress/pull/3325

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).