### PR TITLE
fix(theme/Tag): render SVG and local image tags correctly

### DIFF
--- a/packages/core/src/theme/components/Tag/index.test.tsx
+++ b/packages/core/src/theme/components/Tag/index.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, it, rs } from '@rstest/core';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { Tag } from './index';
+
+rs.mock('@rspress/core/runtime', () => ({
+  isDataUrl: (url: string) => url.startsWith('data:'),
+  isExternalUrl: (url: string) => /^https?:\/\//.test(url),
+  normalizeImagePath: (url: string) =>
+    url.startsWith('/') ? `/base${url}` : url,
+}));
+
+rs.mock('@rspress/core/theme', () => ({
+  Badge: ({
+    children,
+    text,
+    type,
+  }: {
+    children?: React.ReactNode;
+    text?: string;
+    type?: string;
+  }) => (
+    <span data-badge-type={type} data-text={text}>
+      {children}
+    </span>
+  ),
+  IconDeprecated: 'deprecated-icon',
+  IconExperimental: 'experimental-icon',
+  SvgWrapper: ({ icon }: { icon: string }) => <span data-icon={icon} />,
+  Tag: ({ tag }: { tag?: string }) => <span data-tag={tag}>{tag}</span>,
+}));
+
+describe('Tag', () => {
+  it('renders inline svg strings before splitting comma-separated tags', () => {
+    const markup = renderToStaticMarkup(
+      <Tag tag='<svg xmlns="http://www.w3.org/2000/svg" width="30" height="20" transform="translate(0, 0)" stroke="white"><text x="0" y="15">test</text></svg>' />,
+    );
+
+    expect(markup).toContain('<svg');
+    expect(markup).toContain('transform="translate(0, 0)"');
+  });
+
+  it('renders root-relative image paths as images', () => {
+    const markup = renderToStaticMarkup(<Tag tag="/my.svg" />);
+
+    expect(markup).toContain('<img');
+    expect(markup).toContain('src="/base/my.svg"');
+  });
+
+  it('keeps rendering multiple common tags separated by commas', () => {
+    const markup = renderToStaticMarkup(<Tag tag="new, experimental" />);
+
+    expect(markup).toContain('data-tag="new"');
+    expect(markup).toContain('data-tag="experimental"');
+  });
+});

--- a/packages/core/src/theme/components/Tag/index.test.tsx
+++ b/packages/core/src/theme/components/Tag/index.test.tsx
@@ -39,7 +39,7 @@ describe('Tag', () => {
     expect(markup).toContain('transform="translate(0, 0)"');
   });
 
-  it('renders root-relative image paths as images', () => {
+  it('renders public folder image paths as images', () => {
     const markup = renderToStaticMarkup(<Tag tag="/my.svg" />);
 
     expect(markup).toContain('<img');

--- a/packages/core/src/theme/components/Tag/index.tsx
+++ b/packages/core/src/theme/components/Tag/index.tsx
@@ -1,4 +1,8 @@
-import { isDataUrl, isExternalUrl } from '@rspress/core/runtime';
+import {
+  isDataUrl,
+  isExternalUrl,
+  normalizeImagePath,
+} from '@rspress/core/runtime';
 import {
   Badge,
   IconDeprecated,
@@ -24,12 +28,24 @@ function parseCommonTagsArrayStr(tagStr: string): string[] | null {
   return tags;
 }
 
+function isLocalImagePath(tag: string): boolean {
+  if (!tag.startsWith('/') && !tag.startsWith('./') && !tag.startsWith('../')) {
+    return false;
+  }
+
+  return /\.(?:avif|gif|ico|jpe?g|png|svg|webp)(?:[?#].*)?$/i.test(tag);
+}
+
 const getTagType = (tag: string) => {
   const normalizedTag = tag.trim();
   const isSvgTagString = normalizedTag.startsWith('<svg');
-  const isPic = isExternalUrl(normalizedTag) || isDataUrl(normalizedTag);
+  const isPic =
+    isExternalUrl(normalizedTag) ||
+    isDataUrl(normalizedTag) ||
+    isLocalImagePath(normalizedTag);
 
-  const tagsArray = parseCommonTagsArrayStr(normalizedTag);
+  const tagsArray =
+    isSvgTagString || isPic ? null : parseCommonTagsArrayStr(normalizedTag);
 
   return {
     isSvgTagString,
@@ -67,14 +83,14 @@ export const Tag = ({ tag }: { tag?: string }) => {
     return (
       <div
         // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{ __html: tag }}
+        dangerouslySetInnerHTML={{ __html: normalizedTag }}
         style={{ width: 20, marginRight: 4 }}
       ></div>
     );
   }
 
   if (isPic) {
-    return <img src={tag} />;
+    return <img src={normalizeImagePath(normalizedTag)} />;
   }
 
   if (normalizedTag === 'experimental') {

--- a/packages/core/src/theme/components/Tag/index.tsx
+++ b/packages/core/src/theme/components/Tag/index.tsx
@@ -19,6 +19,8 @@ const BADGE_TAGS = {
   danger: 'danger',
 } as const;
 
+const IMAGE_EXT_REGEXP = /\.(?:avif|gif|ico|jpe?g|png|svg|webp)(?:[?#].*)?$/i;
+
 function parseCommonTagsArrayStr(tagStr: string): string[] | null {
   const tags = tagStr
     .split(',')
@@ -28,12 +30,8 @@ function parseCommonTagsArrayStr(tagStr: string): string[] | null {
   return tags;
 }
 
-function isLocalImagePath(tag: string): boolean {
-  if (!tag.startsWith('/') && !tag.startsWith('./') && !tag.startsWith('../')) {
-    return false;
-  }
-
-  return /\.(?:avif|gif|ico|jpe?g|png|svg|webp)(?:[?#].*)?$/i.test(tag);
+function isPublicFolderPath(tag: string): boolean {
+  return tag.startsWith('/');
 }
 
 const getTagType = (tag: string) => {
@@ -42,7 +40,7 @@ const getTagType = (tag: string) => {
   const isPic =
     isExternalUrl(normalizedTag) ||
     isDataUrl(normalizedTag) ||
-    isLocalImagePath(normalizedTag);
+    (isPublicFolderPath(normalizedTag) && IMAGE_EXT_REGEXP.test(normalizedTag));
 
   const tagsArray =
     isSvgTagString || isPic ? null : parseCommonTagsArrayStr(normalizedTag);

--- a/website/docs/en/ui/layout-components/tag.mdx
+++ b/website/docs/en/ui/layout-components/tag.mdx
@@ -117,7 +117,7 @@ tag: <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0
 
 ### Image URL
 
-You can use an external URL or data URL as a tag:
+You can use an external URL, data URL, or local image path as a tag:
 
 ```mdx
 ---
@@ -128,6 +128,12 @@ tag: https://example.com/icon.png
 ```mdx
 ---
 tag: data:image/svg+xml;base64,...
+---
+```
+
+```mdx
+---
+tag: /icons/status.svg
 ---
 ```
 
@@ -156,7 +162,7 @@ interface TagProps {
    * - Common tags: 'new', 'experimental', 'deprecated', 'updated'
    * - Multiple common tags: 'new, experimental'
    * - SVG string: '<svg>...</svg>'
-   * - Image URL: 'https://...' or 'data:...'
+   * - Image URL: 'https://...', 'data:...', or '/icons/status.svg'
    * - Plain text: any other string
    */
   tag?: string;

--- a/website/docs/en/ui/layout-components/tag.mdx
+++ b/website/docs/en/ui/layout-components/tag.mdx
@@ -117,7 +117,7 @@ tag: <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0
 
 ### Image URL
 
-You can use an external URL, data URL, or local image path as a tag:
+You can use an external URL, data URL, or public folder path as a tag:
 
 ```mdx
 ---

--- a/website/docs/zh/ui/layout-components/tag.mdx
+++ b/website/docs/zh/ui/layout-components/tag.mdx
@@ -117,7 +117,7 @@ tag: <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0
 
 ### 图片 URL
 
-你可以使用外部 URL、data URL 或本地图片路径作为标签：
+你可以使用外部 URL、data URL 或 public 目录路径作为标签：
 
 ```mdx
 ---

--- a/website/docs/zh/ui/layout-components/tag.mdx
+++ b/website/docs/zh/ui/layout-components/tag.mdx
@@ -117,7 +117,7 @@ tag: <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0
 
 ### 图片 URL
 
-你可以使用外部 URL 或 data URL 作为标签：
+你可以使用外部 URL、data URL 或本地图片路径作为标签：
 
 ```mdx
 ---
@@ -128,6 +128,12 @@ tag: https://example.com/icon.png
 ```mdx
 ---
 tag: data:image/svg+xml;base64,...
+---
+```
+
+```mdx
+---
+tag: /icons/status.svg
 ---
 ```
 
@@ -156,7 +162,7 @@ interface TagProps {
    * - 常用标签：'new'、'experimental'、'deprecated'、'updated'
    * - 多个常用标签：'new, experimental'
    * - SVG 字符串：'<svg>...</svg>'
-   * - 图片 URL：'https://...' 或 'data:...'
+   * - 图片 URL：'https://...'、'data:...' 或 '/icons/status.svg'
    * - 纯文本：任意其他字符串
    */
   tag?: string;


### PR DESCRIPTION
## Summary

Fixes tag rendering so inline SVG strings are detected before comma-separated tag parsing, preventing SVG attributes such as `transform="translate(0, 0)"` from becoming text badges. It also supports local image paths like `/my.svg` through the existing image path normalization and updates the Tag docs.

## Related Issue

Fixes https://github.com/web-infra-dev/rspress/issues/3427

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).