### PR TITLE
fix(core): preserve false ssg option

### DIFF
--- a/packages/core/src/node/ssg/renderPages.ts
+++ b/packages/core/src/node/ssg/renderPages.ts
@@ -35,7 +35,7 @@ export async function renderPages(
 ) {
   logger.info('Rendering pages...');
   const startTime = Date.now();
-  const ssg = config.ssg || true;
+  const ssg = config.ssg ?? true;
 
   try {
     const routes = routeService.getRoutes();


### PR DESCRIPTION
## Summary

This PR replaces an always-true fallback in SSG rendering config normalization with a nullish fallback. The code path is not expected to trigger for normal `ssg: false` builds because the SSG plugin is not registered, but preserving explicit `false` avoids a potential bug if this helper is reused or called directly.

## Related Issue

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).