### PR TITLE
feat(mdx/FileCodeblock): support file codeblock starts with / prefix

### DIFF
--- a/packages/core/src/node/mdx/options.ts
+++ b/packages/core/src/node/mdx/options.ts
@@ -75,7 +75,7 @@ export async function createMDXOptions(options: {
       cjkFriendlyEmphasis && remarkCjkFriendlyGfmStrikethrough,
       remarkToc,
       !isSsgMd && remarkContainerSyntax,
-      [remarkFileCodeBlock, { filepath, addDependency }],
+      [remarkFileCodeBlock, { filepath, docDirectory, addDependency }],
       [
         remarkLink,
         isSsgMd

--- a/packages/core/src/node/mdx/remarkPlugins/fileCodeBlock.test.ts
+++ b/packages/core/src/node/mdx/remarkPlugins/fileCodeBlock.test.ts
@@ -58,6 +58,31 @@ describe('remarkFileCodeBlock', () => {
     expect(result).toContain('Click me');
   });
 
+  it('should support absolute path with / prefix', async () => {
+    vol.fromJSON({
+      '/usr/rspress-project/docs/components/Button.tsx': `export const Button = () => {
+  return <button>Click me</button>;
+}
+`,
+    });
+    const result = await compile({
+      source: `
+\`\`\`tsx file="/components/Button.tsx"
+\`\`\`
+`,
+
+      docDirectory: '/usr/rspress-project/docs',
+      filepath: '/usr/rspress-project/docs/guide/components.mdx',
+      config: null,
+      pluginDriver: null,
+      routeService: null,
+    });
+    // The result should contain the transformed code with the Button component
+    expect(result).toContain('Button');
+    expect(result).toContain('button');
+    expect(result).toContain('Click me');
+  });
+
   it('should support nested absolute paths with <root>/ prefix', async () => {
     vol.fromJSON({
       '/usr/rspress-project/examples/code/demo.js': `const demo = 'test';

--- a/packages/core/src/node/mdx/remarkPlugins/fileCodeBlock.ts
+++ b/packages/core/src/node/mdx/remarkPlugins/fileCodeBlock.ts
@@ -29,11 +29,12 @@ export const remarkFileCodeBlock: Plugin<
   [
     {
       filepath: string;
+      docDirectory: string;
       addDependency?: Rspack.LoaderContext['addDependency'];
     },
   ],
   Root
-> = ({ filepath, addDependency }) => {
+> = ({ filepath, docDirectory, addDependency }) => {
   return async tree => {
     const promiseList: Promise<void>[] = [];
     visit(tree, 'code', node => {
@@ -46,10 +47,11 @@ export const remarkFileCodeBlock: Plugin<
 
       const originalMetaForErrorInfo = picocolors.cyan(`\`\`\`${lang} ${meta}`);
 
-      // Support relative paths and absolute paths with <root>/ prefix
+      // Support relative paths and absolute paths with / and <root>/ prefix
       if (
         file.startsWith('./') ||
         file.startsWith('../') ||
+        file.startsWith('/') ||
         file.startsWith('<root>/')
       ) {
         let resolvedFilePath: string;
@@ -57,6 +59,9 @@ export const remarkFileCodeBlock: Plugin<
         if (file.startsWith('<root>/')) {
           // Absolute path relative to project root directory
           resolvedFilePath = path.join(cwd(), file.slice('<root>/'.length));
+        } else if (file.startsWith('/')) {
+          // Absolute path relative to project root directory
+          resolvedFilePath = path.join(docDirectory, file.slice(1));
         } else {
           // Relative path to current file
           resolvedFilePath = path.join(path.dirname(filepath), file);
@@ -102,6 +107,11 @@ this usage is not allowed, please use below:
 Please use below:
 
 \`\`\`tsx file="./filename"
+\`\`\`
+
+or
+
+\`\`\`tsx file="/path/to/filename"
 \`\`\`
 
 or

--- a/packages/core/src/node/mdx/remarkPlugins/fileCodeBlock.ts
+++ b/packages/core/src/node/mdx/remarkPlugins/fileCodeBlock.ts
@@ -60,7 +60,7 @@ export const remarkFileCodeBlock: Plugin<
           // Absolute path relative to project root directory
           resolvedFilePath = path.join(cwd(), file.slice('<root>/'.length));
         } else if (file.startsWith('/')) {
-          // Absolute path relative to project root directory
+          // Absolute path relative to docs root directory
           resolvedFilePath = path.join(docDirectory, file.slice(1));
         } else {
           // Relative path to current file

--- a/packages/plugin-llms/src/normalizeMdFile.ts
+++ b/packages/plugin-llms/src/normalizeMdFile.ts
@@ -41,6 +41,7 @@ const mdxToMdPlugin: Plugin<[], Root> = () => {
 function noopPlugin() {}
 
 async function normalizeMdFile(
+  docDirectory: string,
   content: string,
   filepath: string,
   routeService: RouteService,
@@ -54,6 +55,7 @@ async function normalizeMdFile(
     .use(isMd ? noopPlugin : remarkMdx)
     .use(remarkFileCodeBlock, {
       filepath,
+      docDirectory,
     })
     .use(!isMd && mdxToMd ? mdxToMdPlugin : noopPlugin)
     .use(remarkLink, {

--- a/packages/plugin-llms/src/plugin.ts
+++ b/packages/plugin-llms/src/plugin.ts
@@ -51,6 +51,7 @@ function resolveNavForVersion(
 }
 
 const rsbuildPluginLlms = ({
+  docDirectory,
   disableSSGRef,
   baseRef,
   pageDataList,
@@ -107,6 +108,7 @@ const rsbuildPluginLlms = ({
           let mdContent: string | Buffer;
           try {
             mdContent = await normalizeMdFile(
+              docDirectory,
               content,
               filepath,
               routeServiceRef.current!,
@@ -425,10 +427,13 @@ export function pluginLlms(options?: RspressPluginLlmsOptions): RspressPlugin {
         config.builderConfig.plugins = [];
       }
 
+      const docDirectory = config.root!;
+
       config.builderConfig.plugins.push(
         ...(Array.isArray(mergedOptions)
           ? mergedOptions.map((item, index) => {
               return rsbuildPluginLlms({
+                docDirectory,
                 pageDataList,
                 routes,
                 titleRef,
@@ -447,6 +452,7 @@ export function pluginLlms(options?: RspressPluginLlmsOptions): RspressPlugin {
             })
           : [
               rsbuildPluginLlms({
+                docDirectory,
                 pageDataList,
                 routes,
                 titleRef,

--- a/packages/plugin-llms/src/types.ts
+++ b/packages/plugin-llms/src/types.ts
@@ -69,6 +69,7 @@ export interface Options {
 export type RspressPluginLlmsOptions = Options | Options[];
 
 export interface rsbuildPluginLlmsOptions {
+  docDirectory: string;
   disableSSGRef: { current: boolean };
   titleRef: { current: string | undefined };
   descriptionRef: { current: string | undefined };

--- a/website/docs/en/guide/use-mdx/code-blocks.mdx
+++ b/website/docs/en/guide/use-mdx/code-blocks.mdx
@@ -79,6 +79,18 @@ It will be rendered as:
 
 ```
 
+### Absolute paths with `/` prefix
+
+Use the `/` prefix to reference files using absolute paths relative to the docs directory. This is useful when you need to reference shared code files from different locations in your documentation:
+
+````mdx
+```tsx file="/components/Button.tsx"
+
+```
+````
+
+For example, if your docs directory is `/project/docs`, then `/components/Button.tsx` will resolve to `/project/docs/components/Button.tsx`.
+
 ### Absolute paths with `<root>/` prefix
 
 Use the `<root>/` prefix to reference files using absolute paths relative to the project root directory. This is useful when you need to reference shared code files from different locations in your documentation:

--- a/website/docs/zh/guide/use-mdx/code-blocks.mdx
+++ b/website/docs/zh/guide/use-mdx/code-blocks.mdx
@@ -79,6 +79,18 @@ const HelloCodeBlockTitle = (props) => {
 
 ```
 
+### 使用 `/` 前缀的绝对路径
+
+使用 `/` 前缀来引用相对于 docs 目录的绝对路径文件。当你需要从文档的不同位置引用共享的代码文件时，这非常有用：
+
+````mdx
+```tsx file="/components/Button.tsx"
+
+```
+````
+
+例如，如果你的 docs 目录是 `/project/docs`，那么 `/components/Button.tsx` 将解析为 `/project/docs/components/Button.tsx`。
+
 ### 使用 `<root>/` 前缀的绝对路径
 
 使用 `<root>/` 前缀来引用相对于项目根目录的绝对路径文件。当你需要从文档的不同位置引用共享的代码文件时，这非常有用：


### PR DESCRIPTION
## Summary

support file codeblock starts with `/` prefix

## Related Issue

<!--- Provide link of related issues -->

close #3336

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
