### PR TITLE
feat(theme): Add onTouchStart event to preload links on touch devices 📱

### DIFF
--- a/packages/core/src/theme/components/Link/index.tsx
+++ b/packages/core/src/theme/components/Link/index.tsx
@@ -100,6 +100,9 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
           onMouseEnter?.(event);
           preloadLink(removeBaseHref);
         }}
+        onTouchStart={() => {
+          preloadLink(removeBaseHref);
+        }}
         onClick={e => {
           onClick?.(e);
           if (

--- a/packages/core/src/theme/components/Link/index.tsx
+++ b/packages/core/src/theme/components/Link/index.tsx
@@ -137,6 +137,9 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
         onMouseEnter?.(event);
         preloadLink(removeBaseHref);
       }}
+      onTouchStart={() => {
+        preloadLink(removeBaseHref);
+      }}
       onClick={e => {
         onClick?.(e);
         if (


### PR DESCRIPTION
## Summary
This adds prefetching on `onTouchStart` to provide additional time for parsing the required scripts of a page transition if they have not already been parsed. This adjustment can help make the overall transition feel faster.

Inspired by: https://github.com/vercel/next.js/pull/38805
Additional reference: https://instant.page/#:~:text=in%20the%20world.-,On%20mobile,-A%20user%20starts


<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
