### PR TITLE
fix(theme): keep custom outline slots visible

### DIFF
--- a/e2e/fixtures/custom-layout/doc/no-headings.mdx
+++ b/e2e/fixtures/custom-layout/doc/no-headings.mdx
@@ -1,0 +1,3 @@
+# No headings
+
+This page intentionally has no table-of-contents headings.

--- a/e2e/fixtures/custom-layout/index.test.ts
+++ b/e2e/fixtures/custom-layout/index.test.ts
@@ -56,4 +56,36 @@ test.describe('custom layout test', async () => {
     await expect(page.locator('.rp-home-hero')).toHaveCount(0);
     await expect(page.locator('.rp-doc-layout__container')).toHaveCount(0);
   });
+
+  test('should render custom outline slots without toc headings', async ({
+    page,
+  }) => {
+    await page.goto(`http://localhost:${appPort}/no-headings`, {
+      waitUntil: 'networkidle',
+    });
+
+    await expect(page.locator('.rp-toc-item')).toHaveCount(0);
+    await expect(page.locator('.rp-outline__title')).toBeVisible();
+    await expect(page.getByTestId('before-outline')).toBeVisible();
+    await expect(page.getByTestId('after-outline')).toBeVisible();
+  });
+
+  test('should allow opening mobile outline with custom slots only', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 800, height: 600 });
+    await page.goto(`http://localhost:${appPort}/no-headings`, {
+      waitUntil: 'networkidle',
+    });
+
+    const outlineButton = page.locator('.rp-sidebar-menu__right');
+    await expect(outlineButton).toBeEnabled();
+    await outlineButton.click();
+
+    await expect(page.locator('.rp-doc-layout__outline')).toHaveClass(
+      /rp-doc-layout__outline--open/,
+    );
+    await expect(page.getByTestId('before-outline')).toBeVisible();
+    await expect(page.getByTestId('after-outline')).toBeVisible();
+  });
 });

--- a/e2e/fixtures/custom-layout/package.json
+++ b/e2e/fixtures/custom-layout/package.json
@@ -12,6 +12,7 @@
     "@rspress/core": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "^22.8.1"
+    "@types/node": "^22.8.1",
+    "@types/react": "^19.2.15"
   }
 }

--- a/e2e/fixtures/custom-layout/theme/index.tsx
+++ b/e2e/fixtures/custom-layout/theme/index.tsx
@@ -1,0 +1,20 @@
+import {
+  type LayoutProps,
+  Layout as OriginalLayout,
+} from '@rspress/core/theme-original';
+
+export * from '@rspress/core/theme-original';
+
+export function Layout(props: LayoutProps) {
+  return (
+    <OriginalLayout
+      {...props}
+      beforeOutline={
+        <div data-testid="before-outline">Before custom outline content</div>
+      }
+      afterOutline={
+        <div data-testid="after-outline">After custom outline content</div>
+      }
+    />
+  );
+}

--- a/packages/core/src/theme/components/Outline/index.tsx
+++ b/packages/core/src/theme/components/Outline/index.tsx
@@ -5,7 +5,6 @@ import {
   LlmsOpenRow,
   ReadPercent,
   Toc,
-  useDynamicToc,
 } from '@rspress/core/theme';
 import './index.scss';
 import { ScrollToTop } from './ScrollToTop';
@@ -13,16 +12,11 @@ import { ScrollToTop } from './ScrollToTop';
 export function Outline() {
   const t = useI18n();
 
-  const headers = useDynamicToc();
   const {
     site: {
       themeConfig: { enableScrollToTop = true, llmsUI },
     },
   } = useSite();
-
-  if (headers.length === 0) {
-    return <></>;
-  }
 
   const placement =
     typeof llmsUI === 'object' ? (llmsUI?.placement ?? 'title') : 'title';

--- a/packages/core/src/theme/components/SidebarMenu/index.tsx
+++ b/packages/core/src/theme/components/SidebarMenu/index.tsx
@@ -8,7 +8,7 @@ import {
   useActiveAnchor,
   useDynamicToc,
 } from '@rspress/core/theme';
-import { forwardRef, useEffect, useRef } from 'react';
+import { forwardRef, type ReactNode, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import './index.scss';
 
@@ -20,11 +20,15 @@ export const SidebarMenu = forwardRef(
       onIsSidebarOpenChange,
       isOutlineOpen,
       onIsOutlineOpenChange,
+      beforeOutline,
+      afterOutline,
     }: {
       isSidebarOpen: boolean;
       onIsSidebarOpenChange: (isOpen: boolean) => void;
       isOutlineOpen: boolean;
       onIsOutlineOpenChange: (isOpen: boolean) => void;
+      beforeOutline?: ReactNode;
+      afterOutline?: ReactNode;
     },
     forwardedRef,
   ) => {
@@ -35,6 +39,9 @@ export const SidebarMenu = forwardRef(
 
     const headers = useDynamicToc();
     const { scrolledHeader } = useActiveAnchor(headers);
+
+    const outlineDisabled =
+      !beforeOutline && !afterOutline && headers.length === 0;
 
     const {
       frontmatter: {
@@ -98,7 +105,7 @@ export const SidebarMenu = forwardRef(
           {showOutline ? (
             <button
               type="button"
-              disabled={headers.length === 0}
+              disabled={outlineDisabled}
               onClick={e => {
                 e.preventDefault();
                 e.stopPropagation();
@@ -118,7 +125,7 @@ export const SidebarMenu = forwardRef(
               )}
               <ReadPercent size={14} strokeWidth={2} />
               {/* TODO: discussion */}
-              {headers.length !== 0 && (
+              {!outlineDisabled && (
                 <SvgWrapper
                   icon={IconArrowRight}
                   className="rp-sidebar-menu__right__icon"

--- a/packages/core/src/theme/components/SidebarMenu/useSidebarMenu.tsx
+++ b/packages/core/src/theme/components/SidebarMenu/useSidebarMenu.tsx
@@ -1,9 +1,9 @@
 import { clearAllBodyScrollLocks, disableBodyScroll } from 'body-scroll-lock';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { SidebarMenu } from '.';
 import { useClickOutside } from './useClickOutside';
 
-function useSidebarMenu() {
+function useSidebarMenu(beforeOutline?: ReactNode, afterOutline?: ReactNode) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isOutlineOpen, setIsOutlineOpen] = useState(false);
 
@@ -39,9 +39,18 @@ function useSidebarMenu() {
         isOutlineOpen={isOutlineOpen}
         onIsOutlineOpenChange={setIsOutlineOpen}
         ref={sidebarMenuRef}
+        beforeOutline={beforeOutline}
+        afterOutline={afterOutline}
       />
     );
-  }, [isOutlineOpen, isSidebarOpen, setIsOutlineOpen, setIsSidebarOpen]);
+  }, [
+    isOutlineOpen,
+    isSidebarOpen,
+    setIsOutlineOpen,
+    setIsSidebarOpen,
+    beforeOutline,
+    afterOutline,
+  ]);
 
   return {
     sidebarMenu,

--- a/packages/core/src/theme/layout/DocLayout/index.tsx
+++ b/packages/core/src/theme/layout/DocLayout/index.tsx
@@ -79,7 +79,7 @@ export function DocLayout(props: DocLayoutProps) {
     sidebarMenu,
     asideLayoutRef,
     sidebarLayoutRef,
-  } = useSidebarMenu();
+  } = useSidebarMenu(beforeOutline, afterOutline);
 
   const { rspressDocRef } = useWatchToc();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,6 +249,9 @@ importers:
       '@types/node':
         specifier: ^22.8.1
         version: 22.19.15
+      '@types/react':
+        specifier: ^19.2.15
+        version: 19.2.15
 
   e2e/fixtures/custom-plugin:
     dependencies:


### PR DESCRIPTION
## Summary

- Keeps the doc outline rendered when custom beforeOutline/afterOutline slots are present, even if the page has no TOC headings.
- Passes outline slot content into the mobile sidebar menu so the outline button remains enabled for custom outline content.
- Adds custom-layout e2e coverage for desktop and mobile no-heading outline slots.

After:

1. <img width="1167" height="278" alt="image" src="https://github.com/user-attachments/assets/af9af0f6-beaf-4853-a638-afd52a81a077" />
2. <img width="897" height="311" alt="image" src="https://github.com/user-attachments/assets/3b0cc97a-989f-4a63-af4b-4f8452e9b177" />


## Related Issue

None

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).