### PR TITLE
refactor(ssg-md): use import.meta env for SSG-MD and add snapshot tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,10 @@
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
     "@playwright/test": "1.58.2",
+    "@rsbuild/plugin-react": "~2.0.0",
     "@rslint/core": "^0.5.3",
     "@rspress/config": "workspace:*",
+    "@rstest/adapter-rslib": "0.10.0",
     "@rstest/core": "^0.10.0",
     "@types/cross-spawn": "^6.0.6",
     "@types/node": "^22.8.1",

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -40,6 +40,11 @@ const COMMON_EXTERNALS = [
   'react-router-dom',
 ];
 
+// Keep import.meta.env.SSG_MD for the final Rspress app build to replace.
+const PRESERVE_IMPORT_META_ENV = {
+  'import.meta.env': 'import.meta.env',
+};
+
 export default defineConfig({
   plugins: [pluginPublint()],
   lib: [
@@ -94,6 +99,7 @@ export default defineConfig({
       dts: false,
       syntax: 'es2022',
       source: {
+        define: PRESERVE_IMPORT_META_ENV,
         entry: {
           index: [
             './src/runtime/**/*.{tsx,ts}',
@@ -126,6 +132,7 @@ export default defineConfig({
       ],
       source: {
         define: {
+          ...PRESERVE_IMPORT_META_ENV,
           __WEBPACK_PUBLIC_PATH__: '__webpack_public_path__',
         },
         entry: {

--- a/packages/core/src/env.d.ts
+++ b/packages/core/src/env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types='@rslib/core/types' />
+
+interface ImportMetaEnv {
+  readonly SSG_MD: boolean;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/packages/core/src/runtime/App.test.tsx
+++ b/packages/core/src/runtime/App.test.tsx
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
+import { createContext, type ReactNode } from 'react';
+import { renderToMarkdownString } from 'react-render-to-markdown';
+import { PageContext } from '@rspress/core/runtime';
+import { App } from './App';
+
+rs.mock('@rspress/core/runtime', () => ({
+  PageContext: createContext({
+    data: {
+      frontmatter: {},
+      lang: 'en',
+      pagePath: '/index.md',
+      pageType: 'doc',
+      routePath: '/',
+      title: 'Home',
+      toc: [],
+      version: '',
+    },
+    setData: () => {},
+  }),
+  useLocation: () => ({
+    pathname: '/',
+    search: '',
+  }),
+}));
+
+rs.mock('@theme', () => ({
+  Layout: () => 'Layout content',
+  Root: ({ children }: { children: ReactNode }) => children,
+}));
+
+rs.mock('virtual-global-components', () => ({
+  default: [() => 'Global component'],
+}));
+
+rs.mock('./initPageData', () => ({
+  consumeCachedPageData: () => undefined,
+  initPageData: async () => undefined,
+  setCurrentPageData: () => {},
+}));
+
+const originalSsgMd = import.meta.env.SSG_MD;
+
+const setSsgMd = (value: boolean | undefined) => {
+  if (value === undefined) {
+    delete (import.meta.env as unknown as Record<string, unknown>).SSG_MD;
+    return;
+  }
+
+  (import.meta.env as unknown as Record<string, unknown>).SSG_MD = value;
+};
+
+afterEach(() => {
+  setSsgMd(originalSsgMd);
+});
+
+describe('App', () => {
+  it('omits global UI components when SSG_MD is enabled', async () => {
+    setSsgMd(true);
+
+    expect(
+      await renderToMarkdownString(
+        <PageContext.Provider
+          value={{
+            data: {
+              frontmatter: {},
+              lang: 'en',
+              pagePath: '/index.md',
+              pageType: 'doc',
+              routePath: '/',
+              title: 'Home',
+              toc: [],
+              version: '',
+            },
+            setData: () => {},
+          }}
+        >
+          <App />
+        </PageContext.Provider>,
+      ),
+    ).toMatchInlineSnapshot('"Layout content"');
+  });
+});

--- a/packages/core/src/runtime/App.tsx
+++ b/packages/core/src/runtime/App.tsx
@@ -48,7 +48,7 @@ export function App() {
     frontmatter[GLOBAL_COMPONENTS_KEY] === false ||
     query.get(GLOBAL_COMPONENTS_KEY) === QueryStatus.Hide;
 
-  if (process.env.__SSR_MD__) {
+  if (import.meta.env.SSG_MD) {
     return (
       <Root>
         <Layout />

--- a/packages/core/src/theme/components/CodeBlock/index.test.tsx
+++ b/packages/core/src/theme/components/CodeBlock/index.test.tsx
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
+import { renderToMarkdownString } from 'react-render-to-markdown';
+import { CodeBlock } from './index';
+
+rs.mock('@rspress/core/theme', () => ({
+  CodeButtonGroup: () => null,
+  IconArrowDown: () => null,
+  SvgWrapper: () => null,
+  useCodeButtonGroup: () => ({
+    copyElementRef: { current: null },
+    toggleWrapCode: () => {},
+    wrapCode: false,
+  }),
+}));
+
+const originalSsgMd = import.meta.env.SSG_MD;
+
+const setSsgMd = (value: boolean | undefined) => {
+  if (value === undefined) {
+    delete (import.meta.env as unknown as Record<string, unknown>).SSG_MD;
+    return;
+  }
+
+  (import.meta.env as unknown as Record<string, unknown>).SSG_MD = value;
+};
+
+afterEach(() => {
+  setSsgMd(originalSsgMd);
+});
+
+describe('CodeBlock', () => {
+  it('renders only its children when SSG_MD is enabled', async () => {
+    setSsgMd(true);
+
+    expect(
+      await renderToMarkdownString(
+        <CodeBlock title="example.ts">
+          <pre>const value = true;</pre>
+        </CodeBlock>,
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      \`\`\`\`
+      const value = true;
+      \`\`\`\`
+      "
+    `);
+  });
+});

--- a/packages/core/src/theme/components/CodeBlock/index.tsx
+++ b/packages/core/src/theme/components/CodeBlock/index.tsx
@@ -81,7 +81,7 @@ export function CodeBlock({
   codeButtonGroupProps,
   children,
 }: CodeBlockProps) {
-  if (process.env.__SSR_MD__) {
+  if (import.meta.env.SSG_MD) {
     return <>{children}</>;
   }
 

--- a/packages/core/src/theme/components/FallbackHeading/index.test.tsx
+++ b/packages/core/src/theme/components/FallbackHeading/index.test.tsx
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
+import { renderToMarkdownString } from 'react-render-to-markdown';
+import { FallbackHeading } from './index';
+
+rs.mock('@rspress/core/theme', () => ({
+  getCustomMDXComponent: () => ({
+    a: 'a',
+    h1: 'h1',
+    h2: 'h2',
+    h3: 'h3',
+    h4: 'h4',
+    h5: 'h5',
+    h6: 'h6',
+  }),
+  renderInlineMarkdown: (text: string) => ({
+    dangerouslySetInnerHTML: { __html: text },
+  }),
+}));
+
+const originalSsgMd = import.meta.env.SSG_MD;
+
+const setSsgMd = (value: boolean | undefined) => {
+  if (value === undefined) {
+    delete (import.meta.env as unknown as Record<string, unknown>).SSG_MD;
+    return;
+  }
+
+  (import.meta.env as unknown as Record<string, unknown>).SSG_MD = value;
+};
+
+afterEach(() => {
+  setSsgMd(originalSsgMd);
+});
+
+describe('FallbackHeading', () => {
+  it('renders markdown when SSG_MD is enabled', async () => {
+    setSsgMd(true);
+
+    expect(
+      await renderToMarkdownString(
+        <FallbackHeading level={2} title="Getting Started" />,
+      ),
+    ).toBe('## Getting Started\n\n');
+  });
+});

--- a/packages/core/src/theme/components/FallbackHeading/index.tsx
+++ b/packages/core/src/theme/components/FallbackHeading/index.tsx
@@ -31,7 +31,7 @@ export function FallbackHeading({
   level: 1 | 2 | 3 | 4 | 5 | 6;
   title: string;
 }) {
-  if (process.env.__SSR_MD__) {
+  if (import.meta.env.SSG_MD) {
     return <>{`${'#'.repeat(level)} ${title}\n\n`}</>;
   }
 

--- a/packages/core/src/theme/components/Overview/index.test.tsx
+++ b/packages/core/src/theme/components/Overview/index.test.tsx
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
+import { renderToMarkdownString } from 'react-render-to-markdown';
+import { Overview } from './index';
+
+rs.mock('@rspress/core/runtime', () => ({
+  isEqualPath: (a: string, b: string) => a === b,
+  useI18n: () => (key: string) => key,
+  usePageData: () => ({
+    page: {
+      frontmatter: { overview: true },
+      routePath: '/guide/overview',
+      title: 'Guide Overview',
+    },
+    siteData: { pages: [] },
+  }),
+  useSidebar: () => [{ link: '/guide/overview', text: 'Overview' }],
+}));
+
+rs.mock('@rspress/core/theme', () => ({
+  FallbackHeading: ({ level, title }: { level: number; title: string }) =>
+    `${'#'.repeat(level)} ${title}\n\n`,
+  OverviewGroup: ({ group }: { group: { name: string } }) =>
+    `## ${group.name}\n\n`,
+}));
+
+const originalSsgMd = import.meta.env.SSG_MD;
+
+const setSsgMd = (value: boolean | undefined) => {
+  if (value === undefined) {
+    delete (import.meta.env as unknown as Record<string, unknown>).SSG_MD;
+    return;
+  }
+
+  (import.meta.env as unknown as Record<string, unknown>).SSG_MD = value;
+};
+
+afterEach(() => {
+  setSsgMd(originalSsgMd);
+});
+
+describe('Overview', () => {
+  it('renders heading and groups as markdown when SSG_MD is enabled', async () => {
+    setSsgMd(true);
+
+    expect(
+      await renderToMarkdownString(
+        <Overview groups={[{ name: 'Guides', items: [] }]} />,
+      ),
+    ).toMatchInlineSnapshot(`
+      "# Guide Overview
+
+      ## Guides
+
+      "
+    `);
+  });
+});

--- a/packages/core/src/theme/components/Overview/index.tsx
+++ b/packages/core/src/theme/components/Overview/index.tsx
@@ -242,7 +242,7 @@ export function Overview(props: {
 
   const overviewTitle = title || 'Overview';
 
-  if (process.env.__SSR_MD__) {
+  if (import.meta.env.SSG_MD) {
     return (
       <>
         <FallbackHeading level={1} title={overviewTitle} />

--- a/packages/core/src/theme/components/OverviewGroup/index.test.tsx
+++ b/packages/core/src/theme/components/OverviewGroup/index.test.tsx
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
+import { renderToMarkdownString } from 'react-render-to-markdown';
+import { OverviewGroup, type Group } from './index';
+
+rs.mock('@rspress/core/runtime', () => ({
+  routePathToMdPath: (routePath: string) => `${routePath}.md`,
+}));
+
+rs.mock('@rspress/core/theme', () => ({
+  FallbackHeading: () => null,
+  Link: 'a',
+  SvgWrapper: () => null,
+  renderInlineMarkdown: (text: string) => ({
+    dangerouslySetInnerHTML: { __html: text },
+  }),
+}));
+
+const originalSsgMd = import.meta.env.SSG_MD;
+
+const setSsgMd = (value: boolean | undefined) => {
+  if (value === undefined) {
+    delete (import.meta.env as unknown as Record<string, unknown>).SSG_MD;
+    return;
+  }
+
+  (import.meta.env as unknown as Record<string, unknown>).SSG_MD = value;
+};
+
+afterEach(() => {
+  setSsgMd(originalSsgMd);
+});
+
+describe('OverviewGroup', () => {
+  it('renders overview links as markdown when SSG_MD is enabled', async () => {
+    setSsgMd(true);
+
+    const group: Group = {
+      name: 'Guide',
+      items: [
+        {
+          text: 'Introduction',
+          link: '/guide/introduction',
+          headers: [{ id: 'install', text: 'Install', depth: 2 }],
+          items: [{ text: 'Configuration', link: '/guide/configuration' }],
+        },
+      ],
+    };
+
+    expect(await renderToMarkdownString(<OverviewGroup group={group} />))
+      .toMatchInlineSnapshot(`
+      "## Guide
+
+      ### [Introduction](/guide/introduction.md)
+
+      - [Install](/guide/introduction.md#install)
+
+      - [Configuration](/guide/configuration.md)
+      "
+    `);
+  });
+});

--- a/packages/core/src/theme/components/OverviewGroup/index.tsx
+++ b/packages/core/src/theme/components/OverviewGroup/index.tsx
@@ -62,7 +62,7 @@ export interface Group {
 }
 
 export const OverviewGroup = ({ group }: { group: Group }) => {
-  if (process.env.__SSR_MD__) {
+  if (import.meta.env.SSG_MD) {
     return <OverviewGroupMarkdown group={group} />;
   }
 

--- a/packages/core/src/theme/components/PackageManagerTabs/index.test.tsx
+++ b/packages/core/src/theme/components/PackageManagerTabs/index.test.tsx
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
+import type { ReactNode } from 'react';
+import { renderToMarkdownString } from 'react-render-to-markdown';
+import { PackageManagerTabs } from './index';
+
+rs.mock('@rspress/core/theme', () => ({
+  getCustomMDXComponent: () => ({
+    pre: 'pre',
+  }),
+  Tab: ({ children }: { children: ReactNode }) => children,
+  Tabs: ({ children }: { children: ReactNode }) => children,
+}));
+
+const originalSsgMd = import.meta.env.SSG_MD;
+
+const setSsgMd = (value: boolean | undefined) => {
+  if (value === undefined) {
+    delete (import.meta.env as unknown as Record<string, unknown>).SSG_MD;
+    return;
+  }
+
+  (import.meta.env as unknown as Record<string, unknown>).SSG_MD = value;
+};
+
+afterEach(() => {
+  setSsgMd(originalSsgMd);
+});
+
+describe('PackageManagerTabs', () => {
+  it('renders install commands as markdown code fences when SSG_MD is enabled', async () => {
+    setSsgMd(true);
+
+    expect(
+      await renderToMarkdownString(
+        <PackageManagerTabs
+          command={{
+            npm: 'npm install rspress',
+            pnpm: 'pnpm add rspress',
+          }}
+        />,
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      \`\`\`sh [npm]
+      npm install rspress
+      \`\`\`
+
+      \`\`\`sh [pnpm]
+      pnpm add rspress
+      \`\`\`
+      "
+    `);
+  });
+});

--- a/packages/core/src/theme/components/PackageManagerTabs/index.tsx
+++ b/packages/core/src/theme/components/PackageManagerTabs/index.tsx
@@ -218,7 +218,7 @@ export function PackageManagerTabs({
     commandInfo = command;
   }
 
-  if (process.env.__SSR_MD__) {
+  if (import.meta.env.SSG_MD) {
     return Object.values(commandInfo).reduce((previous, current) => {
       const [packageManager, command] = splitTo2Parts(current);
       return (

--- a/packages/core/src/theme/components/Tabs/index.test.tsx
+++ b/packages/core/src/theme/components/Tabs/index.test.tsx
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
+import { renderToMarkdownString } from 'react-render-to-markdown';
+import { Tab, Tabs } from './index';
+
+rs.mock('@rspress/core/theme', () => ({
+  useStorageValue: () => ['0', () => {}],
+}));
+
+const originalSsgMd = import.meta.env.SSG_MD;
+
+const setSsgMd = (value: boolean | undefined) => {
+  if (value === undefined) {
+    delete (import.meta.env as unknown as Record<string, unknown>).SSG_MD;
+    return;
+  }
+
+  (import.meta.env as unknown as Record<string, unknown>).SSG_MD = value;
+};
+
+afterEach(() => {
+  setSsgMd(originalSsgMd);
+});
+
+describe('Tabs', () => {
+  it('renders every tab as markdown when SSG_MD is enabled', async () => {
+    setSsgMd(true);
+
+    expect(
+      await renderToMarkdownString(
+        <Tabs>
+          <Tab label="npm" value="npm">
+            npm install
+          </Tab>
+          <Tab label="pnpm" value="pnpm">
+            pnpm install
+          </Tab>
+        </Tabs>,
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      **npm**
+
+      npm install
+
+      **pnpm**
+
+      pnpm install
+      "
+    `);
+  });
+});

--- a/packages/core/src/theme/components/Tabs/index.tsx
+++ b/packages/core/src/theme/components/Tabs/index.tsx
@@ -116,7 +116,7 @@ export const Tabs = forwardRef(
       return getTabValuesFromChildren(children, values);
     }, [children, values]);
 
-    if (process.env.__SSR_MD__) {
+    if (import.meta.env.SSG_MD) {
       return (
         <>
           {tabValues.map(({ label, content }) => {

--- a/packages/core/src/theme/layout/DocLayout/index.test.tsx
+++ b/packages/core/src/theme/layout/DocLayout/index.test.tsx
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
+import type { ReactNode } from 'react';
+import { renderToMarkdownString } from 'react-render-to-markdown';
+import { DocLayout } from './index';
+
+let overview = false;
+
+rs.mock('@rspress/core/runtime', () => ({
+  useFrontmatter: () => ({
+    frontmatter: { overview },
+  }),
+}));
+
+rs.mock('@rspress/core/theme', () => ({
+  DocContent: ({ isOverviewPage }: { isOverviewPage?: boolean }) =>
+    isOverviewPage ? 'Overview doc content' : 'Doc content',
+  DocFooter: () => null,
+  Outline: () => null,
+  Overview: ({ content }: { content: ReactNode }) => (
+    <>
+      {'# Overview\n\n'}
+      {content}
+    </>
+  ),
+  Sidebar: () => null,
+  useWatchToc: () => ({
+    rspressDocRef: { current: null },
+  }),
+}));
+
+rs.mock('../../components/SidebarMenu/useSidebarMenu', () => ({
+  useSidebarMenu: () => ({
+    asideLayoutRef: { current: null },
+    isOutlineOpen: false,
+    isSidebarOpen: false,
+    sidebarLayoutRef: { current: null },
+    sidebarMenu: null,
+  }),
+}));
+
+const originalSsgMd = import.meta.env.SSG_MD;
+
+const setSsgMd = (value: boolean | undefined) => {
+  if (value === undefined) {
+    delete (import.meta.env as unknown as Record<string, unknown>).SSG_MD;
+    return;
+  }
+
+  (import.meta.env as unknown as Record<string, unknown>).SSG_MD = value;
+};
+
+afterEach(() => {
+  overview = false;
+  setSsgMd(originalSsgMd);
+});
+
+describe('DocLayout', () => {
+  it('renders only doc content when SSG_MD is enabled', async () => {
+    setSsgMd(true);
+
+    expect(await renderToMarkdownString(<DocLayout />)).toMatchInlineSnapshot(
+      '"Doc content"',
+    );
+  });
+
+  it('renders overview content when SSG_MD is enabled on overview pages', async () => {
+    overview = true;
+    setSsgMd(true);
+
+    expect(await renderToMarkdownString(<DocLayout />)).toMatchInlineSnapshot(`
+      "# Overview
+
+      Overview doc content"
+    `);
+  });
+});

--- a/packages/core/src/theme/layout/DocLayout/index.tsx
+++ b/packages/core/src/theme/layout/DocLayout/index.tsx
@@ -57,7 +57,7 @@ export function DocLayout(props: DocLayoutProps) {
 
   const showSidebarMenu = showSidebar || (!isOverviewPage && showOutline);
 
-  if (process.env.__SSR_MD__) {
+  if (import.meta.env.SSG_MD) {
     return (
       <>
         {isOverviewPage ? (

--- a/packages/core/src/theme/layout/HomeLayout/index.test.tsx
+++ b/packages/core/src/theme/layout/HomeLayout/index.test.tsx
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
+import { renderToMarkdownString } from 'react-render-to-markdown';
+import { HomeLayout } from './index';
+
+rs.mock('@rspress/core/runtime', () => ({
+  useFrontmatter: () => ({
+    frontmatter: {
+      hero: {
+        name: 'Rspress',
+        text: 'Static site generation made simple.',
+        tagline: 'Build fast documentation sites.',
+        actions: [{ text: 'Get Started', link: '/guide/start' }],
+      },
+      features: [
+        {
+          title: 'Fast',
+          details: 'Powered by Rspack.',
+        },
+        {
+          title: 'Extensible',
+          details: 'Use plugins and custom themes.',
+          link: '/plugin',
+        },
+      ],
+    },
+  }),
+}));
+
+rs.mock('@rspress/core/theme', () => ({
+  HomeBackground: () => null,
+  HomeFeature: () => null,
+  HomeFooter: () => null,
+  HomeHero: () => null,
+}));
+
+const originalSsgMd = import.meta.env.SSG_MD;
+
+const setSsgMd = (value: boolean | undefined) => {
+  if (value === undefined) {
+    delete (import.meta.env as unknown as Record<string, unknown>).SSG_MD;
+    return;
+  }
+
+  (import.meta.env as unknown as Record<string, unknown>).SSG_MD = value;
+};
+
+afterEach(() => {
+  setSsgMd(originalSsgMd);
+});
+
+describe('HomeLayout', () => {
+  it('renders frontmatter hero and features as markdown when SSG_MD is enabled', async () => {
+    setSsgMd(true);
+
+    expect(await renderToMarkdownString(<HomeLayout />)).toMatchInlineSnapshot(`
+      "# Rspress
+
+      Static site generation made simple.
+
+      > Build fast documentation sites.
+
+      [Get Started](/guide/start)
+
+      ## Features
+
+      - **Fast**: Powered by Rspack.
+      - [**Extensible**](/plugin): Use plugins and custom themes.
+      "
+    `);
+  });
+});

--- a/packages/core/src/theme/layout/HomeLayout/index.tsx
+++ b/packages/core/src/theme/layout/HomeLayout/index.tsx
@@ -64,7 +64,7 @@ function HomeLayoutMarkdown() {
 }
 
 export function HomeLayout(props: HomeLayoutProps) {
-  if (process.env.__SSR_MD__) {
+  if (import.meta.env.SSG_MD) {
     return <HomeLayoutMarkdown />;
   }
 

--- a/packages/core/src/theme/layout/Layout/index.test.tsx
+++ b/packages/core/src/theme/layout/Layout/index.test.tsx
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
+import { renderToMarkdownString } from 'react-render-to-markdown';
+import { Layout } from './index';
+
+rs.mock('@rspress/core/runtime', () => ({
+  Content: () => 'Custom content',
+  useFrontmatter: () => ({
+    frontmatter: {},
+  }),
+  useLocaleSiteData: () => ({
+    description: 'Locale description',
+    title: 'Locale title',
+  }),
+  usePage: () => ({
+    page: {
+      description: 'Page description',
+      lang: 'en',
+      pageType: 'doc',
+      title: 'Guide',
+    },
+  }),
+  useSite: () => ({
+    site: {
+      description: 'Site description',
+      title: 'Rspress',
+    },
+  }),
+}));
+
+rs.mock('@rspress/core/theme', () => ({
+  DocLayout: () => 'Doc layout',
+  HomeLayout: () => 'Home layout',
+  Nav: () => 'Nav',
+  NotFoundLayout: () => 'Not found',
+  useRedirect4FirstVisit: () => {
+    throw new Error('client-only layout hook should not run in SSG_MD mode');
+  },
+  useScrollReset: () => {
+    throw new Error('client-only layout hook should not run in SSG_MD mode');
+  },
+  useSetup: () => {
+    throw new Error('client-only layout hook should not run in SSG_MD mode');
+  },
+}));
+
+const originalSsgMd = import.meta.env.SSG_MD;
+
+const setSsgMd = (value: boolean | undefined) => {
+  if (value === undefined) {
+    delete (import.meta.env as unknown as Record<string, unknown>).SSG_MD;
+    return;
+  }
+
+  (import.meta.env as unknown as Record<string, unknown>).SSG_MD = value;
+};
+
+afterEach(() => {
+  setSsgMd(originalSsgMd);
+});
+
+describe('Layout', () => {
+  it('renders only the page content layout when SSG_MD is enabled', async () => {
+    setSsgMd(true);
+
+    expect(
+      await renderToMarkdownString(
+        <Layout
+          afterNav="After nav"
+          beforeNav="Before nav"
+          bottom="Bottom"
+          top="Top"
+        />,
+      ),
+    ).toMatchInlineSnapshot('"Doc layout"');
+  });
+});

--- a/packages/core/src/theme/layout/Layout/index.tsx
+++ b/packages/core/src/theme/layout/Layout/index.tsx
@@ -219,7 +219,7 @@ export function Layout(props: LayoutProps) {
     }
   };
 
-  if (process.env.__SSR_MD__) {
+  if (import.meta.env.SSG_MD) {
     return <>{getContentLayout()}</>;
   }
 

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src"],
-  "exclude": ["**/*.test.ts", "**/fixtures"]
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/fixtures"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,18 @@ importers:
       '@playwright/test':
         specifier: 1.58.2
         version: 1.58.2
+      '@rsbuild/plugin-react':
+        specifier: ~2.0.0
+        version: 2.0.0(@rsbuild/core@2.0.6)(@rspack/core@2.0.3(@swc/helpers@0.5.21))
       '@rslint/core':
         specifier: ^0.5.3
         version: 0.5.3(jiti@2.6.1)
       '@rspress/config':
         specifier: workspace:*
         version: link:scripts/config
+      '@rstest/adapter-rslib':
+        specifier: 0.10.0
+        version: 0.10.0(@rslib/core@0.21.5(@microsoft/api-extractor@7.57.7(@types/node@22.19.15))(@typescript/native-preview@7.0.0-dev.20260516.1)(typescript@6.0.3))(@rstest/core@0.10.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: ^0.10.0
         version: 0.10.0
@@ -3420,6 +3426,16 @@ packages:
       '@rspress/core': '>=2.0.0'
     peerDependenciesMeta:
       '@rspress/core':
+        optional: true
+
+  '@rstest/adapter-rslib@0.10.0':
+    resolution: {integrity: sha512-QNgVrFSP9190+VoZ+2IlzALxGE+Av46c+8qFFUwmCfGA/uxfJMiiyHX28gmdxGXIYcvjZBRij8a4QJq4Wke8jA==}
+    peerDependencies:
+      '@rslib/core': '>=0.18.6'
+      '@rstest/core': ^0.10.0
+      typescript: ^5 || ^6
+    peerDependenciesMeta:
+      typescript:
         optional: true
 
   '@rstest/core@0.10.0':
@@ -9075,6 +9091,13 @@ snapshots:
   '@rstack-dev/doc-ui@1.14.2(@rspress/core@packages+core)':
     optionalDependencies:
       '@rspress/core': link:packages/core
+
+  '@rstest/adapter-rslib@0.10.0(@rslib/core@0.21.5(@microsoft/api-extractor@7.57.7(@types/node@22.19.15))(@typescript/native-preview@7.0.0-dev.20260516.1)(typescript@6.0.3))(@rstest/core@0.10.0)(typescript@6.0.3)':
+    dependencies:
+      '@rslib/core': 0.21.5(@microsoft/api-extractor@7.57.7(@types/node@22.19.15))(@typescript/native-preview@7.0.0-dev.20260516.1)(typescript@6.0.3)
+      '@rstest/core': 0.10.0
+    optionalDependencies:
+      typescript: 6.0.3
 
   '@rstest/core@0.10.0':
     dependencies:

--- a/rstest.config.ts
+++ b/rstest.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig } from '@rstest/core';
+import { withRslibConfig } from '@rstest/adapter-rslib';
+import { pluginReact } from '@rsbuild/plugin-react';
 
 // Disable color in test
 process.env.NO_COLOR = '1';
 process.env.FORCE_COLOR = '0';
 
 export default defineConfig({
+  extends: withRslibConfig(),
+  plugins: [pluginReact()],
   name: 'node',
   globals: false,
   testEnvironment: 'node',
@@ -14,5 +18,15 @@ export default defineConfig({
   setupFiles: ['./scripts/test-helper/rstest.setup.ts'],
   output: {
     module: true,
+  },
+  tools: {
+    rspack(config) {
+      config.module ??= {};
+      config.module.rules ??= [];
+      config.module.rules.push({
+        test: /\.(css|sass|scss)$/,
+        type: 'asset/source',
+      });
+    },
   },
 });


### PR DESCRIPTION
## Summary

This PR replaces the remaining theme and runtime checks of `process.env.__SSR_MD__` with `import.meta.env.SSG_MD` so SSG-MD components use the public env flag consistently. It also adds markdown-rendering unit tests that manually enable `import.meta.env.SSG_MD` for the affected components and layouts.

## Related Issue

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).