### PR TITLE
docs(plugins): add pretext breaker to community plugins

### DIFF
--- a/website/docs/en/plugin/community-plugins/overview.mdx
+++ b/website/docs/en/plugin/community-plugins/overview.mdx
@@ -27,6 +27,7 @@ Here are some community plugins:
 - [rspress-plugin-auto-sidebar](https://github.com/buyfakett/rspress-plugin-auto-sidebar.git): Automatically generate the sidebar from the navbar configuration.
 - [rspress-plugin-giscus](https://github.com/buyfakett/rspress-plugin-giscus.git): Integrate [giscus](https://github.com/giscus/giscus) into Rspress, a comment system powered by GitHub Discussions.
 - [rspress-plugin-blog-list](https://github.com/buyfakett/rspress-plugin-blog-list.git): Integrate blog list into Rspress.
+- [rspress-plugin-pretext-breaker](https://github.com/y-lakhdar/rspress-plugin-pretext-breaker): Add the Pretext Breaker game to your Rspress site.
 - [rspress-plugin-comments](https://github.com/kalicyh/rspress-plugin-comments): Provide page comments and text selection comments for Rspress, with support for a self-hosted backend and optional Gitea OAuth login.
 - [rspress-plugin-typesense](https://github.com/typesense/rspress-plugin-typesense): Rspress plugin that replaces the built-in search with [Typesense](https://typesense.org/), an open-source, typo-tolerant search engine.
 

--- a/website/docs/zh/plugin/community-plugins/overview.mdx
+++ b/website/docs/zh/plugin/community-plugins/overview.mdx
@@ -27,6 +27,7 @@
 - [rspress-plugin-auto-sidebar](https://github.com/buyfakett/rspress-plugin-auto-sidebar.git): 通过 navbar 自动生成生成 sidebar。
 - [rspress-plugin-giscus](https://github.com/buyfakett/rspress-plugin-giscus.git): 集成 [giscus](https://github.com/giscus/giscus) 到 Rspress，一个基于 GitHub Discussions 的评论系统。
 - [rspress-plugin-blog-list](https://github.com/buyfakett/rspress-plugin-blog-list.git): 集成博客列表到 Rspress。
+- [rspress-plugin-pretext-breaker](https://github.com/y-lakhdar/rspress-plugin-pretext-breaker): 为你的 Rspress 站点添加 Pretext Breaker 游戏。
 - [rspress-plugin-comments](https://github.com/kalicyh/rspress-plugin-comments): 为 Rspress 提供页面评论与文本选区评论，支持自托管后端和可选的 Gitea OAuth 登录。
 - [rspress-plugin-typesense](https://github.com/typesense/rspress-plugin-typesense): 使用 [Typesense](https://typesense.org/)（一个开源、支持容错拼写的搜索引擎）替换 Rspress 内置搜索的插件。
 


### PR DESCRIPTION
## Summary
- add `rspress-plugin-pretext-breaker` to the community plugin overview in English
- add the matching Chinese community plugin entry to keep docs aligned
- follow the existing community plugin listing pattern used by prior plugin additions