### PR TITLE
fix(theme/Steps): h3 styles in Steps component

### DIFF
--- a/packages/core/src/theme/components/Steps/index.scss
+++ b/packages/core/src/theme/components/Steps/index.scss
@@ -20,9 +20,9 @@
       // position
       content: counter(step);
       position: absolute;
+      top: 50%;
       left: calc(-1 * var(--rp-steps-gap));
-      transform: translate(-50%, 0);
-      align-self: center;
+      transform: translate(-50%, -50%);
 
       // size
       width: var(--rp-steps-size);

--- a/packages/core/src/theme/components/Steps/index.scss
+++ b/packages/core/src/theme/components/Steps/index.scss
@@ -47,7 +47,9 @@
     /* anchor link: move to the front and ensure it's clickable */
     .rp-header-anchor {
       position: absolute;
+      top: 50%;
       left: calc(-1 * var(--rp-steps-gap) - var(--rp-steps-size) / 2);
+      transform: translate(0, -50%);
     }
   }
 }

--- a/packages/core/src/theme/components/Steps/index.scss
+++ b/packages/core/src/theme/components/Steps/index.scss
@@ -14,8 +14,6 @@
     counter-increment: step;
     margin-top: 0;
     position: relative;
-    display: flex;
-    align-items: center;
     min-height: 30px;
 
     &::before {
@@ -24,6 +22,7 @@
       position: absolute;
       left: calc(-1 * var(--rp-steps-gap));
       transform: translate(-50%, 0);
+      align-self: center;
 
       // size
       width: var(--rp-steps-size);

--- a/packages/core/src/theme/components/Steps/index.scss
+++ b/packages/core/src/theme/components/Steps/index.scss
@@ -1,6 +1,7 @@
 :root {
   --rp-steps-gap: 24px;
   --rp-steps-size: 30px;
+  --rp-steps-offset-y: 4px;
 }
 
 .rp-steps {
@@ -14,13 +15,13 @@
     counter-increment: step;
     margin-top: 0;
     position: relative;
-    min-height: 30px;
+    min-height: var(--rp-steps-size);
 
     &::before {
       // position
       content: counter(step);
       position: absolute;
-      top: 50%;
+      top: calc(var(--rp-steps-size) / 2 + var(--rp-steps-offset-y));
       left: calc(-1 * var(--rp-steps-gap));
       transform: translate(-50%, -50%);
 
@@ -47,7 +48,7 @@
     /* anchor link: move to the front and ensure it's clickable */
     .rp-header-anchor {
       position: absolute;
-      top: 50%;
+      top: calc(var(--rp-steps-size) / 2 + var(--rp-steps-offset-y));
       left: calc(-1 * var(--rp-steps-gap) - var(--rp-steps-size) / 2);
       transform: translate(0, -50%);
     }


### PR DESCRIPTION
## Summary

Updated the h3 styles in Steps component to use align-self for centering.

## Related Issue

<!--- Provide link of related issues -->

https://github.com/web-infra-dev/rspress/pull/3276/changes#r3287136326

<img width="875" height="181" alt="image" src="https://github.com/user-attachments/assets/201d37d0-1361-4e27-9a6a-0e7ba9167fa6" />

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
