### PR TITLE
docs: update rspress architecture image

### DIFF
--- a/website/docs/en/plugin/system/introduction.mdx
+++ b/website/docs/en/plugin/system/introduction.mdx
@@ -4,7 +4,7 @@ The plugin system is a crucial part of Rspress, which allows you to easily exten
 
 The overall architecture of Rspress is shown in the figure below:
 
-![Rspress Architecture](https://lf3-static.bytednsdoc.com/obj/eden-cn/uhbfnupenuhf/edenx-doc/arch-en.png)
+![Rspress Architecture](https://assets.rspack.rs/rspress/assets/rspress-architecture.png)
 
 Rspress is divided into two parts: **Node Side** and **Browser Runtime**. Through the plugin system, you can easily extend the abilities of these two parts. Specifically, you can extend the ability to:
 

--- a/website/docs/zh/plugin/system/introduction.mdx
+++ b/website/docs/zh/plugin/system/introduction.mdx
@@ -4,7 +4,7 @@
 
 Rspress 的整体架构如下图所示：
 
-![Rspress 架构图](https://lf3-static.bytednsdoc.com/obj/eden-cn/uhbfnupenuhf/edenx-doc/arch.png)
+![Rspress 架构图](https://assets.rspack.rs/rspress/assets/rspress-architecture.png)
 
 Rspress 整体分为**Node 端**和**浏览器运行时**两部分。通过插件机制，你可以轻松地扩展这两部分的功能。具体来说，你可以扩展如下的能力:
 


### PR DESCRIPTION
## Summary

- Update the English and Chinese plugin system introduction docs to use the uploaded Rspress architecture image from `assets.rspack.rs`.
- Validation: `pnpm exec prettier --check website/docs/en/plugin/system/introduction.mdx website/docs/zh/plugin/system/introduction.mdx` passed.
- Validation: `pnpm run build:website` was attempted, but failed in the existing `@rspress/core:build` declaration generation step with `Cannot find module 'mdast-util-mdxjs-esm'`.

## Related Issue

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
