### PR TITLE
feat(theme): add BrowserOnly runtime component for sideEffects import and deprecate NoSSR

### DIFF
--- a/e2e/fixtures/with-base/doc/en/_BrowserOnlyDemo.tsx
+++ b/e2e/fixtures/with-base/doc/en/_BrowserOnlyDemo.tsx
@@ -1,0 +1,47 @@
+import { BrowserOnly } from '@rspress/core/runtime';
+import { useState } from 'react';
+
+export function BrowserOnlySyncDemo() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div>
+      <button
+        id="browser-only-sync-increment"
+        onClick={() => setCount(count + 1)}
+      >
+        Increment
+      </button>
+      <BrowserOnly
+        fallback={<span id="browser-only-sync-fallback">Sync fallback</span>}
+      >
+        {() => <span id="browser-only-sync-content">Sync {count}</span>}
+      </BrowserOnly>
+    </div>
+  );
+}
+
+export function BrowserOnlyAsyncDemo() {
+  const [value, setValue] = useState('initial');
+
+  return (
+    <div>
+      <button
+        id="browser-only-async-update"
+        onClick={() => setValue('updated')}
+      >
+        Update
+      </button>
+      <BrowserOnly
+        fallback={
+          <span id="browser-only-async-fallback">Async fallback {value}</span>
+        }
+      >
+        {async () => {
+          await new Promise(resolve => setTimeout(resolve, 500));
+          return <span id="browser-only-async-content">Async {value}</span>;
+        }}
+      </BrowserOnly>
+    </div>
+  );
+}

--- a/e2e/fixtures/with-base/doc/en/index.mdx
+++ b/e2e/fixtures/with-base/doc/en/index.mdx
@@ -3,7 +3,14 @@
 [click](/guide/quick-start) to go to guide
 
 import { NoSSR } from '@rspress/core/runtime';
+import { BrowserOnlyAsyncDemo, BrowserOnlySyncDemo } from './_BrowserOnlyDemo';
 
 <NoSSR>
   <div id="NoSSR">This is the index page</div>
 </NoSSR>
+
+## BrowserOnly
+
+<BrowserOnlySyncDemo />
+
+<BrowserOnlyAsyncDemo />

--- a/e2e/fixtures/with-base/index.test.ts
+++ b/e2e/fixtures/with-base/index.test.ts
@@ -57,4 +57,36 @@ test.describe('plugin test', async () => {
     const docContent = page.locator('.rspress-doc');
     await expect(docContent).toContainText('This is the index page');
   });
+
+  test('BrowserOnly should render fallback and update client content', async ({
+    page,
+  }) => {
+    await page.goto(`http://localhost:${appPort}/base/en/`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    await expect(page.locator('#browser-only-async-fallback')).toHaveText(
+      'Async fallback initial',
+    );
+    await expect(page.locator('#browser-only-sync-content')).toHaveText(
+      'Sync 0',
+    );
+
+    await page.locator('#browser-only-sync-increment').click();
+    await expect(page.locator('#browser-only-sync-content')).toHaveText(
+      'Sync 1',
+    );
+
+    await expect(page.locator('#browser-only-async-content')).toHaveText(
+      'Async initial',
+    );
+
+    await page.locator('#browser-only-async-update').click();
+    await expect(page.locator('#browser-only-async-fallback')).toHaveText(
+      'Async fallback updated',
+    );
+    await expect(page.locator('#browser-only-async-content')).toHaveText(
+      'Async updated',
+    );
+  });
 });

--- a/e2e/fixtures/with-base/package.json
+++ b/e2e/fixtures/with-base/package.json
@@ -8,8 +8,12 @@
     "dev": "rspress dev",
     "preview": "rspress preview"
   },
+  "dependencies": {
+    "react": "^19.2.5"
+  },
   "devDependencies": {
     "@rspress/core": "workspace:*",
-    "@types/node": "^22.8.1"
+    "@types/node": "^22.8.1",
+    "@types/react": "^19.2.14"
   }
 }

--- a/packages/core/src/runtime/BrowserOnly.test.tsx
+++ b/packages/core/src/runtime/BrowserOnly.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from '@rstest/core';
+import { createElement } from 'react';
+import { renderToString } from 'react-dom/server';
+import { BrowserOnly, type BrowserOnlyProps } from './BrowserOnly';
+import { NoSSR } from './NoSSR';
+
+describe('BrowserOnly', () => {
+  it('renders fallback during SSR', () => {
+    const browserOnlyProps: BrowserOnlyProps = {
+      fallback: createElement('div', null, 'Loading...'),
+      children: () => createElement('div', null, 'Browser content'),
+    };
+
+    const html = renderToString(createElement(BrowserOnly, browserOnlyProps));
+
+    expect(html).toBe('<div>Loading...</div>');
+  });
+
+  it('does not call children during SSR', () => {
+    let called = false;
+    const browserOnlyProps: BrowserOnlyProps = {
+      children: () => {
+        called = true;
+        return createElement('div', null, 'Browser content');
+      },
+    };
+
+    renderToString(createElement(BrowserOnly, browserOnlyProps));
+
+    expect(called).toBe(false);
+  });
+
+  it('keeps NoSSR empty during SSR', () => {
+    const html = renderToString(
+      createElement(NoSSR, null, createElement('div', null, 'Browser content')),
+    );
+
+    expect(html).toBe('');
+  });
+});

--- a/packages/core/src/runtime/BrowserOnly.tsx
+++ b/packages/core/src/runtime/BrowserOnly.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export interface BrowserOnlyProps {
   children: () => ReactNode | Promise<ReactNode>;
@@ -9,39 +9,42 @@ export interface BrowserOnlyProps {
 type BrowserOnlyState =
   | {
       status: 'pending';
+      children: BrowserOnlyProps['children'];
     }
   | {
       status: 'resolved';
+      children: BrowserOnlyProps['children'];
       content: ReactNode;
     }
   | {
       status: 'rejected';
+      children: BrowserOnlyProps['children'];
       error: unknown;
     };
 
 export function BrowserOnly(props: BrowserOnlyProps) {
   const { children, fallback = null } = props;
-  const childrenRef = useRef(children);
   const [state, setState] = useState<BrowserOnlyState>({
     status: 'pending',
+    children,
   });
-
-  childrenRef.current = children;
 
   useEffect(() => {
     let isMounted = true;
 
+    setState({ status: 'pending', children });
+
     Promise.resolve()
-      .then(() => childrenRef.current())
+      .then(() => children())
       .then(
         content => {
           if (isMounted) {
-            setState({ status: 'resolved', content });
+            setState({ status: 'resolved', children, content });
           }
         },
         error => {
           if (isMounted) {
-            setState({ status: 'rejected', error });
+            setState({ status: 'rejected', children, error });
           }
         },
       );
@@ -49,7 +52,11 @@ export function BrowserOnly(props: BrowserOnlyProps) {
     return () => {
       isMounted = false;
     };
-  }, []);
+  }, [children]);
+
+  if (state.children !== children) {
+    return fallback;
+  }
 
   if (state.status === 'rejected') {
     throw state.error;

--- a/packages/core/src/runtime/BrowserOnly.tsx
+++ b/packages/core/src/runtime/BrowserOnly.tsx
@@ -1,0 +1,65 @@
+import type { ReactNode } from 'react';
+import { useEffect, useRef, useState } from 'react';
+
+export interface BrowserOnlyProps {
+  children: () => ReactNode | Promise<ReactNode>;
+  fallback?: ReactNode;
+}
+
+type BrowserOnlyState =
+  | {
+      status: 'pending';
+    }
+  | {
+      status: 'resolved';
+      content: ReactNode;
+    }
+  | {
+      status: 'rejected';
+      error: unknown;
+    };
+
+export function BrowserOnly(props: BrowserOnlyProps) {
+  const { children, fallback = null } = props;
+  const childrenRef = useRef(children);
+  const [state, setState] = useState<BrowserOnlyState>({
+    status: 'pending',
+  });
+
+  childrenRef.current = children;
+
+  useEffect(() => {
+    let isMounted = true;
+
+    Promise.resolve()
+      .then(() => childrenRef.current())
+      .then(
+        content => {
+          if (isMounted) {
+            setState({ status: 'resolved', content });
+          }
+        },
+        error => {
+          if (isMounted) {
+            setState({ status: 'rejected', error });
+          }
+        },
+      );
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  if (state.status === 'rejected') {
+    throw state.error;
+  }
+
+  if (state.status === 'resolved') {
+    return state.content;
+  }
+
+  return fallback;
+}
+
+export default BrowserOnly;

--- a/packages/core/src/runtime/NoSSR.tsx
+++ b/packages/core/src/runtime/NoSSR.tsx
@@ -1,12 +1,16 @@
-import type { ReactNode } from 'react';
-import { createElement } from 'react';
-import { BrowserOnly, type BrowserOnlyProps } from './BrowserOnly';
+import { useEffect, useState } from 'react';
 
-export function NoSSR(props: { children: ReactNode }) {
+export function NoSSR(props: { children: React.ReactNode }) {
   const { children } = props;
-  const browserOnlyProps: BrowserOnlyProps = {
-    children: () => children,
-  };
+  const [isMounted, setIsMounted] = useState(false);
 
-  return createElement(BrowserOnly, browserOnlyProps);
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  if (!isMounted) {
+    return null;
+  }
+
+  return <>{children}</>;
 }

--- a/packages/core/src/runtime/NoSSR.tsx
+++ b/packages/core/src/runtime/NoSSR.tsx
@@ -1,16 +1,12 @@
-import { useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+import { BrowserOnly, type BrowserOnlyProps } from './BrowserOnly';
 
-export function NoSSR(props: { children: React.ReactNode }) {
+export function NoSSR(props: { children: ReactNode }) {
   const { children } = props;
-  const [isMounted, setIsMounted] = useState(false);
+  const browserOnlyProps: BrowserOnlyProps = {
+    children: () => children,
+  };
 
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
-
-  if (!isMounted) {
-    return null;
-  }
-
-  return <>{children}</>;
+  return createElement(BrowserOnly, browserOnlyProps);
 }

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -7,6 +7,7 @@ export {
 } from '@rspress/shared';
 export { Head, useHead } from '@unhead/react';
 export * from 'react-router-dom';
+export { BrowserOnly, type BrowserOnlyProps } from './BrowserOnly';
 export { Content } from './Content';
 export { useActiveMatcher } from './hooks/useActiveMatcher';
 export { ThemeContext, useDark } from './hooks/useDark';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -952,6 +952,10 @@ importers:
         version: 22.19.15
 
   e2e/fixtures/with-base:
+    dependencies:
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
     devDependencies:
       '@rspress/core':
         specifier: workspace:*
@@ -959,6 +963,9 @@ importers:
       '@types/node':
         specifier: ^22.8.1
         version: 22.19.15
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
 
   packages/core:
     dependencies:

--- a/website/docs/en/guide/basic/ssg.mdx
+++ b/website/docs/en/guide/basic/ssg.mdx
@@ -138,7 +138,27 @@ The core difference between the two modes lies in the HTML file content:
 
 **Solutions**:
 
-1. **Use `useEffect` for delayed execution**: Place browser API calls inside `useEffect` to ensure they only run on the client
+1. **Use `BrowserOnly` for browser-only rendering**: Wrap code that cannot run during SSG in a function, and optionally provide a fallback for SSG and loading states.
+
+   ```tsx
+   import { BrowserOnly } from '@rspress/core/runtime';
+
+   function MyComponent(props) {
+     return (
+       <BrowserOnly fallback={<div>Loading...</div>}>
+         {async () => {
+           const { LibComponent } =
+             await import('some-lib-that-accesses-window');
+           return <LibComponent {...props} />;
+         }}
+       </BrowserOnly>
+     );
+   }
+   ```
+
+   The children must be a function, not JSX. Otherwise, expressions like `window.location.href` are still evaluated while React builds the SSG render tree.
+
+2. **Use `useEffect` for delayed execution**: Place browser API calls inside `useEffect` to ensure they only run on the client
 
    ```tsx
    import { useEffect, useState } from 'react';
@@ -155,7 +175,7 @@ The core difference between the two modes lies in the HTML file content:
    }
    ```
 
-2. **Conditional check**: Check the environment before accessing browser APIs
+3. **Conditional check**: Check the environment before accessing browser APIs
 
    ```tsx
    if (typeof window !== 'undefined') {
@@ -164,7 +184,7 @@ The core difference between the two modes lies in the HTML file content:
    }
    ```
 
-3. **Dynamic import**: For third-party libraries that depend on browser APIs, use dynamic imports
+4. **Dynamic import in `useEffect`**: For third-party libraries that depend on browser APIs, use dynamic imports in `useEffect`
 
    ```tsx
    import { useEffect, useState } from 'react';

--- a/website/docs/en/guide/basic/ssg.mdx
+++ b/website/docs/en/guide/basic/ssg.mdx
@@ -138,7 +138,7 @@ The core difference between the two modes lies in the HTML file content:
 
 **Solutions**:
 
-1. **Use `BrowserOnly` for browser-only rendering**: Wrap code that cannot run during SSG in a function, and optionally provide a fallback for SSG and loading states.
+1. **Use [`BrowserOnly`](/ui/runtime-components/browser-only) for browser-only rendering**: Wrap code that cannot run during SSG in a function.
 
    ```tsx
    import { BrowserOnly } from '@rspress/core/runtime';

--- a/website/docs/en/ui/runtime-components/browser-only.mdx
+++ b/website/docs/en/ui/runtime-components/browser-only.mdx
@@ -1,0 +1,48 @@
+---
+description: BrowserOnly component for rendering content only in the browser after hydration.
+overviewHeaders: []
+---
+
+# BrowserOnly
+
+`BrowserOnly` renders its fallback during SSG and renders its children only in the browser after hydration.
+
+Use it when a component or third-party library depends on browser-only APIs such as `window`, `document`, or `localStorage`.
+
+## Usage
+
+```tsx title="index.mdx"
+import { BrowserOnly } from '@rspress/core/runtime';
+
+function MyComponent(props) {
+  return (
+    <BrowserOnly fallback={<div>Loading...</div>}>
+      {async () => {
+        const { LibComponent } = await import('some-lib-that-accesses-window');
+        return <LibComponent {...props} />;
+      }}
+    </BrowserOnly>
+  );
+}
+```
+
+The `children` of `BrowserOnly` must be a function that returns a React node. It can also be an async function that returns a React node.
+
+Do not pass browser-only JSX directly:
+
+```tsx
+import { BrowserOnly } from '@rspress/core/runtime';
+
+<BrowserOnly>
+  {/* This still evaluates window during SSG */}
+  <span>Current URL: {window.location.href}</span>
+</BrowserOnly>;
+```
+
+During SSG, React still evaluates the JSX tree before `BrowserOnly` can decide what to render. Passing a function delays access to browser-only APIs until the component is mounted in the browser.
+
+## Difference from NoSSR
+
+`NoSSR` is a simple wrapper that skips rendering its children during SSG and renders them after hydration.
+
+`BrowserOnly` is more suitable when the code itself cannot be evaluated during SSG, especially when you need to dynamically import a browser-only dependency.

--- a/website/docs/en/ui/runtime-components/browser-only.mdx
+++ b/website/docs/en/ui/runtime-components/browser-only.mdx
@@ -48,4 +48,8 @@ import { BrowserOnly } from '@rspress/core/runtime';
 ;
 ```
 
-You might expect `BrowserOnly` to hide its children during SSG, but in fact it cannot. When the React renderer tries to render this JSX tree, it evaluates the `{window.location.href}` expression as a node of the tree before `BrowserOnly` can decide what to render. Using a function ensures that the renderer only evaluates the browser-only code when the component is mounted in the browser.
+If you pass JSX directly as children, React evaluates the expressions inside while building the JSX tree, before `window` and other browser objects are available, which causes errors. By writing children as a function, the expressions are not evaluated in advance. They only execute after BrowserOnly confirms it is running in the browser, thus avoiding browser API access during SSR.
+
+## How it works
+
+`BrowserOnly` is implemented using **useEffect + dynamic imports**, thus avoiding SSR compatibility issues.

--- a/website/docs/en/ui/runtime-components/browser-only.mdx
+++ b/website/docs/en/ui/runtime-components/browser-only.mdx
@@ -5,44 +5,47 @@ overviewHeaders: []
 
 # BrowserOnly
 
-`BrowserOnly` renders its fallback during SSG and renders its children only in the browser after hydration.
+Rspress statically renders your React code into HTML during the build phase. This means the code is executed in a Node.js environment, where browser globals like `window`, `document`, and `localStorage` do not exist.
 
-Use it when a component or third-party library depends on browser-only APIs such as `window`, `document`, or `localStorage`.
+When a component or third-party library depends on these browser-only APIs, you need to escape from [static site generation (SSG)](/guide/basic/ssg). `BrowserOnly` renders a fallback during the SSG phase and renders its children only after hydration is complete in the browser.
 
 ## Usage
 
-```tsx title="index.mdx"
+```mdx title="index.mdx"
 import { BrowserOnly } from '@rspress/core/runtime';
 
-function MyComponent(props) {
-  return (
-    <BrowserOnly fallback={<div>Loading...</div>}>
-      {async () => {
-        const { LibComponent } = await import('some-lib-that-accesses-window');
-        return <LibComponent {...props} />;
-      }}
-    </BrowserOnly>
-  );
-}
+<BrowserOnly fallback={<div>Loading...</div>}>
+  {async () => {
+    const { LibComponent } = await import('some-lib-that-accesses-window');
+    return <LibComponent {...props} />;
+  }}
+</BrowserOnly>
 ```
 
-The `children` of `BrowserOnly` must be a function that returns a React node. It can also be an async function that returns a React node.
+import { BrowserOnly } from '@rspress/core/runtime';
 
-Do not pass browser-only JSX directly:
+<BrowserOnly fallback={<div>Loading...</div>}>
+  {() => {
+    return (
+      <>{`LibComponent can access \`window.location.pathname\` via BrowserOnly: ${window.location.pathname}`}</>
+    );
+  }}
+</BrowserOnly>
 
-```tsx
+## Why must children be a function?
+
+The `children` of `BrowserOnly` must be a function that returns a React node. It is important to realize that the children is not a JSX element, but a function. This is an intentional design decision.
+
+Consider this incorrect code:
+
+```mdx
 import { BrowserOnly } from '@rspress/core/runtime';
 
 <BrowserOnly>
-  {/* This still evaluates window during SSG */}
+  {/* Do not do this — it still evaluates `window` during SSG */}
   <span>Current URL: {window.location.href}</span>
-</BrowserOnly>;
+</BrowserOnly>
+;
 ```
 
-During SSG, React still evaluates the JSX tree before `BrowserOnly` can decide what to render. Passing a function delays access to browser-only APIs until the component is mounted in the browser.
-
-## Difference from NoSSR
-
-`NoSSR` is a simple wrapper that skips rendering its children during SSG and renders them after hydration.
-
-`BrowserOnly` is more suitable when the code itself cannot be evaluated during SSG, especially when you need to dynamically import a browser-only dependency.
+You might expect `BrowserOnly` to hide its children during SSG, but in fact it cannot. When the React renderer tries to render this JSX tree, it evaluates the `{window.location.href}` expression as a node of the tree before `BrowserOnly` can decide what to render. Using a function ensures that the renderer only evaluates the browser-only code when the component is mounted in the browser.

--- a/website/docs/en/ui/runtime-components/index.mdx
+++ b/website/docs/en/ui/runtime-components/index.mdx
@@ -1,7 +1,7 @@
 ---
-description: Overview of Rspress runtime components, including Head and NoSSR for runtime use.
+description: Overview of Rspress runtime components, including Head, NoSSR, and BrowserOnly for runtime use.
 title: Runtime components
 overview: true
 ---
 
-Rspress runtime components include special features like routing and SSR.
+Rspress runtime components include special features like routing, SSR, and browser-only rendering.

--- a/website/docs/en/ui/runtime-components/no-ssr.mdx
+++ b/website/docs/en/ui/runtime-components/no-ssr.mdx
@@ -17,4 +17,6 @@ import { NoSSR } from '@rspress/core/runtime';
 </NoSSR>
 ```
 
-Use it when a component depends on browser-only APIs or needs to avoid SSR.
+Use it when a component needs to avoid SSR but can still be evaluated during SSG.
+
+If the code itself depends on browser-only APIs or needs to dynamically import a browser-only dependency, use [`BrowserOnly`](./browser-only) instead.

--- a/website/docs/en/ui/runtime-components/no-ssr.mdx
+++ b/website/docs/en/ui/runtime-components/no-ssr.mdx
@@ -1,11 +1,18 @@
 ---
 description: NoSSR component for disabling server-side rendering and rendering content only on the client.
 overviewHeaders: []
+tag: deprecated
 ---
 
 # NoSSR
 
-`NoSSR` skips server-side rendering for its children.
+:::danger Deprecated
+
+`NoSSR` is deprecated. Use [`BrowserOnly`](./browser-only) instead.
+
+:::
+
+`NoSSR` is used to skip server-side rendering of its subtree.
 
 ## Usage
 
@@ -17,6 +24,6 @@ import { NoSSR } from '@rspress/core/runtime';
 </NoSSR>
 ```
 
-Use it when a component needs to avoid SSR but can still be evaluated during SSG.
+## See also
 
-If the code itself depends on browser-only APIs or needs to dynamically import a browser-only dependency, use [`BrowserOnly`](./browser-only) instead.
+- [`BrowserOnly`](./browser-only) — render content only in the browser after hydration.

--- a/website/docs/zh/guide/basic/ssg.mdx
+++ b/website/docs/zh/guide/basic/ssg.mdx
@@ -138,7 +138,7 @@ doc_build/
 
 **解决方案**：
 
-1. **使用 `BrowserOnly` 进行仅浏览器渲染**：把无法在 SSG 阶段运行的代码放在函数中，并按需提供 SSG 和加载阶段展示的 fallback。
+1. **使用 [`BrowserOnly`](/ui/runtime-components/browser-only) 进行仅浏览器渲染**：把无法在 SSG 阶段运行的代码放在函数中。
 
    ```tsx
    import { BrowserOnly } from '@rspress/core/runtime';

--- a/website/docs/zh/guide/basic/ssg.mdx
+++ b/website/docs/zh/guide/basic/ssg.mdx
@@ -138,7 +138,27 @@ doc_build/
 
 **解决方案**：
 
-1. **使用 `useEffect` 延迟执行**：将浏览器 API 的调用放在 `useEffect` 中，确保只在客户端执行
+1. **使用 `BrowserOnly` 进行仅浏览器渲染**：把无法在 SSG 阶段运行的代码放在函数中，并按需提供 SSG 和加载阶段展示的 fallback。
+
+   ```tsx
+   import { BrowserOnly } from '@rspress/core/runtime';
+
+   function MyComponent(props) {
+     return (
+       <BrowserOnly fallback={<div>Loading...</div>}>
+         {async () => {
+           const { LibComponent } =
+             await import('some-lib-that-accesses-window');
+           return <LibComponent {...props} />;
+         }}
+       </BrowserOnly>
+     );
+   }
+   ```
+
+   children 必须是函数，而不是 JSX。否则 `window.location.href` 这类表达式仍然会在 React 构建 SSG 渲染树时被求值。
+
+2. **使用 `useEffect` 延迟执行**：将浏览器 API 的调用放在 `useEffect` 中，确保只在客户端执行
 
    ```tsx
    import { useEffect, useState } from 'react';
@@ -155,7 +175,7 @@ doc_build/
    }
    ```
 
-2. **条件检查**：在访问浏览器 API 前检查环境
+3. **条件检查**：在访问浏览器 API 前检查环境
 
    ```tsx
    if (typeof window !== 'undefined') {
@@ -164,7 +184,7 @@ doc_build/
    }
    ```
 
-3. **动态导入**：对于依赖浏览器 API 的第三方库，使用动态导入
+4. **在 `useEffect` 中动态导入**：对于依赖浏览器 API 的第三方库，在 `useEffect` 中使用动态导入
 
    ```tsx
    import { useEffect, useState } from 'react';

--- a/website/docs/zh/ui/runtime-components/browser-only.mdx
+++ b/website/docs/zh/ui/runtime-components/browser-only.mdx
@@ -1,0 +1,48 @@
+---
+description: BrowserOnly 组件，用于在 hydration 后仅在浏览器中渲染内容。
+overviewHeaders: []
+---
+
+# BrowserOnly
+
+`BrowserOnly` 会在 SSG 阶段渲染 fallback，并在浏览器完成 hydration 后再渲染 children。
+
+当组件或第三方库依赖 `window`、`document`、`localStorage` 等浏览器 API 时，可以使用它。
+
+## 用法
+
+```tsx title="index.mdx"
+import { BrowserOnly } from '@rspress/core/runtime';
+
+function MyComponent(props) {
+  return (
+    <BrowserOnly fallback={<div>Loading...</div>}>
+      {async () => {
+        const { LibComponent } = await import('some-lib-that-accesses-window');
+        return <LibComponent {...props} />;
+      }}
+    </BrowserOnly>
+  );
+}
+```
+
+`BrowserOnly` 的 children 必须是一个返回 React 节点的函数，也可以是返回 React 节点的异步函数。
+
+不要直接传入依赖浏览器 API 的 JSX：
+
+```tsx
+import { BrowserOnly } from '@rspress/core/runtime';
+
+<BrowserOnly>
+  {/* 这里仍然会在 SSG 阶段求值 window */}
+  <span>Current URL: {window.location.href}</span>
+</BrowserOnly>;
+```
+
+在 SSG 阶段，React 会先求值 JSX 树，然后 `BrowserOnly` 才能决定渲染什么。使用函数可以把浏览器 API 的访问延迟到组件在浏览器中挂载之后。
+
+## 与 NoSSR 的区别
+
+`NoSSR` 是一个简单包装器，用于在 SSG 阶段跳过 children，并在 hydration 后渲染。
+
+当代码本身无法在 SSG 阶段求值时，尤其是需要动态导入浏览器专用依赖时，`BrowserOnly` 更合适。

--- a/website/docs/zh/ui/runtime-components/browser-only.mdx
+++ b/website/docs/zh/ui/runtime-components/browser-only.mdx
@@ -5,44 +5,47 @@ overviewHeaders: []
 
 # BrowserOnly
 
-`BrowserOnly` 会在 SSG 阶段渲染 fallback，并在浏览器完成 hydration 后再渲染 children。
+Rspress 在构建阶段会将 React 代码静态渲染为 HTML，这意味着代码在 Node.js 环境中执行，此时 `window`、`document`、`localStorage` 等浏览器全局对象并不存在。
 
-当组件或第三方库依赖 `window`、`document`、`localStorage` 等浏览器 API 时，可以使用它。
+当组件或第三方库依赖这些浏览器专属 API 时，你需要从 [静态站点生成（SSG）](/guide/basic/ssg) 中逃逸出来。`BrowserOnly` 会在 SSG 阶段渲染 fallback，并在浏览器完成 hydration 后再渲染 children。
 
 ## 用法
 
-```tsx title="index.mdx"
+```mdx title="index.mdx"
 import { BrowserOnly } from '@rspress/core/runtime';
 
-function MyComponent(props) {
-  return (
-    <BrowserOnly fallback={<div>Loading...</div>}>
-      {async () => {
-        const { LibComponent } = await import('some-lib-that-accesses-window');
-        return <LibComponent {...props} />;
-      }}
-    </BrowserOnly>
-  );
-}
+<BrowserOnly fallback={<div>Loading...</div>}>
+  {async () => {
+    const { LibComponent } = await import('some-lib-that-accesses-window');
+    return <LibComponent {...props} />;
+  }}
+</BrowserOnly>
 ```
 
-`BrowserOnly` 的 children 必须是一个返回 React 节点的函数，也可以是返回 React 节点的异步函数。
+import { BrowserOnly } from '@rspress/core/runtime';
 
-不要直接传入依赖浏览器 API 的 JSX：
+<BrowserOnly fallback={<div>Loading...</div>}>
+  {() => {
+    return (
+      <>{`LibComponent can access \`window.location.pathname\` via BrowserOnly: ${window.location.pathname}`}</>
+    );
+  }}
+</BrowserOnly>
 
-```tsx
+## 为什么 children 必须是函数？
+
+`BrowserOnly` 的 children 必须是一个返回 React 节点的函数。需要明确的是，children 不是 JSX 元素，而是函数，这是一个有意的设计决策。
+
+考虑下面这段错误的代码：
+
+```mdx
 import { BrowserOnly } from '@rspress/core/runtime';
 
 <BrowserOnly>
-  {/* 这里仍然会在 SSG 阶段求值 window */}
+  {/* 不要这样做——它仍会在 SSG 阶段求值 window */}
   <span>Current URL: {window.location.href}</span>
-</BrowserOnly>;
+</BrowserOnly>
+;
 ```
 
-在 SSG 阶段，React 会先求值 JSX 树，然后 `BrowserOnly` 才能决定渲染什么。使用函数可以把浏览器 API 的访问延迟到组件在浏览器中挂载之后。
-
-## 与 NoSSR 的区别
-
-`NoSSR` 是一个简单包装器，用于在 SSG 阶段跳过 children，并在 hydration 后渲染。
-
-当代码本身无法在 SSG 阶段求值时，尤其是需要动态导入浏览器专用依赖时，`BrowserOnly` 更合适。
+你可能期望 `BrowserOnly` 在 SSG 阶段隐藏 children，但实际上它做不到。当 React 渲染器尝试渲染这棵 JSX 树时，它会在 `BrowserOnly` 决定渲染什么之前，就把 `{window.location.href}` 表达式作为树的一个节点进行求值。使用函数可以确保渲染器只在组件挂载到浏览器时才去求值浏览器专属代码。

--- a/website/docs/zh/ui/runtime-components/browser-only.mdx
+++ b/website/docs/zh/ui/runtime-components/browser-only.mdx
@@ -48,4 +48,8 @@ import { BrowserOnly } from '@rspress/core/runtime';
 ;
 ```
 
-你可能期望 `BrowserOnly` 在 SSG 阶段隐藏 children，但实际上它做不到。当 React 渲染器尝试渲染这棵 JSX 树时，它会在 `BrowserOnly` 决定渲染什么之前，就把 `{window.location.href}` 表达式作为树的一个节点进行求值。使用函数可以确保渲染器只在组件挂载到浏览器时才去求值浏览器专属代码。
+如果直接把 JSX 作为 children 传入，React 会在创建 JSX 树时就对其中的表达式求值，此时 `window` 等浏览器对象尚未就绪，会导致报错。将 children 写成函数后，表达式不会被提前求值，只有在 BrowserOnly 确认已进入浏览器环境后才会执行，从而避免在 SSR 阶段访问浏览器 API。
+
+## 原理
+
+`BrowserOnly` 使用 **useEffect + 动态导入** 实现，从而规避 SSR 兼容问题。

--- a/website/docs/zh/ui/runtime-components/index.mdx
+++ b/website/docs/zh/ui/runtime-components/index.mdx
@@ -1,7 +1,7 @@
 ---
-description: Rspress 运行时组件概览，包含 Head 和 NoSSR 等运行时使用的组件。
+description: Rspress 运行时组件概览，包含 Head、NoSSR 和 BrowserOnly 等运行时使用的组件。
 title: 运行时组件
 overview: true
 ---
 
-Rspress 的运行时组件，包含一些路由、SSR 等特殊功能。
+Rspress 的运行时组件，包含一些路由、SSR 和仅浏览器渲染等特殊功能。

--- a/website/docs/zh/ui/runtime-components/no-ssr.mdx
+++ b/website/docs/zh/ui/runtime-components/no-ssr.mdx
@@ -17,4 +17,6 @@ import { NoSSR } from '@rspress/core/runtime';
 </NoSSR>
 ```
 
-常用于依赖浏览器 API 的组件，避免 SSR 阶段报错或与客户端渲染不一致。
+常用于需要避免 SSR，但代码本身仍然可以在 SSG 阶段求值的组件。
+
+如果代码本身依赖浏览器 API，或者需要动态导入浏览器专用依赖，请使用 [`BrowserOnly`](./browser-only)。

--- a/website/docs/zh/ui/runtime-components/no-ssr.mdx
+++ b/website/docs/zh/ui/runtime-components/no-ssr.mdx
@@ -1,11 +1,18 @@
 ---
 description: NoSSR 组件，用于禁用服务端渲染，仅在客户端渲染特定内容。
 overviewHeaders: []
+tag: deprecated
 ---
 
 # NoSSR
 
-`NoSSR` 用于禁用特定子树在服务端渲染，强制只在客户端渲染。
+:::danger 已废弃
+
+`NoSSR` 已废弃，请使用 [`BrowserOnly`](./browser-only)。
+
+:::
+
+`NoSSR` 用于跳过其子树的服务端渲染。
 
 ## 用法
 
@@ -17,6 +24,6 @@ import { NoSSR } from '@rspress/core/runtime';
 </NoSSR>
 ```
 
-常用于需要避免 SSR，但代码本身仍然可以在 SSG 阶段求值的组件。
+## 另见
 
-如果代码本身依赖浏览器 API，或者需要动态导入浏览器专用依赖，请使用 [`BrowserOnly`](./browser-only)。
+- [`BrowserOnly`](./browser-only) — 仅在浏览器 hydration 后渲染内容。


### PR DESCRIPTION
## Summary

- Add a BrowserOnly runtime component that renders fallback during SSG and supports sync or async render callbacks in the browser.
- Reuse BrowserOnly in NoSSR to keep existing client-only rendering behavior.
- Document BrowserOnly in English and Chinese runtime component docs and SSG troubleshooting guides.


https://docusaurus.io/docs/3.9.2/advanced/ssg#escape-hatches


```ts
import BrowserOnly from '@docusaurus/BrowserOnly';
function MyComponent(props) {
  return (
    <BrowserOnly fallback={<div>Loading...</div>}>
      {async () =>
        const { LibComponent } = await import('some-lib-that-accesses-window');

        return <LibComponent {...props} />;
      }
    </BrowserOnly>
  );
}
```

## Related Issue

None

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).