### PR TITLE
fix(layout): Fixed mobile doc layout menu showing unnecessarily

### DIFF
--- a/packages/core/src/theme/layout/DocLayout/index.scss
+++ b/packages/core/src/theme/layout/DocLayout/index.scss
@@ -41,6 +41,11 @@
   }
 }
 
+// Don't push content down when the mobile menu isn't being rendered.
+:root:has(.rp-doc-layout__container--no-menu) {
+  --rp-sidebar-menu-height: 0px;
+}
+
 .rp-doc-layout {
   &__container {
     width: 100%; // mobile
@@ -51,13 +56,6 @@
     display: flex;
     justify-content: flex-start;
     flex-direction: row;
-
-    // When neither sidebar nor outline is shown, the menu wrapper is omitted
-    // from the DOM. Reset the height variable so descendant sidebar/outline
-    // margin top offsets dont compensate for space that no longer exists.
-    &--no-menu {
-      --rp-sidebar-menu-height: 0px;
-    }
   }
 
   &__doc {

--- a/packages/core/src/theme/layout/DocLayout/index.scss
+++ b/packages/core/src/theme/layout/DocLayout/index.scss
@@ -51,6 +51,13 @@
     display: flex;
     justify-content: flex-start;
     flex-direction: row;
+
+    // When neither sidebar nor outline is shown, the menu wrapper is omitted
+    // from the DOM. Reset the height variable so descendant sidebar/outline
+    // margin top offsets dont compensate for space that no longer exists.
+    &--no-menu {
+      --rp-sidebar-menu-height: 0px;
+    }
   }
 
   &__doc {

--- a/packages/core/src/theme/layout/DocLayout/index.tsx
+++ b/packages/core/src/theme/layout/DocLayout/index.tsx
@@ -55,6 +55,8 @@ export function DocLayout(props: DocLayoutProps) {
     pageType,
   } = frontmatter;
 
+  const showSidebarMenu = showSidebar || showOutline;
+
   if (process.env.__SSR_MD__) {
     return (
       <>
@@ -83,9 +85,16 @@ export function DocLayout(props: DocLayoutProps) {
 
   return (
     <>
-      <div className="rp-doc-layout__menu">{sidebarMenu}</div>
+      {showSidebarMenu && (
+        <div className="rp-doc-layout__menu">{sidebarMenu}</div>
+      )}
       {beforeDoc}
-      <div className="rp-doc-layout__container">
+      <div
+        className={clsx(
+          'rp-doc-layout__container',
+          !showSidebarMenu && 'rp-doc-layout__container--no-menu',
+        )}
+      >
         {/* Sidebar */}
         {showSidebar ? (
           <aside

--- a/packages/core/src/theme/layout/DocLayout/index.tsx
+++ b/packages/core/src/theme/layout/DocLayout/index.tsx
@@ -55,7 +55,7 @@ export function DocLayout(props: DocLayoutProps) {
     pageType,
   } = frontmatter;
 
-  const showSidebarMenu = showSidebar || showOutline;
+  const showSidebarMenu = showSidebar || (!isOverviewPage && showOutline);
 
   if (process.env.__SSR_MD__) {
     return (


### PR DESCRIPTION


## Summary

This bar to allow the user to navigate the table of contents or other pages is meant to show on mobile at the top of the screen. However if the current page has `outline: false` and `sidebar: false` then this navigation bar thats added on on mobile does nothing.

This just hides it when there is nothing to show.

I was able to fix this upstream in my own site by using this:

```scss
/* On pages with no sidebar or table of contents, AND we are on mobile. Just
 * hide this element so we don't do weird layout shifts */
.rp-doc-layout__menu:has(> .rp-sidebar-menu > .rp-sidebar-menu__left:empty + .rp-sidebar-menu__right:empty) {
  display: none;
}
```

But this was 100% a hack and I don't know if there is an elegant way to do this in an scss way only.

### Reproduction

You can reproduce this on main by applying this patch:

```diff
diff --git a/website/docs/en/blog/index.mdx b/website/docs/en/blog/index.mdx
index 82f18d5f..d31a6fad 100644
--- a/website/docs/en/blog/index.mdx
+++ b/website/docs/en/blog/index.mdx
@@ -1,6 +1,7 @@
 ---
 pageType: doc-wide
 sidebar: false
+outline: false
 ---
 
 # Rspress blogs
```

#### Bug

https://github.com/user-attachments/assets/74d945c9-21f5-4887-8c2d-53db18e863d1

#### Fix

https://github.com/user-attachments/assets/286ba7bc-71c5-4e57-b79a-eb5c00161a17

## Related Issue

N/A

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
