### PR TITLE
chore(deps): harden pnpm install settings

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,14 +7,27 @@ packages:
   - '!**/tests/**'
   - '!packages/create-rspress/template-*'
 
+allowBuilds:
+  nx: false
+  sharp: true
+  simple-git-hooks: false
+
 hoistPattern: []
 
 linkWorkspacePackages: true
 
-onlyBuiltDependencies:
-  - core-js
-  - esbuild
-  - nx
-  - sharp
+# Reduce the risk of installing compromised packages
+minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - '@rspack/*'
+  - '@rsbuild/*'
+  - '@rslib/*'
+  - '@rspress/*'
+  - '@rstest/*'
+  - '@rsdoctor/*'
+  - '@rslint/*'
+
+# Prevent un-reviewed build scripts
+strictDepBuilds: true
 
 strictPeerDependencies: false


### PR DESCRIPTION
## Summary

This PR hardens pnpm install behavior by requiring review for build scripts and delaying installation of newly published packages, while allowing the known Rsbuild/Rspack/Rspress ecosystem packages to resolve without delay.

## Related Issue

None

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).