### PR TITLE
fix: `remarkImage` lint compatibility with plain markdown files

### DIFF
--- a/e2e/fixtures/remark-image/doc/index.md
+++ b/e2e/fixtures/remark-image/doc/index.md
@@ -1,0 +1,3 @@
+![existing image](./existing.png)
+
+![dead image](./not-exist.png)

--- a/e2e/fixtures/remark-image/index.test.mjs
+++ b/e2e/fixtures/remark-image/index.test.mjs
@@ -1,0 +1,32 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import test, { expect } from '@playwright/test';
+import { remarkImage } from '@rspress/core';
+import picocolors from 'picocolors';
+import { remark } from 'remark';
+import { lintRule } from 'unified-lint-rule';
+
+import config from './rspress.config.mjs';
+
+const checkDeadImages = lintRule('check-dead-images', (tree, file) => {
+  remarkImage({
+    docDirectory: config.root,
+    remarkImageOptions: config.markdown.image,
+    lint: true,
+  })(tree, file);
+});
+
+test.describe('check dead images', async () => {
+  test('should not throw on unknown MDX nodes and report dead images via remark message', async () => {
+    const filepath = path.resolve(import.meta.dirname, 'doc/index.md');
+    // remark without remark-mdx: would throw "Cannot handle unknown node `mdxjsEsm`"
+    // if remarkImage transforms nodes even in lint mode
+    const { messages } = await remark()
+      .use(checkDeadImages)
+      .process({ path: filepath, value: await fs.readFile(filepath) });
+    expect(messages).toHaveLength(1);
+    expect(messages[0].reason).toBe(
+      `Dead images found:\n  ${picocolors.green(`"![..](./not-exist.png)"`)} ${picocolors.gray(path.resolve(import.meta.dirname, 'doc/not-exist.png'))}`,
+    );
+  });
+});

--- a/e2e/fixtures/remark-image/index.test.mjs
+++ b/e2e/fixtures/remark-image/index.test.mjs
@@ -4,6 +4,7 @@ import test, { expect } from '@playwright/test';
 import { remarkImage } from '@rspress/core';
 import picocolors from 'picocolors';
 import { remark } from 'remark';
+import remarkStringify from 'remark-stringify';
 import { lintRule } from 'unified-lint-rule';
 
 import config from './rspress.config.mjs';
@@ -23,6 +24,7 @@ test.describe('check dead images', async () => {
     // if remarkImage transforms nodes even in lint mode
     const { messages } = await remark()
       .use(checkDeadImages)
+      .use(remarkStringify)
       .process({ path: filepath, value: await fs.readFile(filepath) });
     expect(messages).toHaveLength(1);
     expect(messages[0].reason).toBe(

--- a/e2e/fixtures/remark-image/package.json
+++ b/e2e/fixtures/remark-image/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@rspress-fixture/remark-image",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rspress build",
+    "dev": "rspress dev",
+    "preview": "rspress preview"
+  },
+  "dependencies": {
+    "@rspress/core": "workspace:*"
+  },
+  "devDependencies": {
+    "picocolors": "^1.1.1",
+    "remark": "^15.0.1",
+    "unified-lint-rule": "^3.0.1"
+  }
+}

--- a/e2e/fixtures/remark-image/package.json
+++ b/e2e/fixtures/remark-image/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "picocolors": "^1.1.1",
     "remark": "^15.0.1",
+    "remark-stringify": "^11.0.0",
     "unified-lint-rule": "^3.0.1"
   }
 }

--- a/e2e/fixtures/remark-image/rspress.config.mjs
+++ b/e2e/fixtures/remark-image/rspress.config.mjs
@@ -1,0 +1,11 @@
+import * as path from 'node:path';
+import { defineConfig } from '@rspress/core';
+
+export default defineConfig({
+  root: path.join(import.meta.dirname, 'doc'),
+  markdown: {
+    image: {
+      checkDeadImages: true,
+    },
+  },
+});

--- a/packages/core/src/node/mdx/remarkPlugins/image.ts
+++ b/packages/core/src/node/mdx/remarkPlugins/image.ts
@@ -107,22 +107,41 @@ export const remarkImage =
   }: {
     docDirectory: string;
     remarkImageOptions?: MarkdownOptions['image'];
-    /**
-     * When true, skip transforming image nodes into MDX-specific AST nodes
-     * (mdxJsxFlowElement, mdxjsEsm). Use this when the output will be
-     * serialized back to Markdown (e.g. remark-stringify) rather than
-     * compiled as MDX, to avoid "Cannot handle unknown node" errors from
-     * mdast-util-to-markdown.
-     */
     lint?: boolean;
   }) =>
   (tree: Root, file: VFile) => {
     const { checkDeadImages: shouldCheckDeadImages = true } =
       remarkImageOptions ?? {};
     const deadImages = new Map<string, string>();
+    const images: MdxjsEsm[] = [];
+    const getMdxSrcAttribute = (tempVar: string) => {
+      return {
+        type: 'mdxJsxAttribute',
+        name: 'src',
+        value: {
+          type: 'mdxJsxAttributeValueExpression',
+          value: tempVar,
+          data: {
+            estree: {
+              type: 'Program',
+              sourceType: 'module',
+              body: [
+                {
+                  type: 'ExpressionStatement',
+                  expression: {
+                    type: 'Identifier',
+                    name: tempVar,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      };
+    };
 
     visit(tree, 'image', node => {
-      const { url } = node;
+      const { alt, url } = node;
       if (!url) {
         return;
       }
@@ -130,101 +149,69 @@ export const remarkImage =
       if (shouldCheckDeadImages) {
         resolveImage(url, file.path, docDirectory, deadImages);
       }
+
+      if (lint) {
+        return;
+      }
+
+      const imagePath = normalizeImageUrl(url);
+      if (!imagePath) {
+        return;
+      }
+      // relative path
+      const tempVariableName = `image${images.length}`;
+
+      Object.assign(node, {
+        type: 'mdxJsxFlowElement',
+        name: 'img',
+        children: [],
+        attributes: [
+          alt && {
+            type: 'mdxJsxAttribute',
+            name: 'alt',
+            value: alt,
+          },
+          getMdxSrcAttribute(tempVariableName),
+        ].filter(Boolean),
+      });
+
+      images.push(getDefaultImportAstNode(tempVariableName, imagePath));
     });
 
-    if (!lint) {
-      const images: MdxjsEsm[] = [];
-      const getMdxSrcAttribute = (tempVar: string) => {
-        return {
-          type: 'mdxJsxAttribute',
-          name: 'src',
-          value: {
-            type: 'mdxJsxAttributeValueExpression',
-            value: tempVar,
-            data: {
-              estree: {
-                type: 'Program',
-                sourceType: 'module',
-                body: [
-                  {
-                    type: 'ExpressionStatement',
-                    expression: {
-                      type: 'Identifier',
-                      name: tempVar,
-                    },
-                  },
-                ],
-              },
-            },
-          },
-        };
-      };
+    visit(tree, node => {
+      if (
+        (node.type !== 'mdxJsxFlowElement' &&
+          node.type !== 'mdxJsxTextElement') ||
+        // get all img src
+        node.name !== 'img'
+      ) {
+        return;
+      }
 
-      visit(tree, 'image', node => {
-        const { alt, url } = node;
-        if (!url) {
-          return;
-        }
+      const srcAttr = getNodeAttribute(node, 'src', true);
 
-        const imagePath = normalizeImageUrl(url);
-        if (!imagePath) {
-          return;
-        }
-        // relative path
-        const tempVariableName = `image${images.length}`;
+      if (typeof srcAttr?.value !== 'string') {
+        return;
+      }
 
-        Object.assign(node, {
-          type: 'mdxJsxFlowElement',
-          name: 'img',
-          children: [],
-          attributes: [
-            alt && {
-              type: 'mdxJsxAttribute',
-              name: 'alt',
-              value: alt,
-            },
-            getMdxSrcAttribute(tempVariableName),
-          ].filter(Boolean),
-        });
+      if (shouldCheckDeadImages) {
+        resolveImage(srcAttr.value, file.path, docDirectory, deadImages);
+      }
 
-        images.push(getDefaultImportAstNode(tempVariableName, imagePath));
-      });
+      const imagePath = normalizeImageUrl(srcAttr.value);
 
-      visit(tree, node => {
-        if (
-          (node.type !== 'mdxJsxFlowElement' &&
-            node.type !== 'mdxJsxTextElement') ||
-          // get all img src
-          node.name !== 'img'
-        ) {
-          return;
-        }
+      if (!imagePath) {
+        return;
+      }
 
-        const srcAttr = getNodeAttribute(node, 'src', true);
+      const tempVariableName = `image${images.length}`;
 
-        if (typeof srcAttr?.value !== 'string') {
-          return;
-        }
+      Object.assign(srcAttr, getMdxSrcAttribute(tempVariableName));
 
-        if (shouldCheckDeadImages) {
-          resolveImage(srcAttr.value, file.path, docDirectory, deadImages);
-        }
+      images.push(getDefaultImportAstNode(tempVariableName, imagePath));
+    });
 
-        const imagePath = normalizeImageUrl(srcAttr.value);
-
-        if (!imagePath) {
-          return;
-        }
-
-        const tempVariableName = `image${images.length}`;
-
-        Object.assign(srcAttr, getMdxSrcAttribute(tempVariableName));
-
-        images.push(getDefaultImportAstNode(tempVariableName, imagePath));
-      });
-
-      tree.children.unshift(...images);
-    }
+    tree.children.unshift(...images);
 
     if (shouldCheckDeadImages) {
       checkDeadImages(shouldCheckDeadImages, deadImages, file, lint);

--- a/packages/core/src/node/mdx/remarkPlugins/image.ts
+++ b/packages/core/src/node/mdx/remarkPlugins/image.ts
@@ -107,41 +107,22 @@ export const remarkImage =
   }: {
     docDirectory: string;
     remarkImageOptions?: MarkdownOptions['image'];
+    /**
+     * When true, skip transforming image nodes into MDX-specific AST nodes
+     * (mdxJsxFlowElement, mdxjsEsm). Use this when the output will be
+     * serialized back to Markdown (e.g. remark-stringify) rather than
+     * compiled as MDX, to avoid "Cannot handle unknown node" errors from
+     * mdast-util-to-markdown.
+     */
     lint?: boolean;
   }) =>
   (tree: Root, file: VFile) => {
     const { checkDeadImages: shouldCheckDeadImages = true } =
       remarkImageOptions ?? {};
     const deadImages = new Map<string, string>();
-    const images: MdxjsEsm[] = [];
-    const getMdxSrcAttribute = (tempVar: string) => {
-      return {
-        type: 'mdxJsxAttribute',
-        name: 'src',
-        value: {
-          type: 'mdxJsxAttributeValueExpression',
-          value: tempVar,
-          data: {
-            estree: {
-              type: 'Program',
-              sourceType: 'module',
-              body: [
-                {
-                  type: 'ExpressionStatement',
-                  expression: {
-                    type: 'Identifier',
-                    name: tempVar,
-                  },
-                },
-              ],
-            },
-          },
-        },
-      };
-    };
 
     visit(tree, 'image', node => {
-      const { alt, url } = node;
+      const { url } = node;
       if (!url) {
         return;
       }
@@ -149,65 +130,101 @@ export const remarkImage =
       if (shouldCheckDeadImages) {
         resolveImage(url, file.path, docDirectory, deadImages);
       }
+    });
 
-      const imagePath = normalizeImageUrl(url);
-      if (!imagePath) {
-        return;
-      }
-      // relative path
-      const tempVariableName = `image${images.length}`;
-
-      Object.assign(node, {
-        type: 'mdxJsxFlowElement',
-        name: 'img',
-        children: [],
-        attributes: [
-          alt && {
-            type: 'mdxJsxAttribute',
-            name: 'alt',
-            value: alt,
+    if (!lint) {
+      const images: MdxjsEsm[] = [];
+      const getMdxSrcAttribute = (tempVar: string) => {
+        return {
+          type: 'mdxJsxAttribute',
+          name: 'src',
+          value: {
+            type: 'mdxJsxAttributeValueExpression',
+            value: tempVar,
+            data: {
+              estree: {
+                type: 'Program',
+                sourceType: 'module',
+                body: [
+                  {
+                    type: 'ExpressionStatement',
+                    expression: {
+                      type: 'Identifier',
+                      name: tempVar,
+                    },
+                  },
+                ],
+              },
+            },
           },
-          getMdxSrcAttribute(tempVariableName),
-        ].filter(Boolean),
+        };
+      };
+
+      visit(tree, 'image', node => {
+        const { alt, url } = node;
+        if (!url) {
+          return;
+        }
+
+        const imagePath = normalizeImageUrl(url);
+        if (!imagePath) {
+          return;
+        }
+        // relative path
+        const tempVariableName = `image${images.length}`;
+
+        Object.assign(node, {
+          type: 'mdxJsxFlowElement',
+          name: 'img',
+          children: [],
+          attributes: [
+            alt && {
+              type: 'mdxJsxAttribute',
+              name: 'alt',
+              value: alt,
+            },
+            getMdxSrcAttribute(tempVariableName),
+          ].filter(Boolean),
+        });
+
+        images.push(getDefaultImportAstNode(tempVariableName, imagePath));
       });
 
-      images.push(getDefaultImportAstNode(tempVariableName, imagePath));
-    });
+      visit(tree, node => {
+        if (
+          (node.type !== 'mdxJsxFlowElement' &&
+            node.type !== 'mdxJsxTextElement') ||
+          // get all img src
+          node.name !== 'img'
+        ) {
+          return;
+        }
 
-    visit(tree, node => {
-      if (
-        (node.type !== 'mdxJsxFlowElement' &&
-          node.type !== 'mdxJsxTextElement') ||
-        // get all img src
-        node.name !== 'img'
-      ) {
-        return;
-      }
+        const srcAttr = getNodeAttribute(node, 'src', true);
 
-      const srcAttr = getNodeAttribute(node, 'src', true);
+        if (typeof srcAttr?.value !== 'string') {
+          return;
+        }
 
-      if (typeof srcAttr?.value !== 'string') {
-        return;
-      }
+        if (shouldCheckDeadImages) {
+          resolveImage(srcAttr.value, file.path, docDirectory, deadImages);
+        }
 
-      if (shouldCheckDeadImages) {
-        resolveImage(srcAttr.value, file.path, docDirectory, deadImages);
-      }
+        const imagePath = normalizeImageUrl(srcAttr.value);
 
-      const imagePath = normalizeImageUrl(srcAttr.value);
+        if (!imagePath) {
+          return;
+        }
 
-      if (!imagePath) {
-        return;
-      }
+        const tempVariableName = `image${images.length}`;
 
-      const tempVariableName = `image${images.length}`;
+        Object.assign(srcAttr, getMdxSrcAttribute(tempVariableName));
 
-      Object.assign(srcAttr, getMdxSrcAttribute(tempVariableName));
+        images.push(getDefaultImportAstNode(tempVariableName, imagePath));
+      });
 
-      images.push(getDefaultImportAstNode(tempVariableName, imagePath));
-    });
-
-    tree.children.unshift(...images);
+      tree.children.unshift(...images);
+    }
 
     if (shouldCheckDeadImages) {
       checkDeadImages(shouldCheckDeadImages, deadImages, file, lint);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -762,6 +762,9 @@ importers:
       remark:
         specifier: ^15.0.1
         version: 15.0.1
+      remark-stringify:
+        specifier: ^11.0.0
+        version: 11.0.0
       unified-lint-rule:
         specifier: ^3.0.1
         version: 3.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -750,6 +750,22 @@ importers:
         specifier: ^22.8.1
         version: 22.19.15
 
+  e2e/fixtures/remark-image:
+    dependencies:
+      '@rspress/core':
+        specifier: workspace:*
+        version: link:../../../packages/core
+    devDependencies:
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+      remark:
+        specifier: ^15.0.1
+        version: 15.0.1
+      unified-lint-rule:
+        specifier: ^3.0.1
+        version: 3.0.1
+
   e2e/fixtures/remark-link:
     dependencies:
       '@rspress/core':


### PR DESCRIPTION
## Summary

`remarkImage` lint compatibility with plain markdown files

## Related Issue

<!--- Provide link of related issues -->

close #3387

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
