### PR TITLE
ci: allow ecosystem CI commit comments

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'web-infra-dev/rspress' && github.event_name != 'workflow_dispatch' && needs.changes.outputs.changed == 'true'
     permissions:
-      contents: read
+      contents: write
     steps:
       - name: Trigger Ecosystem CI
         uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@ca8d345a115158ea5ab3807378357f2162be7467 # main


### PR DESCRIPTION
## Summary

Restore the `contents: write` permission for the per-commit Ecosystem CI job so the failure-reporting path can create commit comments after downstream ecosystem CI failures. This mirrors https://github.com/web-infra-dev/rsbuild/pull/7694 while keeping the other narrowed permissions unchanged.

## Related Issue

https://github.com/web-infra-dev/rsbuild/pull/7694

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).