### PR TITLE
docs: add cleanUrls server support warning

### DIFF
--- a/website/docs/en/api/config/config-basic.mdx
+++ b/website/docs/en/api/config/config-basic.mdx
@@ -643,6 +643,12 @@ export default defineConfig({
 
 Generate url without suffix when `cleanUrls` is `true` for shorter url link.
 
+:::warning Server Support Required
+
+Enabling this may require additional configuration on your hosting platform. For it to work, your server must be able to serve `/foo.html` when visiting `/foo` without a redirect.
+
+:::
+
 ```js
 import { defineConfig } from '@rspress/core';
 

--- a/website/docs/zh/api/config/config-basic.mdx
+++ b/website/docs/zh/api/config/config-basic.mdx
@@ -643,6 +643,12 @@ export default defineConfig({
 
 开启后可以生成无 `.html` 后缀的链接，URL 可以更加简洁。
 
+:::warning 需要服务器支持
+
+启用此选项可能需要在托管平台上进行额外配置。要使其生效，服务器必须能够在访问 `/foo` 时不经过重定向直接提供 `/foo.html`。
+
+:::
+
 ```js title="rspress.config.ts"
 import { defineConfig } from '@rspress/core';
 


### PR DESCRIPTION
## Summary

Add warning callouts to the `route.cleanUrls` docs in English and Chinese to clarify that hosting platforms may need server support for serving `/foo.html` when visiting `/foo` without redirects.

## Related Issue

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).