### PR TITLE
feat(theme/lastUpdated): support displaying `lastUpdated.author`

### DIFF
--- a/packages/core/src/node/PluginDriver.ts
+++ b/packages/core/src/node/PluginDriver.ts
@@ -68,7 +68,7 @@ export class PluginDriver {
     const mediumZoomConfig = config?.mediumZoom ?? true;
     if (enableLastUpdated) {
       const { pluginLastUpdated } = await import('./last-updated/index');
-      this.addPlugin(pluginLastUpdated());
+      this.addPlugin(pluginLastUpdated(themeConfig?.lastUpdatedAuthor));
     }
     if (mediumZoomConfig) {
       const { pluginMediumZoom } = await import('./medium-zoom/index');

--- a/packages/core/src/node/PluginDriver.ts
+++ b/packages/core/src/node/PluginDriver.ts
@@ -64,11 +64,17 @@ export class PluginDriver {
     this.clearPlugins();
     const config = this.#config;
     const themeConfig = config?.themeConfig || {};
-    const enableLastUpdated = themeConfig?.lastUpdated;
+    const lastUpdatedConfig = themeConfig?.lastUpdated;
     const mediumZoomConfig = config?.mediumZoom ?? true;
-    if (enableLastUpdated) {
+    if (lastUpdatedConfig) {
       const { pluginLastUpdated } = await import('./last-updated/index');
-      this.addPlugin(pluginLastUpdated(themeConfig?.lastUpdatedAuthor));
+      this.addPlugin(
+        pluginLastUpdated(
+          typeof lastUpdatedConfig === 'object'
+            ? lastUpdatedConfig.author
+            : false,
+        ),
+      );
     }
     if (mediumZoomConfig) {
       const { pluginMediumZoom } = await import('./medium-zoom/index');

--- a/packages/core/src/node/last-updated/index.test.ts
+++ b/packages/core/src/node/last-updated/index.test.ts
@@ -63,6 +63,7 @@ describe('pluginLastUpdated', () => {
       'log',
       '-1',
       '--format=%at%n%an%n%ae',
+      '--',
       'docs/index.mdx',
     ]);
   });

--- a/packages/core/src/node/last-updated/index.test.ts
+++ b/packages/core/src/node/last-updated/index.test.ts
@@ -1,0 +1,69 @@
+import type { PageIndexInfo } from '@rspress/shared';
+import { beforeEach, describe, expect, it, rs } from '@rstest/core';
+import { execa } from 'execa';
+import { pluginLastUpdated } from './index';
+
+rs.mock('execa', () => ({
+  execa: rs.fn(async () => ({
+    stdout: '100\nAlice\nalice@example.com',
+  })),
+}));
+
+type TestPageIndexInfo = PageIndexInfo & {
+  lastUpdatedTime?: string;
+  lastUpdatedAuthor?: string;
+};
+
+const pageData = (): TestPageIndexInfo =>
+  ({
+    _filepath: 'docs/index.mdx',
+    lang: 'en',
+  }) as TestPageIndexInfo;
+
+describe('pluginLastUpdated', () => {
+  beforeEach(() => {
+    rs.clearAllMocks();
+  });
+
+  it('should only add last updated time by default', async () => {
+    const data = pageData();
+
+    await pluginLastUpdated().extendPageData?.(data, true);
+
+    expect(data.lastUpdatedTime).toBe(new Date(100000).toLocaleString('en'));
+    expect(data.lastUpdatedAuthor).toBeUndefined();
+  });
+
+  it('should add author name when author is enabled', async () => {
+    const data = pageData();
+
+    await pluginLastUpdated(true).extendPageData?.(data, true);
+
+    expect(data.lastUpdatedAuthor).toBe('Alice');
+  });
+
+  it('should support custom author display text', async () => {
+    const data = pageData();
+
+    await pluginLastUpdated(({ name, email, filePath }) => {
+      return `${name} <${email}> ${filePath}`;
+    }).extendPageData?.(data, true);
+
+    expect(data.lastUpdatedAuthor).toBe(
+      'Alice <alice@example.com> docs/index.mdx',
+    );
+  });
+
+  it('should pass file path to git log', async () => {
+    const data = pageData();
+
+    await pluginLastUpdated().extendPageData?.(data, true);
+
+    expect(execa).toHaveBeenCalledWith('git', [
+      'log',
+      '-1',
+      '--format=%at%n%an%n%ae',
+      'docs/index.mdx',
+    ]);
+  });
+});

--- a/packages/core/src/node/last-updated/index.ts
+++ b/packages/core/src/node/last-updated/index.ts
@@ -1,40 +1,66 @@
 import type { RspressPlugin } from '@rspress/shared';
 import { execa } from 'execa';
 
+type LastUpdatedAuthorOption =
+  | boolean
+  | ((info: { name: string; email: string; filePath: string }) => string);
+
 function transform(timestamp: number, lang: string) {
   return new Date(timestamp).toLocaleString(lang || 'zh');
 }
 
-async function getGitLastUpdatedTimeStamp(filePath: string) {
-  let lastUpdated;
+interface GitInfo {
+  timestamp: number;
+  authorName: string;
+  authorEmail: string;
+}
+
+async function getGitInfo(filePath: string): Promise<GitInfo | undefined> {
   try {
     const { stdout } = await execa('git', [
       'log',
       '-1',
-      '--format=%at',
+      '--format=%at%n%an%n%ae',
       filePath,
     ]);
-    lastUpdated = Number(stdout) * 1000;
+    const [at, an, ae] = stdout.split('\n');
+    if (!at) return undefined;
+    return {
+      timestamp: Number(at) * 1000,
+      authorName: an ?? '',
+      authorEmail: ae ?? '',
+    };
   } catch (_e) {
-    /* noop */
+    return undefined;
   }
-  return lastUpdated;
 }
 
 /**
- * The plugin is used to add the last updated time to the page.
+ * The plugin is used to add the last updated time and author to the page.
  */
-export function pluginLastUpdated(): RspressPlugin {
+export function pluginLastUpdated(
+  authorOption: LastUpdatedAuthorOption = true,
+): RspressPlugin {
   return {
     name: '@rspress/plugin-last-updated',
     async extendPageData(pageData) {
       const { _filepath, lang } = pageData;
-      const lastUpdated = await getGitLastUpdatedTimeStamp(_filepath);
-      if (lastUpdated) {
-        // Property 'lastUpdatedTime' does not exist on type 'PageIndexInfo'.
-        // @ts-expect-error
-        pageData.lastUpdatedTime = transform(lastUpdated, lang);
-      }
+      const info = await getGitInfo(_filepath);
+      if (!info) return;
+      // Property does not exist on type 'PageIndexInfo'.
+      // @ts-expect-error
+      pageData.lastUpdatedTime = transform(info.timestamp, lang);
+      if (authorOption === false) return;
+      const display =
+        typeof authorOption === 'function'
+          ? authorOption({
+              name: info.authorName,
+              email: info.authorEmail,
+              filePath: _filepath,
+            })
+          : info.authorName;
+      // @ts-expect-error see types/index.ts
+      pageData.lastUpdatedAuthor = display;
     },
   };
 }

--- a/packages/core/src/node/last-updated/index.ts
+++ b/packages/core/src/node/last-updated/index.ts
@@ -39,7 +39,7 @@ async function getGitInfo(filePath: string): Promise<GitInfo | undefined> {
  * The plugin is used to add the last updated time and author to the page.
  */
 export function pluginLastUpdated(
-  authorOption: LastUpdatedAuthorOption = true,
+  authorOption: LastUpdatedAuthorOption = false,
 ): RspressPlugin {
   return {
     name: '@rspress/plugin-last-updated',

--- a/packages/core/src/node/last-updated/index.ts
+++ b/packages/core/src/node/last-updated/index.ts
@@ -1,9 +1,5 @@
-import type { RspressPlugin } from '@rspress/shared';
+import type { LastUpdatedAuthor, RspressPlugin } from '@rspress/shared';
 import { execa } from 'execa';
-
-type LastUpdatedAuthorOption =
-  | boolean
-  | ((info: { name: string; email: string; filePath: string }) => string);
 
 function transform(timestamp: number, lang: string) {
   return new Date(timestamp).toLocaleString(lang || 'zh');
@@ -21,6 +17,7 @@ async function getGitInfo(filePath: string): Promise<GitInfo | undefined> {
       'log',
       '-1',
       '--format=%at%n%an%n%ae',
+      '--',
       filePath,
     ]);
     const [at, an, ae] = stdout.split('\n');
@@ -39,7 +36,7 @@ async function getGitInfo(filePath: string): Promise<GitInfo | undefined> {
  * The plugin is used to add the last updated time and author to the page.
  */
 export function pluginLastUpdated(
-  authorOption: LastUpdatedAuthorOption = false,
+  authorOption: LastUpdatedAuthor = false,
 ): RspressPlugin {
   return {
     name: '@rspress/plugin-last-updated',

--- a/packages/core/src/node/runtimeModule/DEFAULT_I18N_TEXT.ts
+++ b/packages/core/src/node/runtimeModule/DEFAULT_I18N_TEXT.ts
@@ -51,6 +51,13 @@ export const DEFAULT_I18N_TEXT = {
     ko: '업데이트 날짜',
     ru: 'Последнее обновление',
   },
+  lastUpdatedAuthorText: {
+    en: 'by',
+    zh: '作者',
+    ja: '更新者',
+    ko: '작성자',
+    ru: 'автор',
+  },
   prevPageText: {
     en: 'Previous page',
     zh: '上一页',

--- a/packages/core/src/node/runtimeModule/siteData/normalizeThemeConfig.test.ts
+++ b/packages/core/src/node/runtimeModule/siteData/normalizeThemeConfig.test.ts
@@ -1,0 +1,25 @@
+import type { UserConfig } from '@rspress/shared';
+import { describe, expect, it } from '@rstest/core';
+import { normalizeThemeConfig } from './normalizeThemeConfig';
+
+describe('normalizeThemeConfig', () => {
+  it('should normalize lastUpdated author callback for runtime site data', async () => {
+    const author = ({ name }: { name: string }) => name;
+    const config: UserConfig = {
+      themeConfig: {
+        lastUpdated: {
+          author,
+        },
+      },
+    };
+
+    const themeConfig = await normalizeThemeConfig(config);
+
+    expect(themeConfig.lastUpdated).toEqual({
+      author: true,
+    });
+    expect(
+      typeof (config.themeConfig?.lastUpdated as { author: unknown }).author,
+    ).toBe('function');
+  });
+});

--- a/packages/core/src/node/runtimeModule/siteData/normalizeThemeConfig.ts
+++ b/packages/core/src/node/runtimeModule/siteData/normalizeThemeConfig.ts
@@ -4,6 +4,7 @@ import {
   isExternalUrl,
   type NavItem,
   type NormalizedDefaultThemeConfig,
+  type NormalizedLastUpdated,
   type NormalizedSidebarGroup,
   normalizeHref,
   type Sidebar,
@@ -64,6 +65,20 @@ export async function normalizeThemeConfig(
 
   const textReplace = (text: string, currentLang: string) => {
     return applyReplaceRules(getI18nText(text, currentLang), replaceRules);
+  };
+
+  const normalizeLastUpdated = (
+    lastUpdated: DefaultThemeConfig['lastUpdated'],
+  ): NormalizedLastUpdated | undefined => {
+    if (typeof lastUpdated !== 'object' || lastUpdated === null) {
+      return lastUpdated;
+    }
+
+    return {
+      ...lastUpdated,
+      author:
+        typeof lastUpdated.author === 'function' ? true : lastUpdated.author,
+    };
   };
 
   // Normalize sidebar
@@ -206,5 +221,8 @@ export async function normalizeThemeConfig(
     themeConfig.sidebar = normalizeSidebar(themeConfig?.sidebar, '');
     themeConfig.nav = normalizeNav(themeConfig?.nav, '');
   }
-  return themeConfig as NormalizedDefaultThemeConfig;
+  return {
+    ...themeConfig,
+    lastUpdated: normalizeLastUpdated(themeConfig.lastUpdated),
+  } as NormalizedDefaultThemeConfig;
 }

--- a/packages/core/src/theme/components/LastUpdated/index.tsx
+++ b/packages/core/src/theme/components/LastUpdated/index.tsx
@@ -3,7 +3,7 @@ import './index.scss';
 
 export function LastUpdated() {
   const {
-    page: { lastUpdatedTime },
+    page: { lastUpdatedTime, lastUpdatedAuthor },
   } = usePage();
   const { site } = useSite();
   const { themeConfig } = site;
@@ -11,7 +11,7 @@ export function LastUpdated() {
 
   const t = useI18n();
 
-  if (!showLastUpdated) {
+  if (!showLastUpdated || !lastUpdatedTime) {
     return null;
   }
 
@@ -19,6 +19,12 @@ export function LastUpdated() {
     <div className="rp-last-updated">
       <p>
         {t('lastUpdatedText')}: <span>{lastUpdatedTime}</span>
+        {lastUpdatedAuthor && (
+          <>
+            {' '}
+            {t('lastUpdatedAuthorText')} <span>{lastUpdatedAuthor}</span>
+          </>
+        )}
       </p>
     </div>
   );

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -340,6 +340,7 @@ export interface PageDataLegacy {
     headingTitle?: string;
     pagePath: string;
     lastUpdatedTime?: string;
+    lastUpdatedAuthor?: string;
     description?: string;
     pageType: PageType;
     [key: string]: unknown;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -15,8 +15,11 @@ export type { I18nText } from './theme/i18nText';
 export type {
   EditLink,
   Footer,
+  LastUpdated,
+  LastUpdatedAuthor,
   LlmsUI,
   LlmsViewOption,
+  NormalizedLastUpdated,
   NormalizedLocales,
   NormalizedThemeConfig,
   ThemeConfig,

--- a/packages/shared/src/types/theme/i18nText.ts
+++ b/packages/shared/src/types/theme/i18nText.ts
@@ -21,6 +21,7 @@ export interface I18nText {
 
   // docFooter
   lastUpdatedText?: I18nTextValue;
+  lastUpdatedAuthorText?: I18nTextValue;
   prevPageText?: I18nTextValue;
   nextPageText?: I18nTextValue;
   editLinkText?: I18nTextValue;

--- a/packages/shared/src/types/theme/index.ts
+++ b/packages/shared/src/types/theme/index.ts
@@ -61,6 +61,23 @@ export interface Footer {
   message?: string;
 }
 
+export type LastUpdatedAuthor =
+  | boolean
+  | ((info: { name: string; email: string; filePath: string }) => string);
+
+export type LastUpdated =
+  | boolean
+  | {
+      /**
+       * Whether to display the last author of the file (from git log).
+       * - `false`: hide the author.
+       * - `true`: show the commit author's name.
+       * - function: receives `{ name, email, filePath }` and returns the display string.
+       * @default false
+       */
+      author?: LastUpdatedAuthor;
+    };
+
 export type ThemeConfig = {
   /**
    * Whether to enable dark mode.
@@ -83,20 +100,10 @@ export type ThemeConfig = {
   editLink?: EditLink;
   /**
    * Whether to display the last update time of the file.
+   * Set `author` to show the last commit author.
    * @default false
    */
-  lastUpdated?: boolean;
-  /**
-   * Whether to display the last author of the file (from git log).
-   * Only effective when `lastUpdated` is enabled.
-   * - `false`: hide the author.
-   * - `true` (default when `lastUpdated` is on): show the commit author's name.
-   * - function: receives `{ name, email, filePath }` and returns the display string.
-   * @default true
-   */
-  lastUpdatedAuthor?:
-    | boolean
-    | ((info: { name: string; email: string; filePath: string }) => string);
+  lastUpdated?: LastUpdated;
   /**
    * The social links to be displayed at the end of the nav bar. Perfect for
    * placing links to social services such as GitHub, X, Facebook, etc.

--- a/packages/shared/src/types/theme/index.ts
+++ b/packages/shared/src/types/theme/index.ts
@@ -87,6 +87,17 @@ export type ThemeConfig = {
    */
   lastUpdated?: boolean;
   /**
+   * Whether to display the last author of the file (from git log).
+   * Only effective when `lastUpdated` is enabled.
+   * - `false`: hide the author.
+   * - `true` (default when `lastUpdated` is on): show the commit author's name.
+   * - function: receives `{ name, email, filePath }` and returns the display string.
+   * @default true
+   */
+  lastUpdatedAuthor?:
+    | boolean
+    | ((info: { name: string; email: string; filePath: string }) => string);
+  /**
    * The social links to be displayed at the end of the nav bar. Perfect for
    * placing links to social services such as GitHub, X, Facebook, etc.
    * @default []

--- a/packages/shared/src/types/theme/index.ts
+++ b/packages/shared/src/types/theme/index.ts
@@ -65,6 +65,8 @@ export type LastUpdatedAuthor =
   | boolean
   | ((info: { name: string; email: string; filePath: string }) => string);
 
+export type NormalizedLastUpdated = boolean | { author?: boolean };
+
 export type LastUpdated =
   | boolean
   | {
@@ -168,8 +170,9 @@ export interface NormalizedLocales extends Omit<LocaleConfig, 'sidebar'> {
 
 export interface NormalizedThemeConfig extends Omit<
   ThemeConfig,
-  'locales' | 'sidebar'
+  'lastUpdated' | 'locales' | 'sidebar'
 > {
+  lastUpdated?: NormalizedLastUpdated;
   locales: NormalizedLocales[];
   sidebar: NormalizedSidebar;
 }

--- a/website/docs/en/api/config/config-theme.mdx
+++ b/website/docs/en/api/config/config-theme.mdx
@@ -221,7 +221,7 @@ export default defineConfig({
 
 ## lastUpdated
 
-- **Type**: `boolean`
+- **Type**: `boolean | { author?: boolean | ((info: { name: string; email: string; filePath: string }) => string) }`
 - **Default**: `false`
 
 Whether to display the last updated time of each document page. Rspress reads this value from the file's latest Git commit.
@@ -238,22 +238,16 @@ export default defineConfig({
 
 When deploying in CI, make sure the Git history is available. For example, use `fetch-depth: 0` with `actions/checkout` on GitHub Actions.
 
-## lastUpdatedAuthor
-
-- **Type**: `boolean | ((info: { name: string; email: string; filePath: string }) => string)`
-- **Default**: `true` when `lastUpdated` is enabled
-
-Whether to display the last commit author of each document page. This option only takes effect when `lastUpdated` is enabled.
-
-Set it to `false` to hide the author, or pass a function to customize the rendered author text.
+Set `author` to display the last commit author as well. Pass a function to customize the rendered author text.
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from '@rspress/core';
 
 export default defineConfig({
   themeConfig: {
-    lastUpdated: true,
-    lastUpdatedAuthor: ({ name, email }) => `${name} <${email}>`,
+    lastUpdated: {
+      author: ({ name, email }) => `${name} <${email}>`,
+    },
   },
 });
 ```

--- a/website/docs/en/api/config/config-theme.mdx
+++ b/website/docs/en/api/config/config-theme.mdx
@@ -219,6 +219,45 @@ export default defineConfig({
 });
 ```
 
+## lastUpdated
+
+- **Type**: `boolean`
+- **Default**: `false`
+
+Whether to display the last updated time of each document page. Rspress reads this value from the file's latest Git commit.
+
+```ts title="rspress.config.ts"
+import { defineConfig } from '@rspress/core';
+
+export default defineConfig({
+  themeConfig: {
+    lastUpdated: true,
+  },
+});
+```
+
+When deploying in CI, make sure the Git history is available. For example, use `fetch-depth: 0` with `actions/checkout` on GitHub Actions.
+
+## lastUpdatedAuthor
+
+- **Type**: `boolean | ((info: { name: string; email: string; filePath: string }) => string)`
+- **Default**: `true` when `lastUpdated` is enabled
+
+Whether to display the last commit author of each document page. This option only takes effect when `lastUpdated` is enabled.
+
+Set it to `false` to hide the author, or pass a function to customize the rendered author text.
+
+```ts title="rspress.config.ts"
+import { defineConfig } from '@rspress/core';
+
+export default defineConfig({
+  themeConfig: {
+    lastUpdated: true,
+    lastUpdatedAuthor: ({ name, email }) => `${name} <${email}>`,
+  },
+});
+```
+
 ## socialLinks
 
 - **Type**: `Array`

--- a/website/docs/en/ui/layout-components/last-updated.mdx
+++ b/website/docs/en/ui/layout-components/last-updated.mdx
@@ -1,11 +1,11 @@
 ---
-description: LastUpdated component for displaying the page's last updated time.
+description: LastUpdated component for displaying the page's last updated time and author.
 overviewHeaders: []
 ---
 
 # LastUpdated
 
-`LastUpdated` displays the page's last updated time. Typically used with the theme's `lastUpdated` configuration.
+`LastUpdated` displays the page's last updated time, and optionally the last author. Typically used with the theme's `lastUpdated` configuration.
 
 ## Usage
 
@@ -34,5 +34,24 @@ export default defineConfig({
 ```
 
 When `lastUpdated` is enabled, the component automatically reads and formats the page metadata.
+
+### Displaying the author
+
+When `lastUpdated` is enabled, the last commit author is also shown by default. Customize via `lastUpdatedAuthor`:
+
+```ts title="rspress.config.ts"
+export default defineConfig({
+  themeConfig: {
+    lastUpdated: true,
+    // Hide the author:
+    // lastUpdatedAuthor: false,
+
+    // Custom display text:
+    lastUpdatedAuthor: ({ name, email }) => `${name} <${email}>`,
+  },
+});
+```
+
+The callback receives `{ name, email, filePath }` (the commit author info from `git log` and the source file path) and returns the string to render.
 
 To customize the display text or time format, you can export and modify `theme/components/LastUpdated/index.tsx` using `rspress eject LastUpdated`.

--- a/website/docs/en/ui/layout-components/last-updated.mdx
+++ b/website/docs/en/ui/layout-components/last-updated.mdx
@@ -37,17 +37,18 @@ When `lastUpdated` is enabled, the component automatically reads and formats the
 
 ### Displaying the author
 
-When `lastUpdated` is enabled, the last commit author is also shown by default. Customize via `lastUpdatedAuthor`:
+Configure `lastUpdated.author` to display the last commit author:
 
 ```ts title="rspress.config.ts"
 export default defineConfig({
   themeConfig: {
-    lastUpdated: true,
-    // Hide the author:
-    // lastUpdatedAuthor: false,
+    lastUpdated: {
+      // Show the commit author's name:
+      // author: true,
 
-    // Custom display text:
-    lastUpdatedAuthor: ({ name, email }) => `${name} <${email}>`,
+      // Or use custom display text:
+      author: ({ name, email }) => `${name} <${email}>`,
+    },
   },
 });
 ```

--- a/website/docs/zh/api/config/config-theme.mdx
+++ b/website/docs/zh/api/config/config-theme.mdx
@@ -208,7 +208,7 @@ export default defineConfig({
 
 ## lastUpdated
 
-- **类型**：`boolean`
+- **类型**：`boolean | { author?: boolean | ((info: { name: string; email: string; filePath: string }) => string) }`
 - **默认值**： `false`
 
 是否展示每个文档页面的最后更新时间。Rspress 会从文件最新一次 Git 提交中读取该时间。
@@ -225,22 +225,16 @@ export default defineConfig({
 
 在 CI 中部署时，请确保可以访问完整的 Git 历史。例如在 GitHub Actions 中为 `actions/checkout` 配置 `fetch-depth: 0`。
 
-## lastUpdatedAuthor
-
-- **类型**：`boolean | ((info: { name: string; email: string; filePath: string }) => string)`
-- **默认值**：启用 `lastUpdated` 时为 `true`
-
-是否展示每个文档页面最后一次提交的作者。该选项仅在启用 `lastUpdated` 时生效。
-
-设置为 `false` 可以隐藏作者，也可以传入函数来自定义展示的作者文本。
+设置 `author` 可以同时展示最后一次提交的作者，也可以传入函数来自定义展示的作者文本。
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from '@rspress/core';
 
 export default defineConfig({
   themeConfig: {
-    lastUpdated: true,
-    lastUpdatedAuthor: ({ name, email }) => `${name} <${email}>`,
+    lastUpdated: {
+      author: ({ name, email }) => `${name} <${email}>`,
+    },
   },
 });
 ```

--- a/website/docs/zh/api/config/config-theme.mdx
+++ b/website/docs/zh/api/config/config-theme.mdx
@@ -206,6 +206,45 @@ export default defineConfig({
 });
 ```
 
+## lastUpdated
+
+- **类型**：`boolean`
+- **默认值**： `false`
+
+是否展示每个文档页面的最后更新时间。Rspress 会从文件最新一次 Git 提交中读取该时间。
+
+```ts title="rspress.config.ts"
+import { defineConfig } from '@rspress/core';
+
+export default defineConfig({
+  themeConfig: {
+    lastUpdated: true,
+  },
+});
+```
+
+在 CI 中部署时，请确保可以访问完整的 Git 历史。例如在 GitHub Actions 中为 `actions/checkout` 配置 `fetch-depth: 0`。
+
+## lastUpdatedAuthor
+
+- **类型**：`boolean | ((info: { name: string; email: string; filePath: string }) => string)`
+- **默认值**：启用 `lastUpdated` 时为 `true`
+
+是否展示每个文档页面最后一次提交的作者。该选项仅在启用 `lastUpdated` 时生效。
+
+设置为 `false` 可以隐藏作者，也可以传入函数来自定义展示的作者文本。
+
+```ts title="rspress.config.ts"
+import { defineConfig } from '@rspress/core';
+
+export default defineConfig({
+  themeConfig: {
+    lastUpdated: true,
+    lastUpdatedAuthor: ({ name, email }) => `${name} <${email}>`,
+  },
+});
+```
+
 ## socialLinks
 
 - **类型**：`Array`

--- a/website/docs/zh/ui/layout-components/last-updated.mdx
+++ b/website/docs/zh/ui/layout-components/last-updated.mdx
@@ -37,17 +37,18 @@ export default defineConfig({
 
 ### 显示作者
 
-启用 `lastUpdated` 后，默认会一并显示最后一次提交的作者。可通过 `lastUpdatedAuthor` 自定义：
+配置 `lastUpdated.author` 可以展示最后一次提交的作者：
 
 ```ts title="rspress.config.ts"
 export default defineConfig({
   themeConfig: {
-    lastUpdated: true,
-    // 隐藏作者：
-    // lastUpdatedAuthor: false,
+    lastUpdated: {
+      // 展示提交作者名称：
+      // author: true,
 
-    // 自定义显示文本：
-    lastUpdatedAuthor: ({ name, email }) => `${name} <${email}>`,
+      // 或使用自定义展示文本：
+      author: ({ name, email }) => `${name} <${email}>`,
+    },
   },
 });
 ```

--- a/website/docs/zh/ui/layout-components/last-updated.mdx
+++ b/website/docs/zh/ui/layout-components/last-updated.mdx
@@ -1,11 +1,11 @@
 ---
-description: LastUpdated 最后更新时间组件，用于展示页面的最后更新时间。
+description: LastUpdated 最后更新时间组件，用于展示页面的最后更新时间与作者。
 overviewHeaders: []
 ---
 
 # LastUpdated
 
-`LastUpdated` 展示页面的最后更新时间。通常配合主题的 `lastUpdated` 配置使用。
+`LastUpdated` 展示页面的最后更新时间，并可选择显示最后的作者。通常配合主题的 `lastUpdated` 配置使用。
 
 ## 用法
 
@@ -34,5 +34,24 @@ export default defineConfig({
 ```
 
 当启用 `lastUpdated` 时，组件会自动读取页面元数据并格式化显示。
+
+### 显示作者
+
+启用 `lastUpdated` 后，默认会一并显示最后一次提交的作者。可通过 `lastUpdatedAuthor` 自定义：
+
+```ts title="rspress.config.ts"
+export default defineConfig({
+  themeConfig: {
+    lastUpdated: true,
+    // 隐藏作者：
+    // lastUpdatedAuthor: false,
+
+    // 自定义显示文本：
+    lastUpdatedAuthor: ({ name, email }) => `${name} <${email}>`,
+  },
+});
+```
+
+回调函数会收到 `{ name, email, filePath }`（来自 `git log` 的作者信息以及源文件路径），返回值即为要展示的字符串。
 
 如需自定义展示文案或时间格式，可通过 `rspress eject LastUpdated` 导出并修改 `theme/components/LastUpdated/index.tsx`。


### PR DESCRIPTION
## Summary

Adds a new `lastUpdatedAuthor` theme config to display the last commit author alongside the last updated time on doc pages.

When `lastUpdated: true` is enabled:

- **default**: also display the commit author's name (`Last Updated: ... by Alice`).
- `lastUpdatedAuthor: false`: hide the author, keep the timestamp as before.
- `lastUpdatedAuthor: ({ name, email, filePath }) => string`: build-time callback to customize the displayed text (e.g. show the email instead of the name). `filePath` is the source file of the doc, useful for path-based formatting.

The author info comes from the same `git log` call already used for the timestamp (extended from `--format=%at` to `--format=%at%n%an%n%ae`), so there is no extra subprocess per page.

### Notes for reviewers

- Behavior change: existing users with `lastUpdated: true` will now see the commit author appear after the timestamp. The author can be hidden with `lastUpdatedAuthor: false` if undesired.
- i18n: added `lastUpdatedAuthorText` to the five default locales (en/zh/ja/ko/ru).

## Related Issue

Closes #725

## Checklist

- [x] Tests updated (or not required). *no existing tests for the `lastUpdated` plugin; manually verified in `website` dev server*
- [x] Documentation updated (or not required). *updated `website/docs/{en,zh}/ui/layout-components/last-updated.mdx`*