### PR TITLE
perf(ssg/experimentalWorker): write SSG worker output to disk directly and skip processAssets for memory

### DIFF
--- a/e2e/fixtures/ssg-worker/index.test.ts
+++ b/e2e/fixtures/ssg-worker/index.test.ts
@@ -1,7 +1,48 @@
-import { test } from '@playwright/test';
+import { access, readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+import { expect, test } from '@playwright/test';
 import { runBuildCommand } from '../../utils/runCommands';
+
+async function pathExists(filePath: string) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 test('build with experimental SSG worker', async () => {
   const appDir = import.meta.dirname;
+  const docBuildDir = path.join(appDir, 'doc_build');
   await runBuildCommand(appDir);
+
+  const indexHtmlPath = path.join(docBuildDir, 'index.html');
+  const notFoundHtmlPath = path.join(docBuildDir, '404.html');
+
+  await Promise.all([access(indexHtmlPath), access(notFoundHtmlPath)]);
+
+  const indexHtml = await readFile(indexHtmlPath, 'utf-8');
+  expect(indexHtml).toContain('<title>SSG worker</title>');
+  expect(indexHtml).toContain('id="ssg-worker"');
+  expect(indexHtml).toContain(
+    '<p>This page is rendered by the experimental SSG worker.</p>',
+  );
+
+  const notFoundHtml = await readFile(notFoundHtmlPath, 'utf-8');
+  expect(notFoundHtml).toContain('<title>404</title>');
+  expect(notFoundHtml).toContain('PAGE NOT FOUND');
+
+  const staticFiles = await readdir(path.join(docBuildDir, 'static'), {
+    recursive: true,
+  });
+  expect(
+    staticFiles.some(
+      file =>
+        typeof file === 'string' &&
+        file.startsWith('search_index.en.') &&
+        file.endsWith('.json'),
+    ),
+  ).toBe(true);
+  expect(await pathExists(path.join(docBuildDir, '__ssg__'))).toBe(false);
 });

--- a/packages/core/src/node/ssg/htmlFile.test.ts
+++ b/packages/core/src/node/ssg/htmlFile.test.ts
@@ -1,0 +1,25 @@
+import path from 'node:path';
+import { describe, expect, it } from '@rstest/core';
+import { resolveHtmlFilePath, routePath2HtmlFileName } from './htmlFile';
+
+describe('SSG html file helpers', () => {
+  it('should convert route path to html file name', () => {
+    expect(routePath2HtmlFileName('/')).toBe('index.html');
+    expect(routePath2HtmlFileName('/guide/')).toBe('guide/index.html');
+    expect(routePath2HtmlFileName('/guide/start')).toBe('guide/start.html');
+  });
+
+  it('should resolve html file path inside dist path', () => {
+    const distPath = path.resolve('dist');
+    expect(resolveHtmlFilePath(distPath, '/guide/')).toBe(
+      path.join(distPath, 'guide', 'index.html'),
+    );
+  });
+
+  it('should reject html file path outside dist path', () => {
+    const distPath = path.resolve('dist');
+    expect(() => resolveHtmlFilePath(distPath, '../outside')).toThrow(
+      'resolves outside of the output directory',
+    );
+  });
+});

--- a/packages/core/src/node/ssg/htmlFile.ts
+++ b/packages/core/src/node/ssg/htmlFile.ts
@@ -1,0 +1,29 @@
+import { isAbsolute, relative, resolve } from 'node:path';
+
+export const routePath2HtmlFileName = (routePath: string) => {
+  let fileName = routePath;
+  if (fileName.endsWith('/')) {
+    fileName = `${routePath}index.html`;
+  } else {
+    fileName = `${routePath}.html`;
+  }
+
+  return fileName.replace(/^\/+/, '');
+};
+
+export function resolveHtmlFilePath(distPath: string, routePath: string) {
+  const distPathAbsolute = resolve(distPath);
+  const fileAbsolutePath = resolve(
+    distPathAbsolute,
+    routePath2HtmlFileName(routePath),
+  );
+  const relativePath = relative(distPathAbsolute, fileAbsolutePath);
+
+  if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
+    throw new Error(
+      `SSG route path "${routePath}" resolves outside of the output directory.`,
+    );
+  }
+
+  return fileAbsolutePath;
+}

--- a/packages/core/src/node/ssg/renderPageWorker.ts
+++ b/packages/core/src/node/ssg/renderPageWorker.ts
@@ -1,24 +1,55 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
 import { workerData } from 'node:worker_threads';
 import type { RouteMeta, UserConfig } from '@rspress/shared';
 import pMap from 'p-map';
 import { createError } from '../utils';
+import { resolveHtmlFilePath } from './htmlFile';
 import { renderPage } from './renderPage';
 
-interface Args {
-  routes: RouteMeta[];
+interface WorkerDataParams {
   htmlTemplate: string;
   head: UserConfig['head'];
   ssrBundlePath: string;
+  distPath?: string;
 }
 
-const params = workerData?.[1]?.params as Omit<Args, 'route'>;
+interface WorkerTask {
+  routes: RouteMeta[];
+}
+
+const params = workerData?.[1]?.params as WorkerDataParams;
 if (!params) {
   throw createError('SSG Worker Thread workerData params missing');
 }
 
-const { htmlTemplate, head, ssrBundlePath } = params;
+const { htmlTemplate, head, ssrBundlePath, distPath } = params;
 
-const exportWorkerGlueFn = async ({ routes }: Args): Promise<string[]> => {
+async function writeHtmlFile(routePath: string, html: string) {
+  if (!distPath) {
+    return;
+  }
+
+  const fileAbsolutePath = resolveHtmlFilePath(distPath, routePath);
+  await mkdir(dirname(fileAbsolutePath), { recursive: true });
+  await writeFile(fileAbsolutePath, html);
+}
+
+const exportWorkerGlueFn = async ({
+  routes,
+}: WorkerTask): Promise<string[]> => {
+  if (distPath) {
+    await pMap(
+      routes,
+      async route => {
+        const html = await renderPage(route, htmlTemplate, head, ssrBundlePath);
+        await writeHtmlFile(route.routePath, html);
+      },
+      { concurrency: 10 },
+    );
+    return [];
+  }
+
   return pMap(
     routes,
     async route => {

--- a/packages/core/src/node/ssg/renderPages.ts
+++ b/packages/core/src/node/ssg/renderPages.ts
@@ -6,6 +6,7 @@ import picocolors from 'picocolors';
 
 import { hintSSGFailed } from '../logger/hint';
 import type { RouteService } from '../route/RouteService';
+import { routePath2HtmlFileName } from './htmlFile';
 import { renderHtmlTemplate } from './renderHtmlTemplate';
 import { renderPage } from './renderPage';
 import {
@@ -15,25 +16,14 @@ import {
   SSGWorkerThreadTaskSize,
 } from './ssgEnv';
 
-const routePath2HtmlFileName = (routePath: string) => {
-  let fileName = routePath;
-  if (fileName.endsWith('/')) {
-    fileName = `${routePath}index.html`;
-  } else {
-    fileName = `${routePath}.html`;
-  }
-
-  return fileName.replace(/^\/+/, '');
-};
-
 export async function renderPages(
   routeService: RouteService,
   config: UserConfig,
   ssrBundlePath: string,
   htmlTemplate: string,
   emitAsset: (assetName: string, content: string | Buffer) => void,
+  workerOutputDistPath?: string,
 ) {
-  logger.info('Rendering pages...');
   const startTime = Date.now();
   const ssg = config.ssg ?? true;
 
@@ -96,6 +86,9 @@ export async function renderPages(
 
     if (typeof ssg === 'object' && ssg?.experimentalWorker) {
       const numberOfThreads = getNumberOfThreads(routes.length);
+      logger.info(
+        `Rendering pages with experimental SSG worker (${picocolors.yellow(numberOfThreads)} threads)...`,
+      );
       const Tinypool = await import('tinypool').then(m => m.default);
 
       const pool = new Tinypool({
@@ -115,6 +108,7 @@ export async function renderPages(
             htmlTemplate,
             head: config.head,
             ssrBundlePath,
+            distPath: workerOutputDistPath,
           },
         },
       });
@@ -123,6 +117,9 @@ export async function renderPages(
         chunk(routes, SSGWorkerThreadTaskSize()).map(
           async (routes: RouteMeta[]) => {
             const htmlList = await pool.run({ routes });
+            if (workerOutputDistPath) {
+              return;
+            }
             for (let i = 0; i < routes.length; i++) {
               const route = routes[i];
               const html = htmlList[i];
@@ -135,6 +132,7 @@ export async function renderPages(
 
       await pool.destroy();
     } else {
+      logger.info('Rendering pages...');
       await pMap(
         routes,
         async route => {

--- a/packages/core/src/node/ssg/rsbuildPluginSSG.ts
+++ b/packages/core/src/node/ssg/rsbuildPluginSSG.ts
@@ -118,6 +118,7 @@ export const rsbuildPluginSSG = ({
             mainCjsAbsolutePath,
             htmlTemplate,
             emitAsset,
+            distPath,
           );
 
           if (!isDebugMode()) {


### PR DESCRIPTION
## Summary


skip rspack compilation

- Make experimental SSG workers write rendered HTML files directly to the output directory.
- Avoid sending rendered HTML back to the main thread for `compilation.emitAsset` when `ssg.experimentalWorker` is enabled.

## Related Issue

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
