### PR TITLE
fix(ssg): experimentalWorker "Cannot find module '@rspress/core/dist/entry/worker.js'"

### DIFF
--- a/.changeset/quiet-pools-build.md
+++ b/.changeset/quiet-pools-build.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+Fix build failures when SSG experimental workers load Tinypool's worker bootstrap.

--- a/e2e/fixtures/ssg-worker/doc/index.mdx
+++ b/e2e/fixtures/ssg-worker/doc/index.mdx
@@ -1,0 +1,3 @@
+# SSG worker
+
+This page is rendered by the experimental SSG worker.

--- a/e2e/fixtures/ssg-worker/index.test.ts
+++ b/e2e/fixtures/ssg-worker/index.test.ts
@@ -1,0 +1,7 @@
+import { test } from '@playwright/test';
+import { runBuildCommand } from '../../utils/runCommands';
+
+test('build with experimental SSG worker', async () => {
+  const appDir = import.meta.dirname;
+  await runBuildCommand(appDir);
+});

--- a/e2e/fixtures/ssg-worker/package.json
+++ b/e2e/fixtures/ssg-worker/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@rspress-fixture/ssg-worker",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rspress build",
+    "dev": "rspress dev",
+    "preview": "rspress preview"
+  },
+  "dependencies": {
+    "@rspress/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.8.1"
+  }
+}

--- a/e2e/fixtures/ssg-worker/rspress.config.ts
+++ b/e2e/fixtures/ssg-worker/rspress.config.ts
@@ -1,0 +1,9 @@
+import * as path from 'node:path';
+import { defineConfig } from '@rspress/core';
+
+export default defineConfig({
+  root: path.join(import.meta.dirname, 'doc'),
+  ssg: {
+    experimentalWorker: true,
+  },
+});

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -15,7 +15,8 @@ const tinypoolDistPath = path.join(
 );
 const tinypoolRuntimeFiles = fs
   .readdirSync(tinypoolDistPath)
-  .filter(file => /^(common|utils)-.*\.js$/.test(file));
+  .filter(file => /^(common|utils)-.*\.js$/.test(file))
+  .sort();
 
 const COMMON_EXTERNALS = [
   'virtual-routes',

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { pluginReact } from '@rsbuild/plugin-react';
@@ -5,6 +7,15 @@ import { pluginSass } from '@rsbuild/plugin-sass';
 import { pluginSvgr } from '@rsbuild/plugin-svgr';
 import { defineConfig } from '@rslib/core';
 import { pluginPublint } from 'rsbuild-plugin-publint';
+
+const require = createRequire(import.meta.url);
+const tinypoolDistPath = path.join(
+  path.dirname(require.resolve('tinypool/package.json')),
+  'dist',
+);
+const tinypoolRuntimeFiles = fs
+  .readdirSync(tinypoolDistPath)
+  .filter(file => /^(common|utils)-.*\.js$/.test(file));
 
 const COMMON_EXTERNALS = [
   'virtual-routes',
@@ -53,6 +64,18 @@ export default defineConfig({
       output: {
         target: 'node',
         externals: COMMON_EXTERNALS,
+        copy: [
+          {
+            from: 'entry',
+            to: 'entry',
+            context: tinypoolDistPath,
+          },
+          ...tinypoolRuntimeFiles.map(file => ({
+            from: file,
+            to: file,
+            context: tinypoolDistPath,
+          })),
+        ],
       },
       tools: {
         rspack: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -876,6 +876,16 @@ importers:
         specifier: ^22.8.1
         version: 22.19.15
 
+  e2e/fixtures/ssg-worker:
+    dependencies:
+      '@rspress/core':
+        specifier: workspace:*
+        version: link:../../../packages/core
+    devDependencies:
+      '@types/node':
+        specifier: ^22.8.1
+        version: 22.19.15
+
   e2e/fixtures/tabs-component:
     dependencies:
       '@rspress/core':


### PR DESCRIPTION
## Summary

Fix SSG builds with `ssg.experimentalWorker` by copying Tinypool's worker bootstrap and runtime helper files into the `@rspress/core` dist output. Adds an e2e fixture that builds with experimental SSG workers to verify the Tinypool worker path resolves.

<img width="857" height="330" alt="image" src="https://github.com/user-attachments/assets/e36ba36f-893b-46e1-bdce-e3199a2aad91" />


## Related Issue

None

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).