### PR TITLE
chore(deps): add renovate security preset

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,10 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: ['config:recommended', 'schedule:weekly'],
+  extends: [
+    'config:recommended',
+    'schedule:weekly',
+    'github>rstackjs/renovate:security',
+  ],
   packageRules: [
     // Use chore as semantic commit type for commit messages
     {


### PR DESCRIPTION
## Summary

This PR extends Renovate with the Rstack security preset so Renovate's minimal release age behavior stays aligned with pnpm's minimum release age settings.

Preset reference: https://github.com/rstackjs/renovate#security-preset

## Related Issue

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).