### PR TITLE
docs: update rspress package deprecation notice

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,7 +8,9 @@
 
 ## Deprecated in Rspress 2.0
 
-This package has been renamed to `@rspress/core` in V2. If you are using or plan to use Rspress V2, please install `@rspress/core` instead of this package.
+This package has been renamed to [`@rspress/core`](https://www.npmjs.com/package/@rspress/core) in Rspress V2. If you are using or plan to use Rspress v2, please install `@rspress/core` instead.
+
+To learn more about package name and import path changes, see the [Rspress 1.x migration guide](https://rspress.rs/guide/migration/rspress-1-x#important-package-name-and-import-path-changes).
 
 ## Getting started
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "rspress",
   "version": "1.47.1",
+  "description": "Deprecated Rspress v1 CLI. Use @rspress/core for Rspress v2.",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rspress",


### PR DESCRIPTION
## Summary

- Refine the `rspress` package deprecation notice in `packages/cli/README.md` to add links to `@rspress/core` on npm and the Rspress 1.x migration guide.
- Add a package `description` that points Rspress v2 users to `@rspress/core`.