### PR TITLE
feat(theme/Tabs): support custom tab labels

### DIFF
--- a/e2e/fixtures/tabs-component/doc/index.mdx
+++ b/e2e/fixtures/tabs-component/doc/index.mdx
@@ -19,3 +19,31 @@ import { Tabs, Tab } from '@rspress/core/theme';
 ## Tab c
 
 <Tabs className="tabs-c"></Tabs>
+
+## Tab d
+
+<Tabs
+  className="tabs-d"
+  defaultValue="ttml"
+  values={[
+    { label: <span className="tab-d-label">index.ttml</span>, value: 'ttml' },
+    { label: 'index.js', value: 'subscribe' },
+  ]}
+>
+<Tab value="ttml">
+
+```ts
+// index.ttml
+const template = 'content ttml';
+```
+
+</Tab>
+<Tab value="subscribe">
+
+```js
+// index.js
+const subscribe = 'content subscribe';
+```
+
+</Tab>
+</Tabs>

--- a/e2e/fixtures/tabs-component/doc/index.mdx
+++ b/e2e/fixtures/tabs-component/doc/index.mdx
@@ -24,17 +24,20 @@ import { Tabs, Tab } from '@rspress/core/theme';
 
 <Tabs
   className="tabs-d"
-  defaultValue="ttml"
+  defaultValue="markup"
   values={[
-    { label: <span className="tab-d-label">index.ttml</span>, value: 'ttml' },
+    {
+      label: <span className="tab-d-label">index.markup</span>,
+      value: 'markup',
+    },
     { label: 'index.js', value: 'subscribe' },
   ]}
 >
-<Tab value="ttml">
+<Tab value="markup">
 
 ```ts
-// index.ttml
-const template = 'content ttml';
+// index.markup
+const template = 'content markup';
 ```
 
 </Tab>

--- a/e2e/fixtures/tabs-component/doc/index.mdx
+++ b/e2e/fixtures/tabs-component/doc/index.mdx
@@ -40,3 +40,19 @@ const subscribe = 'content subscribe';
 
 </Tab>
 </Tabs>
+
+## Tab e
+
+<Tabs
+  className="tabs-e"
+  defaultValue="orange"
+  values={[
+    { label: 'Apple', value: 'apple' },
+    { label: 'Orange', value: 'orange' },
+    { label: 'Banana', value: 'banana' },
+  ]}
+>
+  <Tab value="apple">This is an apple</Tab>
+  <Tab value="orange">This is an orange</Tab>
+  <Tab value="banana">This is a banana</Tab>
+</Tabs>

--- a/e2e/fixtures/tabs-component/doc/index.mdx
+++ b/e2e/fixtures/tabs-component/doc/index.mdx
@@ -22,18 +22,8 @@ import { Tabs, Tab } from '@rspress/core/theme';
 
 ## Tab d
 
-<Tabs
-  className="tabs-d"
-  defaultValue="markup"
-  values={[
-    {
-      label: <span className="tab-d-label">index.markup</span>,
-      value: 'markup',
-    },
-    { label: 'index.js', value: 'subscribe' },
-  ]}
->
-<Tab value="markup">
+<Tabs className="tabs-d">
+<Tab label={<span className="tab-d-label">index.markup</span>}>
 
 ```ts
 // index.markup
@@ -41,7 +31,7 @@ const template = 'content markup';
 ```
 
 </Tab>
-<Tab value="subscribe">
+<Tab label="index.js">
 
 ```js
 // index.js

--- a/e2e/fixtures/tabs-component/index.test.ts
+++ b/e2e/fixtures/tabs-component/index.test.ts
@@ -59,5 +59,17 @@ test.describe('tabs-component test', async () => {
       .locator('.rp-tabs__label__item', { hasText: 'index.js' })
       .click();
     await expect(activeContentD).toContainText('content subscribe');
+
+    // Tab E
+    const tabE = page.locator('.tabs-e');
+    const activeContentE = tabE.locator('.rp-tabs__content__item--active');
+    await expect(tabE.locator('.rp-tabs__label__item')).toHaveText([
+      'Apple',
+      'Orange',
+      'Banana',
+    ]);
+    await expect(activeContentE).toContainText('This is an orange');
+    await tabE.locator('.rp-tabs__label__item', { hasText: 'Banana' }).click();
+    await expect(activeContentE).toContainText('This is a banana');
   });
 });

--- a/e2e/fixtures/tabs-component/index.test.ts
+++ b/e2e/fixtures/tabs-component/index.test.ts
@@ -52,8 +52,8 @@ test.describe('tabs-component test', async () => {
     // Tab D
     const tabD = page.locator('.tabs-d');
     const activeContentD = tabD.locator('.rp-tabs__content__item--active');
-    await expect(tabD.locator('.tab-d-label')).toHaveText('index.ttml');
-    await expect(activeContentD).toContainText('content ttml');
+    await expect(tabD.locator('.tab-d-label')).toHaveText('index.markup');
+    await expect(activeContentD).toContainText('content markup');
     await expect(activeContentD).not.toContainText('content subscribe');
     await tabD
       .locator('.rp-tabs__label__item', { hasText: 'index.js' })

--- a/e2e/fixtures/tabs-component/index.test.ts
+++ b/e2e/fixtures/tabs-component/index.test.ts
@@ -48,5 +48,16 @@ test.describe('tabs-component test', async () => {
     const contentC = page.locator('.tabs-c > div');
     await expect(tabC).toHaveText('');
     await expect(contentC).toHaveText('');
+
+    // Tab D
+    const tabD = page.locator('.tabs-d');
+    const activeContentD = tabD.locator('.rp-tabs__content__item--active');
+    await expect(tabD.locator('.tab-d-label')).toHaveText('index.ttml');
+    await expect(activeContentD).toContainText('content ttml');
+    await expect(activeContentD).not.toContainText('content subscribe');
+    await tabD
+      .locator('.rp-tabs__label__item', { hasText: 'index.js' })
+      .click();
+    await expect(activeContentD).toContainText('content subscribe');
   });
 });

--- a/packages/core/src/theme/components/PackageManagerTabs/index.tsx
+++ b/packages/core/src/theme/components/PackageManagerTabs/index.tsx
@@ -231,30 +231,26 @@ export function PackageManagerTabs({
   }
 
   return (
-    <Tabs
-      groupId="package.manager"
-      values={Object.entries(commandInfo).map(([key]) => ({
-        label: (
-          <div
-            key={key}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              fontSize: 15,
-            }}
-          >
-            {packageMangerToIcon[key]}
-            <span style={{ marginLeft: 6, marginBottom: 2 }}>{key}</span>
-          </div>
-        ),
-        value: key,
-      }))}
-    >
+    <Tabs groupId="package.manager">
       {Object.entries(commandInfo).map(([key, value]) => {
         const [packageManager, command] = splitTo2Parts(value);
 
         return (
-          <Tab key={key} value={key}>
+          <Tab
+            key={key}
+            label={
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  fontSize: 15,
+                }}
+              >
+                {packageMangerToIcon[key]}
+                <span style={{ marginLeft: 6, marginBottom: 2 }}>{key}</span>
+              </div>
+            }
+          >
             <Pre
               lang="bash"
               className="shiki css-variables"

--- a/packages/core/src/theme/components/PackageManagerTabs/index.tsx
+++ b/packages/core/src/theme/components/PackageManagerTabs/index.tsx
@@ -233,25 +233,28 @@ export function PackageManagerTabs({
   return (
     <Tabs
       groupId="package.manager"
-      values={Object.entries(commandInfo).map(([key]) => (
-        <div
-          key={key}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            fontSize: 15,
-          }}
-        >
-          {packageMangerToIcon[key]}
-          <span style={{ marginLeft: 6, marginBottom: 2 }}>{key}</span>
-        </div>
-      ))}
+      values={Object.entries(commandInfo).map(([key]) => ({
+        label: (
+          <div
+            key={key}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              fontSize: 15,
+            }}
+          >
+            {packageMangerToIcon[key]}
+            <span style={{ marginLeft: 6, marginBottom: 2 }}>{key}</span>
+          </div>
+        ),
+        value: key,
+      }))}
     >
       {Object.entries(commandInfo).map(([key, value]) => {
         const [packageManager, command] = splitTo2Parts(value);
 
         return (
-          <Tab key={key}>
+          <Tab key={key} value={key}>
             <Pre
               lang="bash"
               className="shiki css-variables"

--- a/packages/core/src/theme/components/Search/SearchPanel.tsx
+++ b/packages/core/src/theme/components/Search/SearchPanel.tsx
@@ -388,18 +388,10 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
       );
     }
 
-    const tabValues = result.map(item => {
-      return {
-        label: item.group,
-        value: item.group,
-      };
-    });
-
     const renderKey = 'render' as const;
 
     return (
       <Tabs
-        values={tabValues}
         className="rp-search-panel__tabs"
         onChange={index => {
           setResultTabIndex(index);
@@ -409,7 +401,7 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
         ref={searchResultTabRef}
       >
         {result.map(item => (
-          <Tab key={item.group} value={item.group}>
+          <Tab key={item.group} label={item.group}>
             {item.renderType === RenderType.Default &&
               renderSearchResultItem(item.result, query, isSearching)}
             {item.renderType === RenderType.Custom &&

--- a/packages/core/src/theme/components/Search/SearchPanel.tsx
+++ b/packages/core/src/theme/components/Search/SearchPanel.tsx
@@ -389,7 +389,10 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
     }
 
     const tabValues = result.map(item => {
-      return item.group;
+      return {
+        label: item.group,
+        value: item.group,
+      };
     });
 
     const renderKey = 'render' as const;
@@ -406,7 +409,7 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
         ref={searchResultTabRef}
       >
         {result.map(item => (
-          <Tab key={item.group}>
+          <Tab key={item.group} value={item.group}>
             {item.renderType === RenderType.Default &&
               renderSearchResultItem(item.result, query, isSearching)}
             {item.renderType === RenderType.Custom &&

--- a/packages/core/src/theme/components/Tabs/index.tsx
+++ b/packages/core/src/theme/components/Tabs/index.tsx
@@ -13,17 +13,20 @@ import {
 import './index.scss';
 
 type TabItem = {
-  label?: string | ReactNode;
+  label?: ReactNode;
+  value?: string;
   disabled?: boolean;
   content?: ReactNode;
 };
+type TabValue = ReactNode | TabItem;
 
 export interface TabsProps {
-  values?: ReactNode[] | ReadonlyArray<ReactNode> | TabItem[];
+  values?: TabValue[] | ReadonlyArray<TabValue>;
   /**
    * @default 0
    */
   defaultIndex?: number;
+  defaultValue?: string;
   onChange?: (index: number) => void;
   children: ReactNode;
   /**
@@ -45,7 +48,7 @@ export interface TabsProps {
 
 function getTabValuesFromChildren(
   children: ReactElement<TabProps>[],
-  defaultValues: ReactNode[] | ReadonlyArray<ReactNode> | TabItem[] | undefined,
+  defaultValues: TabValue[] | ReadonlyArray<TabValue> | undefined,
 ): TabItem[] {
   // 0. only values, values contain label and content
   // <Tabs values={[{}, {}]}/>
@@ -57,13 +60,24 @@ function getTabValuesFromChildren(
   // <Tabs values={['Tab1', 'Tab2']}><Tab label="Tab1"/></Tab><Tab label="Tab2"/></Tab></Tabs>
   if (defaultValues && defaultValues.length > 0) {
     return defaultValues.map((item, index) => {
+      const tabItem = isTabItem(item) ? item : { label: item };
+      const content =
+        tabItem.content ??
+        (tabItem.value
+          ? children.find(child => child.props?.value === tabItem.value)
+          : undefined) ??
+        children[index];
+
       if (isTabItem(item)) {
-        return item;
+        return {
+          ...item,
+          content,
+        };
       }
 
       return {
         label: item,
-        content: children[index],
+        content,
       } satisfies TabItem;
     });
   }
@@ -76,6 +90,8 @@ function getTabValuesFromChildren(
       if (isValidElement(child)) {
         return {
           label: child.props?.label || undefined,
+          value: child.props?.value,
+          disabled: child.props?.disabled,
           content: children[index],
         } satisfies TabItem;
       }
@@ -102,6 +118,7 @@ export const Tabs = forwardRef(
     const {
       values,
       defaultIndex,
+      defaultValue,
       onChange,
       children: rawChildren,
       groupId,
@@ -138,11 +155,18 @@ export const Tabs = forwardRef(
       );
     }
 
-    const [activeIndex, setActiveIndex] = useState(defaultIndex ?? 0);
+    const defaultActiveIndex =
+      defaultValue !== undefined
+        ? tabValues.findIndex(item => item.value === defaultValue)
+        : -1;
+    const initialActiveIndex =
+      defaultActiveIndex === -1 ? (defaultIndex ?? 0) : defaultActiveIndex;
+
+    const [activeIndex, setActiveIndex] = useState(initialActiveIndex);
 
     const [storageIndex, setStorageIndex] = useStorageValue<string>(
       `${groupIdPrefix}${groupId}`,
-      activeIndex.toString(),
+      initialActiveIndex.toString(),
     );
 
     const currentIndex: number = groupId ? Number(storageIndex) : activeIndex;
@@ -157,11 +181,11 @@ export const Tabs = forwardRef(
                 tabPosition === 'center' ? 'center' : 'flex-start',
             }}
           >
-            {tabValues.map(({ label }, index) => {
+            {tabValues.map(({ label, value, disabled }, index) => {
               const isActive = index === currentIndex;
               return (
                 <div
-                  key={typeof label === 'string' ? label : index}
+                  key={value ?? (typeof label === 'string' ? label : index)}
                   className={clsx(
                     'rp-tabs__label__item',
                     isActive
@@ -171,6 +195,9 @@ export const Tabs = forwardRef(
                   )}
                   data-index={index}
                   onClick={() => {
+                    if (disabled) {
+                      return;
+                    }
                     onChange?.(index);
                     if (groupId) {
                       setStorageIndex(index.toString());
@@ -186,7 +213,7 @@ export const Tabs = forwardRef(
           </div>
         ) : null}
         <div className="rp-tabs__content">
-          {tabValues.map(({ label, content }, index) => {
+          {tabValues.map(({ label, value, content }, index) => {
             const isActive = index === currentIndex;
             if (!keepDOM && !isActive) {
               return null;
@@ -194,7 +221,7 @@ export const Tabs = forwardRef(
 
             return (
               <div
-                key={typeof label === 'string' ? label : index}
+                key={value ?? (typeof label === 'string' ? label : index)}
                 className={clsx(
                   'rp-tabs__content__item',
                   isActive
@@ -217,7 +244,7 @@ export const Tabs = forwardRef(
 
 Tabs.displayName = 'Tabs';
 
-export type TabProps = Pick<TabItem, 'label' | 'disabled'> & {
+export type TabProps = Pick<TabItem, 'label' | 'value' | 'disabled'> & {
   children: ReactNode;
 };
 

--- a/packages/core/src/theme/components/Tabs/index.tsx
+++ b/packages/core/src/theme/components/Tabs/index.tsx
@@ -12,17 +12,26 @@ import {
 } from 'react';
 import './index.scss';
 
+type TabItem = {
+  label: ReactNode;
+  value: string;
+  disabled?: boolean;
+};
+
 type ResolvedTabItem = {
   label?: ReactNode;
+  value?: string;
   disabled?: boolean;
   content?: ReactNode;
 };
 
 export interface TabsProps {
+  values?: ReadonlyArray<TabItem>;
   /**
    * @default 0
    */
   defaultIndex?: number;
+  defaultValue?: string;
   onChange?: (index: number) => void;
   children: ReactNode;
   /**
@@ -44,13 +53,28 @@ export interface TabsProps {
 
 function getTabValuesFromChildren(
   children: ReactElement<TabProps>[],
+  values: ReadonlyArray<TabItem> | undefined,
 ): ResolvedTabItem[] {
+  if (values && values.length > 0) {
+    return values.map((item, index) => {
+      const content =
+        children.find(child => child.props?.value === item.value) ??
+        children[index];
+
+      return {
+        ...item,
+        content,
+      } satisfies ResolvedTabItem;
+    });
+  }
+
   return Children.map<ResolvedTabItem, ReactElement<TabProps>>(
     children,
     (child, index) => {
       if (isValidElement(child)) {
         return {
           label: child.props?.label || undefined,
+          value: child.props?.value,
           disabled: child.props?.disabled,
           content: children[index],
         } satisfies ResolvedTabItem;
@@ -69,7 +93,9 @@ const groupIdPrefix = 'rspress.tabs.';
 export const Tabs = forwardRef(
   (props: TabsProps, ref: ForwardedRef<HTMLDivElement>): ReactElement => {
     const {
+      values,
       defaultIndex,
+      defaultValue,
       onChange,
       children: rawChildren,
       groupId,
@@ -87,8 +113,8 @@ export const Tabs = forwardRef(
     ) as unknown as ReactElement<TabProps>[];
 
     const tabValues: ResolvedTabItem[] = useMemo(() => {
-      return getTabValuesFromChildren(children);
-    }, [children]);
+      return getTabValuesFromChildren(children, values);
+    }, [children, values]);
 
     if (process.env.__SSR_MD__) {
       return (
@@ -106,7 +132,12 @@ export const Tabs = forwardRef(
       );
     }
 
-    const initialActiveIndex = defaultIndex ?? 0;
+    const defaultValueIndex =
+      defaultValue !== undefined
+        ? tabValues.findIndex(item => item.value === defaultValue)
+        : -1;
+    const initialActiveIndex =
+      defaultValueIndex === -1 ? (defaultIndex ?? 0) : defaultValueIndex;
 
     const [activeIndex, setActiveIndex] = useState(initialActiveIndex);
 
@@ -127,11 +158,11 @@ export const Tabs = forwardRef(
                 tabPosition === 'center' ? 'center' : 'flex-start',
             }}
           >
-            {tabValues.map(({ label, disabled }, index) => {
+            {tabValues.map(({ label, value, disabled }, index) => {
               const isActive = index === currentIndex;
               return (
                 <div
-                  key={index}
+                  key={value ?? index}
                   className={clsx(
                     'rp-tabs__label__item',
                     isActive
@@ -159,7 +190,7 @@ export const Tabs = forwardRef(
           </div>
         ) : null}
         <div className="rp-tabs__content">
-          {tabValues.map(({ content }, index) => {
+          {tabValues.map(({ value, content }, index) => {
             const isActive = index === currentIndex;
             if (!keepDOM && !isActive) {
               return null;
@@ -167,7 +198,7 @@ export const Tabs = forwardRef(
 
             return (
               <div
-                key={index}
+                key={value ?? index}
                 className={clsx(
                   'rp-tabs__content__item',
                   isActive
@@ -192,6 +223,7 @@ Tabs.displayName = 'Tabs';
 
 export type TabProps = {
   label?: ReactNode;
+  value?: string;
   disabled?: boolean;
   children: ReactNode;
 };

--- a/packages/core/src/theme/components/Tabs/index.tsx
+++ b/packages/core/src/theme/components/Tabs/index.tsx
@@ -13,15 +13,19 @@ import {
 import './index.scss';
 
 type TabItem = {
+  label: ReactNode;
+  value: string;
+};
+
+type ResolvedTabItem = {
   label?: ReactNode;
   value?: string;
   disabled?: boolean;
   content?: ReactNode;
 };
-type TabValue = ReactNode | TabItem;
 
 export interface TabsProps {
-  values?: TabValue[] | ReadonlyArray<TabValue>;
+  values?: ReadonlyArray<TabItem>;
   /**
    * @default 0
    */
@@ -48,43 +52,26 @@ export interface TabsProps {
 
 function getTabValuesFromChildren(
   children: ReactElement<TabProps>[],
-  defaultValues: TabValue[] | ReadonlyArray<TabValue> | undefined,
-): TabItem[] {
-  // 0. only values, values contain label and content
-  // <Tabs values={[{}, {}]}/>
-  if (defaultValues?.every(item => isTabItem(item) && item.content)) {
-    return defaultValues as TabItem[];
-  }
-
-  // 1. values only contain label
-  // <Tabs values={['Tab1', 'Tab2']}><Tab label="Tab1"/></Tab><Tab label="Tab2"/></Tab></Tabs>
+  defaultValues: ReadonlyArray<TabItem> | undefined,
+): ResolvedTabItem[] {
+  // 1. values contain label and value
+  // <Tabs values={[{ label: 'Tab1', value: 'tab1' }]}><Tab value="tab1" /></Tabs>
   if (defaultValues && defaultValues.length > 0) {
     return defaultValues.map((item, index) => {
-      const tabItem = isTabItem(item) ? item : { label: item };
       const content =
-        tabItem.content ??
-        (tabItem.value
-          ? children.find(child => child.props?.value === tabItem.value)
-          : undefined) ??
+        children.find(child => child.props?.value === item.value) ??
         children[index];
 
-      if (isTabItem(item)) {
-        return {
-          ...item,
-          content,
-        };
-      }
-
       return {
-        label: item,
+        ...item,
         content,
-      } satisfies TabItem;
+      } satisfies ResolvedTabItem;
     });
   }
 
   // 2. no values
   // <Tabs><Tab label="Tab1"/></Tab><Tab label="Tab2"/></Tab></Tabs>
-  return Children.map<TabItem, ReactElement<TabProps>>(
+  return Children.map<ResolvedTabItem, ReactElement<TabProps>>(
     children,
     (child, index) => {
       if (isValidElement(child)) {
@@ -93,22 +80,15 @@ function getTabValuesFromChildren(
           value: child.props?.value,
           disabled: child.props?.disabled,
           content: children[index],
-        } satisfies TabItem;
+        } satisfies ResolvedTabItem;
       }
 
       return {
         label: index,
         content: children[index],
-      } satisfies TabItem;
+      } satisfies ResolvedTabItem;
     },
   );
-}
-
-function isTabItem(item: unknown): item is TabItem {
-  if (item && typeof item === 'object' && 'label' in item) {
-    return true;
-  }
-  return false;
 }
 
 const groupIdPrefix = 'rspress.tabs.';
@@ -135,7 +115,7 @@ export const Tabs = forwardRef(
         isValidElement(child),
     ) as unknown as ReactElement<TabProps>[];
 
-    const tabValues: TabItem[] = useMemo(() => {
+    const tabValues: ResolvedTabItem[] = useMemo(() => {
       return getTabValuesFromChildren(children, values);
     }, [values, children]);
 
@@ -244,7 +224,10 @@ export const Tabs = forwardRef(
 
 Tabs.displayName = 'Tabs';
 
-export type TabProps = Pick<TabItem, 'label' | 'value' | 'disabled'> & {
+export type TabProps = {
+  label?: ReactNode;
+  value?: string;
+  disabled?: boolean;
   children: ReactNode;
 };
 

--- a/packages/core/src/theme/components/Tabs/index.tsx
+++ b/packages/core/src/theme/components/Tabs/index.tsx
@@ -12,25 +12,17 @@ import {
 } from 'react';
 import './index.scss';
 
-type TabItem = {
-  label: ReactNode;
-  value: string;
-};
-
 type ResolvedTabItem = {
   label?: ReactNode;
-  value?: string;
   disabled?: boolean;
   content?: ReactNode;
 };
 
 export interface TabsProps {
-  values?: ReadonlyArray<TabItem>;
   /**
    * @default 0
    */
   defaultIndex?: number;
-  defaultValue?: string;
   onChange?: (index: number) => void;
   children: ReactNode;
   /**
@@ -52,32 +44,13 @@ export interface TabsProps {
 
 function getTabValuesFromChildren(
   children: ReactElement<TabProps>[],
-  defaultValues: ReadonlyArray<TabItem> | undefined,
 ): ResolvedTabItem[] {
-  // 1. values contain label and value
-  // <Tabs values={[{ label: 'Tab1', value: 'tab1' }]}><Tab value="tab1" /></Tabs>
-  if (defaultValues && defaultValues.length > 0) {
-    return defaultValues.map((item, index) => {
-      const content =
-        children.find(child => child.props?.value === item.value) ??
-        children[index];
-
-      return {
-        ...item,
-        content,
-      } satisfies ResolvedTabItem;
-    });
-  }
-
-  // 2. no values
-  // <Tabs><Tab label="Tab1"/></Tab><Tab label="Tab2"/></Tab></Tabs>
   return Children.map<ResolvedTabItem, ReactElement<TabProps>>(
     children,
     (child, index) => {
       if (isValidElement(child)) {
         return {
           label: child.props?.label || undefined,
-          value: child.props?.value,
           disabled: child.props?.disabled,
           content: children[index],
         } satisfies ResolvedTabItem;
@@ -96,9 +69,7 @@ const groupIdPrefix = 'rspress.tabs.';
 export const Tabs = forwardRef(
   (props: TabsProps, ref: ForwardedRef<HTMLDivElement>): ReactElement => {
     const {
-      values,
       defaultIndex,
-      defaultValue,
       onChange,
       children: rawChildren,
       groupId,
@@ -116,8 +87,8 @@ export const Tabs = forwardRef(
     ) as unknown as ReactElement<TabProps>[];
 
     const tabValues: ResolvedTabItem[] = useMemo(() => {
-      return getTabValuesFromChildren(children, values);
-    }, [values, children]);
+      return getTabValuesFromChildren(children);
+    }, [children]);
 
     if (process.env.__SSR_MD__) {
       return (
@@ -135,12 +106,7 @@ export const Tabs = forwardRef(
       );
     }
 
-    const defaultActiveIndex =
-      defaultValue !== undefined
-        ? tabValues.findIndex(item => item.value === defaultValue)
-        : -1;
-    const initialActiveIndex =
-      defaultActiveIndex === -1 ? (defaultIndex ?? 0) : defaultActiveIndex;
+    const initialActiveIndex = defaultIndex ?? 0;
 
     const [activeIndex, setActiveIndex] = useState(initialActiveIndex);
 
@@ -161,11 +127,11 @@ export const Tabs = forwardRef(
                 tabPosition === 'center' ? 'center' : 'flex-start',
             }}
           >
-            {tabValues.map(({ label, value, disabled }, index) => {
+            {tabValues.map(({ label, disabled }, index) => {
               const isActive = index === currentIndex;
               return (
                 <div
-                  key={value ?? (typeof label === 'string' ? label : index)}
+                  key={index}
                   className={clsx(
                     'rp-tabs__label__item',
                     isActive
@@ -193,7 +159,7 @@ export const Tabs = forwardRef(
           </div>
         ) : null}
         <div className="rp-tabs__content">
-          {tabValues.map(({ label, value, content }, index) => {
+          {tabValues.map(({ content }, index) => {
             const isActive = index === currentIndex;
             if (!keepDOM && !isActive) {
               return null;
@@ -201,7 +167,7 @@ export const Tabs = forwardRef(
 
             return (
               <div
-                key={value ?? (typeof label === 'string' ? label : index)}
+                key={index}
                 className={clsx(
                   'rp-tabs__content__item',
                   isActive
@@ -226,7 +192,6 @@ Tabs.displayName = 'Tabs';
 
 export type TabProps = {
   label?: ReactNode;
-  value?: string;
   disabled?: boolean;
   children: ReactNode;
 };

--- a/website/docs/en/ui/components/tabs.mdx
+++ b/website/docs/en/ui/components/tabs.mdx
@@ -65,34 +65,48 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 Use `values` to define tab labels separately from panel content. Each item can provide a `value`, and the matching `<Tab value="...">` supplies the content.
 
-````mdx title="index.mdx" preview
-import { Tab, Tabs } from '@rspress/core/theme';
+```mdx title="index.mdx" preview
+import {
+  IconGithub,
+  IconGitlab,
+  SvgWrapper,
+  Tab,
+  Tabs,
+} from '@rspress/core/theme';
+
+const labelStyle = { display: 'inline-flex', alignItems: 'center', gap: 6 };
 
 <Tabs
-  defaultValue="ttml"
+  defaultValue="github"
   values={[
-    { label: <span>index.ttml</span>, value: 'ttml' },
-    { label: <span>index.js</span>, value: 'subscribe' },
+    {
+      label: (
+        <span style={labelStyle}>
+          <SvgWrapper icon={IconGithub} width={16} height={16} />
+          GitHub
+        </span>
+      ),
+      value: 'github',
+    },
+    {
+      label: (
+        <span style={labelStyle}>
+          <SvgWrapper icon={IconGitlab} width={16} height={16} />
+          GitLab
+        </span>
+      ),
+      value: 'gitlab',
+    },
   ]}
 >
-<Tab value="ttml">
+<Tab value="github">
 
-```ts
-// index.ttml
-const template = 'content ttml';
-```
+GitHub repository settings
 
 </Tab>
-<Tab value="subscribe">
-
-```js
-// index.js
-const subscribe = 'content subscribe';
-```
-
-</Tab>
+<Tab value="gitlab">GitLab project settings</Tab>
 </Tabs>
-````
+```
 
 ### Props
 

--- a/website/docs/en/ui/components/tabs.mdx
+++ b/website/docs/en/ui/components/tabs.mdx
@@ -63,7 +63,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ### Custom labels
 
-Use `values` to define tab labels separately from panel content. Each item can provide a `value`, and the matching `<Tab value="...">` supplies the content.
+Use `label` on each `Tab` to render custom tab labels.
 
 ```mdx title="index.mdx" preview
 import {
@@ -74,31 +74,27 @@ import {
   Tabs,
 } from '@rspress/core/theme';
 
-<Tabs
-  defaultValue="github"
-  values={[
-    {
-      label: (
-        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
-          <SvgWrapper icon={IconGithub} width={16} height={16} />
-          GitHub
-        </span>
-      ),
-      value: 'github',
-    },
-    {
-      label: (
-        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
-          <SvgWrapper icon={IconGitlab} width={16} height={16} />
-          GitLab
-        </span>
-      ),
-      value: 'gitlab',
-    },
-  ]}
->
-  <Tab value="github">GitHub repository settings</Tab>
-  <Tab value="gitlab">GitLab project settings</Tab>
+<Tabs>
+  <Tab
+    label={
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+        <SvgWrapper icon={IconGithub} width={16} height={16} />
+        GitHub
+      </span>
+    }
+  >
+    GitHub repository settings
+  </Tab>
+  <Tab
+    label={
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+        <SvgWrapper icon={IconGitlab} width={16} height={16} />
+        GitLab
+      </span>
+    }
+  >
+    GitLab project settings
+  </Tab>
 </Tabs>
 ```
 
@@ -107,17 +103,15 @@ import {
 ```ts
 interface TabsProps {
   children: React.ReactNode;
-  values?: Array<{ label: React.ReactNode; value: string }>;
-  defaultValue?: string;
+  defaultIndex?: number;
   groupId?: string;
   tabPosition?: 'left' | 'center';
 }
 
 interface TabProps {
   label?: React.ReactNode;
-  value?: string;
   children: React.ReactNode;
 }
 ```
 
-Use `values` to define labels separately from panel content. `label` accepts any renderable React node, so it can include icons or custom markup. Use `defaultValue` to preselect a tab (matches `value`); `groupId` syncs selection across multiple `Tabs`; `tabPosition` sets list alignment.
+`label` accepts any renderable React node, so it can include icons or custom markup. Use `defaultIndex` to preselect a tab; `groupId` syncs selection across multiple `Tabs`; `tabPosition` sets list alignment.

--- a/website/docs/en/ui/components/tabs.mdx
+++ b/website/docs/en/ui/components/tabs.mdx
@@ -97,12 +97,8 @@ import {
     },
   ]}
 >
-<Tab value="github">
-
-GitHub repository settings
-
-</Tab>
-<Tab value="gitlab">GitLab project settings</Tab>
+  <Tab value="github">GitHub repository settings</Tab>
+  <Tab value="gitlab">GitLab project settings</Tab>
 </Tabs>
 ```
 

--- a/website/docs/en/ui/components/tabs.mdx
+++ b/website/docs/en/ui/components/tabs.mdx
@@ -43,21 +43,73 @@ const bar = require('bar');
 </Tabs>
 ````
 
+### Group synchronization
+
+Use the same `groupId` to synchronize the active tab across multiple `Tabs`.
+
+```mdx title="index.mdx" preview
+import { Tab, Tabs } from '@rspress/core/theme';
+
+<Tabs groupId="package-manager">
+  <Tab label="npm">npm install rspress</Tab>
+  <Tab label="pnpm">pnpm add rspress</Tab>
+</Tabs>
+
+<Tabs groupId="package-manager">
+  <Tab label="npm">npm run dev</Tab>
+  <Tab label="pnpm">pnpm dev</Tab>
+</Tabs>
+```
+
+### Custom labels
+
+Use `values` to define tab labels separately from panel content. Each item can provide a `value`, and the matching `<Tab value="...">` supplies the content.
+
+````mdx title="index.mdx" preview
+import { Tab, Tabs } from '@rspress/core/theme';
+
+<Tabs
+  defaultValue="ttml"
+  values={[
+    { label: <span>index.ttml</span>, value: 'ttml' },
+    { label: <span>index.js</span>, value: 'subscribe' },
+  ]}
+>
+<Tab value="ttml">
+
+```ts
+// index.ttml
+const template = 'content ttml';
+```
+
+</Tab>
+<Tab value="subscribe">
+
+```js
+// index.js
+const subscribe = 'content subscribe';
+```
+
+</Tab>
+</Tabs>
+````
+
 ### Props
 
 ```ts
 interface TabsProps {
   children: React.ReactNode;
+  values?: Array<React.ReactNode | { label: React.ReactNode; value: string }>;
   defaultValue?: string;
   groupId?: string;
   tabPosition?: 'left' | 'center';
 }
 
 interface TabProps {
-  label: string;
+  label?: React.ReactNode;
   value?: string;
   children: React.ReactNode;
 }
 ```
 
-Use `defaultValue` to preselect a tab (matches `value`); `groupId` syncs selection across multiple `Tabs`; `tabPosition` sets list alignment.
+Use `values` to define labels separately from panel content. `label` accepts any renderable React node, so it can include icons or custom markup. Use `defaultValue` to preselect a tab (matches `value`); `groupId` syncs selection across multiple `Tabs`; `tabPosition` sets list alignment.

--- a/website/docs/en/ui/components/tabs.mdx
+++ b/website/docs/en/ui/components/tabs.mdx
@@ -74,14 +74,12 @@ import {
   Tabs,
 } from '@rspress/core/theme';
 
-const labelStyle = { display: 'inline-flex', alignItems: 'center', gap: 6 };
-
 <Tabs
   defaultValue="github"
   values={[
     {
       label: (
-        <span style={labelStyle}>
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
           <SvgWrapper icon={IconGithub} width={16} height={16} />
           GitHub
         </span>
@@ -90,7 +88,7 @@ const labelStyle = { display: 'inline-flex', alignItems: 'center', gap: 6 };
     },
     {
       label: (
-        <span style={labelStyle}>
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
           <SvgWrapper icon={IconGitlab} width={16} height={16} />
           GitLab
         </span>

--- a/website/docs/en/ui/components/tabs.mdx
+++ b/website/docs/en/ui/components/tabs.mdx
@@ -18,7 +18,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 </Tabs>
 ```
 
-### Code blocks
+## Code blocks
 
 ````mdx title="index.mdx" preview
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -43,7 +43,7 @@ const bar = require('bar');
 </Tabs>
 ````
 
-### Group synchronization
+## Group synchronization
 
 Use the same `groupId` to synchronize the active tab across multiple `Tabs`.
 
@@ -61,7 +61,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 </Tabs>
 ```
 
-### Custom labels
+## Custom labels
 
 Use `label` on each `Tab` to render custom tab labels.
 
@@ -98,20 +98,44 @@ import {
 </Tabs>
 ```
 
-### Props
+## Separate labels and content
+
+Use `values` to define tab labels separately from panel content. Each item provides a `value`, and the matching `<Tab value="...">` supplies the content. Use `defaultValue` to preselect a tab by `value`.
+
+```mdx title="index.mdx" preview
+import { Tab, Tabs } from '@rspress/core/theme';
+
+<Tabs
+  defaultValue="apple"
+  values={[
+    { label: 'Apple', value: 'apple' },
+    { label: 'Orange', value: 'orange' },
+    { label: 'Banana', value: 'banana' },
+  ]}
+>
+  <Tab value="apple">This is an apple 🍎</Tab>
+  <Tab value="orange">This is an orange 🍊</Tab>
+  <Tab value="banana">This is a banana 🍌</Tab>
+</Tabs>
+```
+
+## Props
 
 ```ts
 interface TabsProps {
   children: React.ReactNode;
+  values?: Array<{ label: React.ReactNode; value: string }>;
   defaultIndex?: number;
+  defaultValue?: string;
   groupId?: string;
   tabPosition?: 'left' | 'center';
 }
 
 interface TabProps {
   label?: React.ReactNode;
+  value?: string;
   children: React.ReactNode;
 }
 ```
 
-`label` accepts any renderable React node, so it can include icons or custom markup. Use `defaultIndex` to preselect a tab; `groupId` syncs selection across multiple `Tabs`; `tabPosition` sets list alignment.
+`label` accepts any renderable React node, so it can include icons or custom markup. Use `defaultIndex` to preselect a tab by index, or `defaultValue` to preselect a tab by `value`; `groupId` syncs selection across multiple `Tabs`; `tabPosition` sets list alignment.

--- a/website/docs/en/ui/components/tabs.mdx
+++ b/website/docs/en/ui/components/tabs.mdx
@@ -107,7 +107,7 @@ import {
 ```ts
 interface TabsProps {
   children: React.ReactNode;
-  values?: Array<React.ReactNode | { label: React.ReactNode; value: string }>;
+  values?: Array<{ label: React.ReactNode; value: string }>;
   defaultValue?: string;
   groupId?: string;
   tabPosition?: 'left' | 'center';

--- a/website/docs/zh/ui/components/tabs.mdx
+++ b/website/docs/zh/ui/components/tabs.mdx
@@ -18,7 +18,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 </Tabs>
 ```
 
-### 代码块
+## 代码块
 
 ````mdx title="index.mdx" preview
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -43,7 +43,7 @@ const bar = require('bar');
 </Tabs>
 ````
 
-### 分组同步
+## 分组同步
 
 使用相同的 `groupId`，可以让多个 `Tabs` 共享当前选中的标签。
 
@@ -61,7 +61,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 </Tabs>
 ```
 
-### 自定义标签
+## 自定义标签
 
 在每个 `Tab` 上使用 `label` 可以渲染自定义标签。
 
@@ -98,20 +98,44 @@ import {
 </Tabs>
 ```
 
-### Props
+## 分离标签和内容
+
+使用 `values` 可以把标签和面板内容分开定义。每一项提供一个 `value`，匹配的 `<Tab value="...">` 会提供对应内容。使用 `defaultValue` 可以按 `value` 预选标签页。
+
+```mdx title="index.mdx" preview
+import { Tab, Tabs } from '@rspress/core/theme';
+
+<Tabs
+  defaultValue="apple"
+  values={[
+    { label: 'Apple', value: 'apple' },
+    { label: 'Orange', value: 'orange' },
+    { label: 'Banana', value: 'banana' },
+  ]}
+>
+  <Tab value="apple">This is an apple 🍎</Tab>
+  <Tab value="orange">This is an orange 🍊</Tab>
+  <Tab value="banana">This is a banana 🍌</Tab>
+</Tabs>
+```
+
+## Props
 
 ```ts
 interface TabsProps {
   children: React.ReactNode;
+  values?: Array<{ label: React.ReactNode; value: string }>;
   defaultIndex?: number;
+  defaultValue?: string;
   groupId?: string;
   tabPosition?: 'left' | 'center';
 }
 
 interface TabProps {
   label?: React.ReactNode;
+  value?: string;
   children: React.ReactNode;
 }
 ```
 
-`label` 支持任意可渲染 React 节点，因此可以放入图标或自定义结构。`defaultIndex` 可设置默认选中的标签；`groupId` 可以让多个 `Tabs` 共享选择状态；`tabPosition` 控制标签列表的对齐方式。
+`label` 支持任意可渲染 React 节点，因此可以放入图标或自定义结构。`defaultIndex` 可按索引设置默认选中的标签，`defaultValue` 可按 `value` 设置默认选中的标签；`groupId` 可以让多个 `Tabs` 共享选择状态；`tabPosition` 控制标签列表的对齐方式。

--- a/website/docs/zh/ui/components/tabs.mdx
+++ b/website/docs/zh/ui/components/tabs.mdx
@@ -63,7 +63,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ### 自定义标签
 
-使用 `values` 可以把标签和面板内容分开定义。每一项都可以提供 `value`，匹配的 `<Tab value="...">` 会提供对应内容。
+在每个 `Tab` 上使用 `label` 可以渲染自定义标签。
 
 ```mdx title="index.mdx" preview
 import {
@@ -74,31 +74,27 @@ import {
   Tabs,
 } from '@rspress/core/theme';
 
-<Tabs
-  defaultValue="github"
-  values={[
-    {
-      label: (
-        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
-          <SvgWrapper icon={IconGithub} width={16} height={16} />
-          GitHub
-        </span>
-      ),
-      value: 'github',
-    },
-    {
-      label: (
-        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
-          <SvgWrapper icon={IconGitlab} width={16} height={16} />
-          GitLab
-        </span>
-      ),
-      value: 'gitlab',
-    },
-  ]}
->
-  <Tab value="github">GitHub 仓库设置</Tab>
-  <Tab value="gitlab">GitLab 项目设置</Tab>
+<Tabs>
+  <Tab
+    label={
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+        <SvgWrapper icon={IconGithub} width={16} height={16} />
+        GitHub
+      </span>
+    }
+  >
+    GitHub 仓库设置
+  </Tab>
+  <Tab
+    label={
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+        <SvgWrapper icon={IconGitlab} width={16} height={16} />
+        GitLab
+      </span>
+    }
+  >
+    GitLab 项目设置
+  </Tab>
 </Tabs>
 ```
 
@@ -107,17 +103,15 @@ import {
 ```ts
 interface TabsProps {
   children: React.ReactNode;
-  values?: Array<{ label: React.ReactNode; value: string }>;
-  defaultValue?: string;
+  defaultIndex?: number;
   groupId?: string;
   tabPosition?: 'left' | 'center';
 }
 
 interface TabProps {
   label?: React.ReactNode;
-  value?: string;
   children: React.ReactNode;
 }
 ```
 
-`values` 可用于把标签和面板内容分开定义。`label` 支持任意可渲染 React 节点，因此可以放入图标或自定义结构。`defaultValue` 可设置默认选中的标签（匹配 `value`）；`groupId` 可以让多个 `Tabs` 共享选择状态；`tabPosition` 控制标签列表的对齐方式。
+`label` 支持任意可渲染 React 节点，因此可以放入图标或自定义结构。`defaultIndex` 可设置默认选中的标签；`groupId` 可以让多个 `Tabs` 共享选择状态；`tabPosition` 控制标签列表的对齐方式。

--- a/website/docs/zh/ui/components/tabs.mdx
+++ b/website/docs/zh/ui/components/tabs.mdx
@@ -65,34 +65,48 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 使用 `values` 可以把标签和面板内容分开定义。每一项都可以提供 `value`，匹配的 `<Tab value="...">` 会提供对应内容。
 
-````mdx title="index.mdx" preview
-import { Tab, Tabs } from '@rspress/core/theme';
+```mdx title="index.mdx" preview
+import {
+  IconGithub,
+  IconGitlab,
+  SvgWrapper,
+  Tab,
+  Tabs,
+} from '@rspress/core/theme';
+
+const labelStyle = { display: 'inline-flex', alignItems: 'center', gap: 6 };
 
 <Tabs
-  defaultValue="ttml"
+  defaultValue="github"
   values={[
-    { label: <span>index.ttml</span>, value: 'ttml' },
-    { label: <span>index.js</span>, value: 'subscribe' },
+    {
+      label: (
+        <span style={labelStyle}>
+          <SvgWrapper icon={IconGithub} width={16} height={16} />
+          GitHub
+        </span>
+      ),
+      value: 'github',
+    },
+    {
+      label: (
+        <span style={labelStyle}>
+          <SvgWrapper icon={IconGitlab} width={16} height={16} />
+          GitLab
+        </span>
+      ),
+      value: 'gitlab',
+    },
   ]}
 >
-<Tab value="ttml">
+<Tab value="github">
 
-```ts
-// index.ttml
-const template = 'content ttml';
-```
+GitHub 仓库设置
 
 </Tab>
-<Tab value="subscribe">
-
-```js
-// index.js
-const subscribe = 'content subscribe';
-```
-
-</Tab>
+<Tab value="gitlab">GitLab 项目设置</Tab>
 </Tabs>
-````
+```
 
 ### Props
 

--- a/website/docs/zh/ui/components/tabs.mdx
+++ b/website/docs/zh/ui/components/tabs.mdx
@@ -43,21 +43,73 @@ const bar = require('bar');
 </Tabs>
 ````
 
+### 分组同步
+
+使用相同的 `groupId`，可以让多个 `Tabs` 共享当前选中的标签。
+
+```mdx title="index.mdx" preview
+import { Tab, Tabs } from '@rspress/core/theme';
+
+<Tabs groupId="package-manager">
+  <Tab label="npm">npm install rspress</Tab>
+  <Tab label="pnpm">pnpm add rspress</Tab>
+</Tabs>
+
+<Tabs groupId="package-manager">
+  <Tab label="npm">npm run dev</Tab>
+  <Tab label="pnpm">pnpm dev</Tab>
+</Tabs>
+```
+
+### 自定义标签
+
+使用 `values` 可以把标签和面板内容分开定义。每一项都可以提供 `value`，匹配的 `<Tab value="...">` 会提供对应内容。
+
+````mdx title="index.mdx" preview
+import { Tab, Tabs } from '@rspress/core/theme';
+
+<Tabs
+  defaultValue="ttml"
+  values={[
+    { label: <span>index.ttml</span>, value: 'ttml' },
+    { label: <span>index.js</span>, value: 'subscribe' },
+  ]}
+>
+<Tab value="ttml">
+
+```ts
+// index.ttml
+const template = 'content ttml';
+```
+
+</Tab>
+<Tab value="subscribe">
+
+```js
+// index.js
+const subscribe = 'content subscribe';
+```
+
+</Tab>
+</Tabs>
+````
+
 ### Props
 
 ```ts
 interface TabsProps {
   children: React.ReactNode;
+  values?: Array<React.ReactNode | { label: React.ReactNode; value: string }>;
   defaultValue?: string;
   groupId?: string;
   tabPosition?: 'left' | 'center';
 }
 
 interface TabProps {
-  label: string;
+  label?: React.ReactNode;
   value?: string;
   children: React.ReactNode;
 }
 ```
 
-`defaultValue` 可设置默认选中的标签（匹配 `value`）；`groupId` 可以让多个 `Tabs` 共享选择状态；`tabPosition` 控制标签列表的对齐方式。
+`values` 可用于把标签和面板内容分开定义。`label` 支持任意可渲染 React 节点，因此可以放入图标或自定义结构。`defaultValue` 可设置默认选中的标签（匹配 `value`）；`groupId` 可以让多个 `Tabs` 共享选择状态；`tabPosition` 控制标签列表的对齐方式。

--- a/website/docs/zh/ui/components/tabs.mdx
+++ b/website/docs/zh/ui/components/tabs.mdx
@@ -97,12 +97,8 @@ import {
     },
   ]}
 >
-<Tab value="github">
-
-GitHub 仓库设置
-
-</Tab>
-<Tab value="gitlab">GitLab 项目设置</Tab>
+  <Tab value="github">GitHub 仓库设置</Tab>
+  <Tab value="gitlab">GitLab 项目设置</Tab>
 </Tabs>
 ```
 

--- a/website/docs/zh/ui/components/tabs.mdx
+++ b/website/docs/zh/ui/components/tabs.mdx
@@ -74,14 +74,12 @@ import {
   Tabs,
 } from '@rspress/core/theme';
 
-const labelStyle = { display: 'inline-flex', alignItems: 'center', gap: 6 };
-
 <Tabs
   defaultValue="github"
   values={[
     {
       label: (
-        <span style={labelStyle}>
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
           <SvgWrapper icon={IconGithub} width={16} height={16} />
           GitHub
         </span>
@@ -90,7 +88,7 @@ const labelStyle = { display: 'inline-flex', alignItems: 'center', gap: 6 };
     },
     {
       label: (
-        <span style={labelStyle}>
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
           <SvgWrapper icon={IconGitlab} width={16} height={16} />
           GitLab
         </span>

--- a/website/docs/zh/ui/components/tabs.mdx
+++ b/website/docs/zh/ui/components/tabs.mdx
@@ -107,7 +107,7 @@ import {
 ```ts
 interface TabsProps {
   children: React.ReactNode;
-  values?: Array<React.ReactNode | { label: React.ReactNode; value: string }>;
+  values?: Array<{ label: React.ReactNode; value: string }>;
   defaultValue?: string;
   groupId?: string;
   tabPosition?: 'left' | 'center';


### PR DESCRIPTION
## Summary

- Add value-backed tab items so `Tabs` values can pair ReactNode labels with matching `<Tab value="...">` content.
- Support `defaultValue` selection by tab value and carry `value`/`disabled` metadata from `Tab` children.
- Cover the values-based usage in the tabs fixture and document `groupId` synchronization plus custom labels in English and Chinese docs.
- Validated with `pnpm exec rslint packages/core/src/theme/components/Tabs/index.tsx e2e/fixtures/tabs-component/index.test.ts`, `pnpm --dir e2e/fixtures/tabs-component build`, and `pnpm build:website`.

## Related Issue

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
