### PR TITLE
chore(rslib): clean up config and align ES target

### DIFF
--- a/e2e/fixtures/auto-nav-sidebar-dir-convention/tsconfig.json
+++ b/e2e/fixtures/auto-nav-sidebar-dir-convention/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/auto-nav-sidebar-issue-1682/tsconfig.json
+++ b/e2e/fixtures/auto-nav-sidebar-issue-1682/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/auto-nav-sidebar-no-meta/tsconfig.json
+++ b/e2e/fixtures/auto-nav-sidebar-no-meta/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/auto-nav-sidebar/tsconfig.json
+++ b/e2e/fixtures/auto-nav-sidebar/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/banner/tsconfig.json
+++ b/e2e/fixtures/banner/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/basic/tsconfig.json
+++ b/e2e/fixtures/basic/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/check-dead-link/tsconfig.json
+++ b/e2e/fixtures/check-dead-link/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/client-redirects/tsconfig.json
+++ b/e2e/fixtures/client-redirects/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/code-block-runtime/tsconfig.json
+++ b/e2e/fixtures/code-block-runtime/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/custom-headers/tsconfig.json
+++ b/e2e/fixtures/custom-headers/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/custom-home-footer/tsconfig.json
+++ b/e2e/fixtures/custom-home-footer/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/custom-layout/tsconfig.json
+++ b/e2e/fixtures/custom-layout/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/github-alert-mdxjs/tsconfig.json
+++ b/e2e/fixtures/github-alert-mdxjs/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/heading-title/tsconfig.json
+++ b/e2e/fixtures/heading-title/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/hmr/tsconfig.json
+++ b/e2e/fixtures/hmr/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/i18n-source-text/tsconfig.json
+++ b/e2e/fixtures/i18n-source-text/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/i18n/tsconfig.json
+++ b/e2e/fixtures/i18n/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/inline-markdown/tsconfig.json
+++ b/e2e/fixtures/inline-markdown/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/issue-1309/tsconfig.json
+++ b/e2e/fixtures/issue-1309/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/markdown-link-asset/tsconfig.json
+++ b/e2e/fixtures/markdown-link-asset/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/markdown-link/tsconfig.json
+++ b/e2e/fixtures/markdown-link/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/multi-version/tsconfig.json
+++ b/e2e/fixtures/multi-version/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/nav-link-item-with-hash/tsconfig.json
+++ b/e2e/fixtures/nav-link-item-with-hash/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/nav-link-items/tsconfig.json
+++ b/e2e/fixtures/nav-link-items/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/nav-link/tsconfig.json
+++ b/e2e/fixtures/nav-link/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/nested-overview/tsconfig.json
+++ b/e2e/fixtures/nested-overview/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/no-config-root/tsconfig.json
+++ b/e2e/fixtures/no-config-root/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/page-type-home/tsconfig.json
+++ b/e2e/fixtures/page-type-home/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/plugin-api-docgen/locales/tsconfig.json
+++ b/e2e/fixtures/plugin-api-docgen/locales/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2020"],
+    "lib": ["DOM", "ES2023"],
     "jsx": "react-jsx",
-    "target": "ES2020",
+    "target": "ES2023",
     "noEmit": true,
     "skipLibCheck": true,
     "useDefineForClassFields": true,

--- a/e2e/fixtures/plugin-api-docgen/single/tsconfig.json
+++ b/e2e/fixtures/plugin-api-docgen/single/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2020"],
+    "lib": ["DOM", "ES2023"],
     "jsx": "react-jsx",
-    "target": "ES2020",
+    "target": "ES2023",
     "noEmit": true,
     "skipLibCheck": true,
     "useDefineForClassFields": true,

--- a/e2e/fixtures/plugin-typedoc/multi/tsconfig.json
+++ b/e2e/fixtures/plugin-typedoc/multi/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/plugin-typedoc/single/tsconfig.json
+++ b/e2e/fixtures/plugin-typedoc/single/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/production/tsconfig.json
+++ b/e2e/fixtures/production/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/public-dir/tsconfig.json
+++ b/e2e/fixtures/public-dir/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/react-18/tsconfig.json
+++ b/e2e/fixtures/react-18/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/react-19/tsconfig.json
+++ b/e2e/fixtures/react-19/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/react-router-dom-6/tsconfig.json
+++ b/e2e/fixtures/react-router-dom-6/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/replace-rules/tsconfig.json
+++ b/e2e/fixtures/replace-rules/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/search-code-blocks/tsconfig.json
+++ b/e2e/fixtures/search-code-blocks/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/ssg-fail-strict/tsconfig.json
+++ b/e2e/fixtures/ssg-fail-strict/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/ssg-md/tsconfig.json
+++ b/e2e/fixtures/ssg-md/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/ssg-missing-public/tsconfig.json
+++ b/e2e/fixtures/ssg-missing-public/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/tailwind-v4/tsconfig.json
+++ b/e2e/fixtures/tailwind-v4/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/theme-css/tsconfig.json
+++ b/e2e/fixtures/theme-css/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/title-number/tsconfig.json
+++ b/e2e/fixtures/title-number/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/title-suffix/tsconfig.json
+++ b/e2e/fixtures/title-suffix/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/e2e/fixtures/with-base/tsconfig.json
+++ b/e2e/fixtures/with-base/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -56,14 +56,11 @@ export default defineConfig({
         },
       },
       dts: false,
-      experiments: {
-        advancedEsm: true,
-      },
+      syntax: 'es2023',
       performance: {
         buildCache: false,
       },
       output: {
-        target: 'node',
         externals: COMMON_EXTERNALS,
         copy: [
           {
@@ -95,7 +92,6 @@ export default defineConfig({
     {
       bundle: false,
       dts: false,
-      format: 'esm',
       syntax: 'es2022',
       source: {
         entry: {
@@ -114,7 +110,6 @@ export default defineConfig({
       plugins: [pluginReact()],
     },
     {
-      format: 'esm',
       bundle: false,
       dts: true,
       redirect: {

--- a/packages/create-rspress/rslib.config.ts
+++ b/packages/create-rspress/rslib.config.ts
@@ -5,11 +5,7 @@ export default defineConfig({
   plugins: [pluginPublint()],
   lib: [
     {
-      format: 'esm',
-      syntax: 'es2021',
-      experiments: {
-        advancedEsm: true,
-      },
+      syntax: 'es2023',
     },
   ],
 });

--- a/packages/create-rspress/template-common/tsconfig.json
+++ b/packages/create-rspress/template-common/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2020"],
+    "lib": ["DOM", "ES2023"],
     "jsx": "react-jsx",
-    "target": "ES2020",
+    "target": "ES2023",
     "noEmit": true,
     "skipLibCheck": true,
     "useDefineForClassFields": true,

--- a/packages/plugin-algolia/rslib.config.ts
+++ b/packages/plugin-algolia/rslib.config.ts
@@ -12,11 +12,7 @@ export default defineConfig({
         },
       },
       dts: true,
-      format: 'esm',
-      experiments: {
-        advancedEsm: true,
-      },
-      syntax: 'esnext',
+      syntax: 'es2023',
       redirect: {
         dts: {
           extension: true,
@@ -31,7 +27,6 @@ export default defineConfig({
       },
       outBase: './src',
       bundle: false,
-      format: 'esm',
       syntax: 'esnext',
       plugins: [pluginReact()],
       output: {

--- a/packages/plugin-api-docgen/rslib.config.ts
+++ b/packages/plugin-api-docgen/rslib.config.ts
@@ -8,11 +8,7 @@ export default defineConfig({
       dts: {
         bundle: true,
       },
-      format: 'esm',
-      experiments: {
-        advancedEsm: true,
-      },
-      syntax: 'es2022',
+      syntax: 'es2023',
     },
   ],
 });

--- a/packages/plugin-client-redirects/rslib.config.ts
+++ b/packages/plugin-client-redirects/rslib.config.ts
@@ -8,11 +8,7 @@ export default defineConfig({
       dts: {
         bundle: true,
       },
-      format: 'esm',
-      experiments: {
-        advancedEsm: true,
-      },
-      syntax: 'esnext',
+      syntax: 'es2023',
       shims: {
         esm: {
           __dirname: true,

--- a/packages/plugin-llms/rslib.config.ts
+++ b/packages/plugin-llms/rslib.config.ts
@@ -15,10 +15,6 @@ export default defineConfig({
         },
       },
       bundle: true,
-      format: 'esm',
-      experiments: {
-        advancedEsm: true,
-      },
       plugins: [pluginReact()],
       output: {
         externals: [
@@ -41,11 +37,7 @@ export default defineConfig({
           index: './src/index.ts',
         },
       },
-      format: 'esm',
-      experiments: {
-        advancedEsm: true,
-      },
-      syntax: 'esnext',
+      syntax: 'es2023',
     },
   ],
 });

--- a/packages/plugin-playground/rslib.config.ts
+++ b/packages/plugin-playground/rslib.config.ts
@@ -6,10 +6,6 @@ export default defineConfig({
   plugins: [pluginPublint()],
   lib: [
     {
-      format: 'esm',
-      experiments: {
-        advancedEsm: true,
-      },
       source: {
         entry: { index: 'src/cli/index.ts' },
       },
@@ -24,14 +20,10 @@ export default defineConfig({
         },
         externals: ['@types/react', 'rspress'],
       },
-      syntax: 'es2022',
+      syntax: 'es2023',
       dts: { bundle: true },
     },
     {
-      format: 'esm',
-      experiments: {
-        advancedEsm: true,
-      },
       source: {
         entry: { index: 'src/web/index.ts' },
       },
@@ -42,7 +34,7 @@ export default defineConfig({
           root: 'dist/web',
         },
       },
-      syntax: 'es2022',
+      syntax: 'es2023',
       dts: { bundle: true },
     },
   ],

--- a/packages/plugin-preview/rslib.config.ts
+++ b/packages/plugin-preview/rslib.config.ts
@@ -5,31 +5,23 @@ export default defineConfig({
   plugins: [pluginPublint()],
   lib: [
     {
-      format: 'esm',
-      experiments: {
-        advancedEsm: true,
-      },
       source: {
         entry: {
           index: 'src/index.ts',
         },
       },
-      syntax: 'es2022',
+      syntax: 'es2023',
       dts: {
         bundle: true,
       },
     },
     {
-      format: 'esm',
-      experiments: {
-        advancedEsm: true,
-      },
       source: {
         entry: {
           utils: 'src/utils.ts',
         },
       },
-      syntax: 'es2022',
+      syntax: 'es2023',
       dts: {
         bundle: true,
       },

--- a/packages/plugin-rss/rslib.config.ts
+++ b/packages/plugin-rss/rslib.config.ts
@@ -6,11 +6,7 @@ export default defineConfig({
   lib: [
     {
       bundle: true,
-      syntax: 'es2022',
-      format: 'esm',
-      experiments: {
-        advancedEsm: true,
-      },
+      syntax: 'es2023',
       dts: {
         bundle: true,
       },

--- a/packages/plugin-rss/tsconfig.tools.json
+++ b/packages/plugin-rss/tsconfig.tools.json
@@ -5,7 +5,7 @@
     "declaration": true,
     "noEmit": false,
     "module": "ESNext",
-    "target": "ES2020",
+    "target": "ES2023",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "moduleResolution": "bundler"

--- a/packages/plugin-sitemap/rslib.config.ts
+++ b/packages/plugin-sitemap/rslib.config.ts
@@ -6,11 +6,7 @@ export default defineConfig({
   lib: [
     {
       bundle: true,
-      syntax: 'es2022',
-      format: 'esm',
-      experiments: {
-        advancedEsm: true,
-      },
+      syntax: 'es2023',
       dts: {
         bundle: true,
       },

--- a/packages/plugin-twoslash/rslib.config.ts
+++ b/packages/plugin-twoslash/rslib.config.ts
@@ -8,11 +8,7 @@ export default defineConfig({
       dts: {
         bundle: true,
       },
-      format: 'esm',
-      experiments: {
-        advancedEsm: true,
-      },
-      syntax: 'esnext',
+      syntax: 'es2023',
       shims: {
         esm: {
           __dirname: true,

--- a/packages/plugin-typedoc/package.json
+++ b/packages/plugin-typedoc/package.json
@@ -9,21 +9,14 @@
     "directory": "packages/plugin-typedoc"
   },
   "license": "MIT",
-  "sideEffects": [
-    "*.css",
-    "*.less",
-    "*.sass",
-    "*.scss"
-  ],
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/types/index.d.ts",
-      "import": "./dist/es/index.js"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],

--- a/packages/plugin-typedoc/rslib.config.ts
+++ b/packages/plugin-typedoc/rslib.config.ts
@@ -7,18 +7,8 @@ export default defineConfig({
     {
       dts: {
         bundle: true,
-        distPath: './dist/types',
       },
-      format: 'esm',
-      experiments: {
-        advancedEsm: true,
-      },
-      syntax: 'es2015',
-      output: {
-        distPath: {
-          root: './dist/es',
-        },
-      },
+      syntax: 'es2023',
     },
   ],
 });

--- a/packages/shared/rslib.config.ts
+++ b/packages/shared/rslib.config.ts
@@ -7,11 +7,7 @@ export default defineConfig({
       dts: {
         bundle: true,
       },
-      format: 'esm',
-      experiments: {
-        advancedEsm: true,
-      },
-      syntax: 'esnext',
+      syntax: 'es2023',
     },
   ],
   source: {

--- a/website/docs/en/guide/start/getting-started.mdx
+++ b/website/docs/en/guide/start/getting-started.mdx
@@ -90,9 +90,9 @@ And then create `tsconfig.json`, add the following config:
 ```json
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2020"],
+    "lib": ["DOM", "ES2023"],
     "jsx": "react-jsx",
-    "target": "ES2020",
+    "target": "ES2023",
     "noEmit": true,
     "skipLibCheck": true,
     "useDefineForClassFields": true,

--- a/website/docs/zh/guide/start/getting-started.mdx
+++ b/website/docs/zh/guide/start/getting-started.mdx
@@ -91,9 +91,9 @@ export default defineConfig({
 ```json
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2020"],
+    "lib": ["DOM", "ES2023"],
     "jsx": "react-jsx",
-    "target": "ES2020",
+    "target": "ES2023",
     "noEmit": true,
     "skipLibCheck": true,
     "useDefineForClassFields": true,


### PR DESCRIPTION
## Summary

This PR cleans up Rslib configs by relying on default ESM output settings and removing the advanced ESM experiment flag.

It also aligns TypeScript targets and docs examples with the current Node 20 engine by moving TS configs and node-targeted Rslib syntax to ES2023.
