### PR TITLE
docs(config): align default value docs

### DIFF
--- a/packages/create-rspress/template-common/rspress.config.ts
+++ b/packages/create-rspress/template-common/rspress.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from '@rspress/core';
 
 export default defineConfig({
   root: path.join(__dirname, 'docs'),
+  lang: 'en',
   title: 'My Site',
   icon: '/rspress-icon.png',
   logo: {

--- a/packages/plugin-preview/src/types.ts
+++ b/packages/plugin-preview/src/types.ts
@@ -4,7 +4,7 @@ import type { RouteMeta } from '@rspress/core';
 export type Options = {
   /**
    * determine how to handle a internal code block without meta like \`\`\`tsx
-   * @default 'preview'
+   * @default 'pure'
    */
   defaultRenderMode?: 'pure' | 'preview';
   /**
@@ -18,10 +18,12 @@ export type Options = {
   iframeOptions?: IframeOptions;
   /**
    * Supported languages to be previewed
+   * @default ['jsx', 'tsx']
    */
   previewLanguages?: string[];
   /**
    * Transform previewed code in custom way
+   * @default ({ code }) => code
    */
   previewCodeTransform?: (codeInfo: {
     language: string;

--- a/packages/plugin-rss/src/type.ts
+++ b/packages/plugin-rss/src/type.ts
@@ -108,7 +108,7 @@ export interface PluginRssOptions {
   siteUrl: string;
   /**
    * Feed options for each rss. If array is given, this plugin will produce multiple feed files.
-   * @default {{ id: 'blog', test: /^\/blog\// }}
+   * @default { id: 'blog', test: '/blog/' }
    */
   feed?: PartialPartial<FeedChannel, 'id' | 'test'> | FeedChannel[];
   /**

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -128,6 +128,7 @@ export interface UserConfig {
   root?: string;
   /**
    * Path to the logo file in nav bar.
+   * @default ''
    */
   logo?: string | { dark: string; light: string };
   /**
@@ -147,6 +148,7 @@ export interface UserConfig {
   base?: string;
   /**
    * Path to html icon file.
+   * @default ''
    */
   icon?: string | URL;
   /**
@@ -180,11 +182,12 @@ export interface UserConfig {
   locales?: Locale[];
   /**
    * The i18n text data source path. Default is `i18n.json` in cwd.
-   * @default '<cwd>/i18n.json'
+   * @default path.join(process.cwd(), 'i18n.json')
    */
   i18nSourcePath?: string;
   /**
    * The i18n text data.
+   * @default {}
    */
   i18nSource?:
     | (I18nText & Record<string, Record<string, string>>)
@@ -215,18 +218,22 @@ export interface UserConfig {
   plugins?: RspressPlugin[];
   /**
    * Replace rule, will replace the content of the page.
+   * @default []
    */
   replaceRules?: ReplaceRule[];
   /**
    * Output directory
+   * @default 'doc_build'
    */
   outDir?: string;
   /**
    * User side custom theme directory
+   * @default path.join(process.cwd(), 'theme')
    */
   themeDir?: string;
   /**
    * Global components
+   * @default []
    */
   globalUIComponents?: (string | [string, object])[];
   /**
@@ -298,14 +305,17 @@ export interface UserConfig {
   languageParity?: {
     /**
      * Whether to enable language parity checking
+     * @default false
      */
     enabled?: boolean;
     /**
      * Directories to include in the parity check
+     * @default []
      */
     include?: string[];
     /**
      * Directories to exclude from the parity check
+     * @default []
      */
     exclude?: string[];
   };
@@ -462,7 +472,7 @@ export interface FrontMatterMeta {
 export interface RouteOptions {
   /**
    * The extension name of the filepath that will be converted to a route
-   * @default ['js','jsx','ts','tsx','md','mdx']
+   * @default ['.js', '.jsx', '.ts', '.tsx', '.md', '.mdx']
    */
   extensions?: string[];
   /**
@@ -536,10 +546,25 @@ export type RemarkImageOptions = {
 };
 
 export interface MarkdownOptions {
+  /**
+   * @default []
+   */
   remarkPlugins?: PluggableList;
+  /**
+   * @default []
+   */
   rehypePlugins?: PluggableList;
+  /**
+   * @default { checkDeadLinks: true, autoPrefix: true }
+   */
   link?: RemarkLinkOptions;
+  /**
+   * @default { checkDeadImages: true }
+   */
   image?: RemarkImageOptions;
+  /**
+   * @default false
+   */
   showLineNumbers?: boolean;
   /**
    * Whether to wrap code by default
@@ -564,6 +589,7 @@ export interface MarkdownOptions {
   };
   /**
    * Register global components in mdx files
+   * @default []
    */
   globalComponents?: string[];
   /**

--- a/packages/shared/src/types/theme/index.ts
+++ b/packages/shared/src/types/theme/index.ts
@@ -69,6 +69,7 @@ export type ThemeConfig = {
   darkMode?: boolean;
   /**
    * The nav items. When it's an object, the key is the version of current doc.
+   * @default []
    */
   nav?: NavItem[] | { [key: string]: NavItem[] };
   /**
@@ -88,6 +89,7 @@ export type ThemeConfig = {
   /**
    * The social links to be displayed at the end of the nav bar. Perfect for
    * placing links to social services such as GitHub, X, Facebook, etc.
+   * @default []
    */
   socialLinks?: SocialLink[];
   /**
@@ -105,7 +107,7 @@ export type ThemeConfig = {
   /**
    * The behavior of hiding navbar
    * Currently, Rspress V2 does not implement `hideNavBar`
-   * @default 'never''
+   * @default 'never'
    */
   hideNavbar?: 'always' | 'auto' | 'never';
   /**

--- a/website/docs/en/api/config/config-basic.mdx
+++ b/website/docs/en/api/config/config-basic.mdx
@@ -89,7 +89,7 @@ For normal path, Rspress will find your icon in the `public` directory, of cours
 ## lang
 
 - **Type**: `string`
-- **Default**: `""`
+- **Default**: `"en"`
 
 Default language of the site. See [Internationalization](/guide/basic/i18n) for more details.
 

--- a/website/docs/en/api/config/config-theme.mdx
+++ b/website/docs/en/api/config/config-theme.mdx
@@ -479,7 +479,7 @@ export default defineConfig({
 ## enableScrollToTop
 
 - **Type**: `boolean`
-- **Default**: `false`
+- **Default**: `true`
 
 Enable scroll to top button on documentation. For example:
 

--- a/website/docs/zh/api/config/config-basic.mdx
+++ b/website/docs/zh/api/config/config-basic.mdx
@@ -89,7 +89,7 @@ export default defineConfig({
 ## lang
 
 - **类型**： `string`
-- **默认值**： `""`
+- **默认值**： `"en"`
 
 站点默认使用的语言。查看 [国际化](/guide/basic/i18n) 了解更多。
 

--- a/website/docs/zh/api/config/config-theme.mdx
+++ b/website/docs/zh/api/config/config-theme.mdx
@@ -466,7 +466,7 @@ export default defineConfig({
 ## enableScrollToTop
 
 - **类型**：`boolean`
-- **默认值**： `false`
+- **默认值**： `true`
 
 启用文档上的滚动到顶部按钮. 比如:
 


### PR DESCRIPTION
## Summary

- Align config default value docs and JSDoc with the actual runtime defaults.
- Document `lang` as defaulting to `"en"` and make the create-rspress template declare it explicitly.
- Fix stale default descriptions for `plugin-preview`, `plugin-rss`, and `themeConfig.enableScrollToTop`.

## Related Issue

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
