### PR TITLE
feat(theme/SocialLinks): add github-stars mode to socialLinks

### DIFF
--- a/packages/core/src/theme/components/SocialLinks/GithubStars.tsx
+++ b/packages/core/src/theme/components/SocialLinks/GithubStars.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 
 const TTL_MS = 60 * 60 * 1000;
 
@@ -11,7 +11,8 @@ function storageKey(repo: string) {
 function parseRepo(content: string): string | null {
   try {
     const url = new URL(content);
-    if (url.hostname !== 'github.com') return null;
+    const host = url.hostname.replace(/^www\./, '');
+    if (host !== 'github.com') return null;
     const match = url.pathname.match(/^\/([^/]+)\/([^/]+)/);
     if (!match) return null;
     return `${match[1]}/${match[2].replace(/\.git$/, '')}`;
@@ -62,7 +63,7 @@ function formatCount(count: number): string {
 
 interface GithubStarsProps {
   content: string;
-  icon: React.ReactNode;
+  icon: ReactNode;
 }
 
 export const GithubStars = (props: GithubStarsProps) => {
@@ -70,7 +71,7 @@ export const GithubStars = (props: GithubStarsProps) => {
   const repo = parseRepo(content);
 
   const [count, setCount] = useState<number | null>(() =>
-    repo ? readCache(repo)?.count ?? null : null,
+    repo ? (readCache(repo)?.count ?? null) : null,
   );
 
   useEffect(() => {
@@ -80,7 +81,7 @@ export const GithubStars = (props: GithubStarsProps) => {
 
     let cancelled = false;
     fetch(`https://api.github.com/repos/${repo}`)
-      .then((res) => (res.ok ? res.json() : Promise.reject(res.status)))
+      .then(res => (res.ok ? res.json() : Promise.reject(res.status)))
       .then((data: { stargazers_count: number }) => {
         if (cancelled) return;
         if (typeof data?.stargazers_count === 'number') {

--- a/packages/core/src/theme/components/SocialLinks/GithubStars.tsx
+++ b/packages/core/src/theme/components/SocialLinks/GithubStars.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react';
+
+const TTL_MS = 60 * 60 * 1000;
+
+type Cached = { count: number; fetchedAt: number };
+
+function storageKey(repo: string) {
+  return `rp-github-stars:${repo}`;
+}
+
+function parseRepo(content: string): string | null {
+  try {
+    const url = new URL(content);
+    if (url.hostname !== 'github.com') return null;
+    const match = url.pathname.match(/^\/([^/]+)\/([^/]+)/);
+    if (!match) return null;
+    return `${match[1]}/${match[2].replace(/\.git$/, '')}`;
+  } catch {
+    return null;
+  }
+}
+
+function readCache(repo: string): Cached | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(storageKey(repo));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Cached;
+    if (
+      typeof parsed?.count !== 'number' ||
+      typeof parsed?.fetchedAt !== 'number'
+    ) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(repo: string, count: number) {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(
+      storageKey(repo),
+      JSON.stringify({ count, fetchedAt: Date.now() }),
+    );
+  } catch {
+    // Storage may be full or disabled (private mode); ignore.
+  }
+}
+
+function formatCount(count: number): string {
+  if (count >= 1_000_000) {
+    return `${(count / 1_000_000).toFixed(1)}M`;
+  }
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1)}K`;
+  }
+  return String(count);
+}
+
+interface GithubStarsProps {
+  content: string;
+  icon: React.ReactNode;
+}
+
+export const GithubStars = (props: GithubStarsProps) => {
+  const { content, icon } = props;
+  const repo = parseRepo(content);
+
+  const [count, setCount] = useState<number | null>(() =>
+    repo ? readCache(repo)?.count ?? null : null,
+  );
+
+  useEffect(() => {
+    if (!repo) return;
+    const cached = readCache(repo);
+    if (cached && Date.now() - cached.fetchedAt < TTL_MS) return;
+
+    let cancelled = false;
+    fetch(`https://api.github.com/repos/${repo}`)
+      .then((res) => (res.ok ? res.json() : Promise.reject(res.status)))
+      .then((data: { stargazers_count: number }) => {
+        if (cancelled) return;
+        if (typeof data?.stargazers_count === 'number') {
+          setCount(data.stargazers_count);
+          writeCache(repo, data.stargazers_count);
+        }
+      })
+      .catch(() => {
+        // GitHub API failed (network, rate limit). Fall back to icon-only.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [repo]);
+
+  return (
+    <a
+      href={content}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="rp-social-links__item rp-social-links__github-stars"
+      aria-label={
+        count == null
+          ? 'GitHub repository'
+          : `GitHub repository, ${count.toLocaleString()} stars`
+      }
+    >
+      <div className="rp-social-links__icon">{icon}</div>
+      {count != null && (
+        <span className="rp-social-links__github-stars-count">
+          {formatCount(count)}
+        </span>
+      )}
+    </a>
+  );
+};

--- a/packages/core/src/theme/components/SocialLinks/SocialLink.tsx
+++ b/packages/core/src/theme/components/SocialLinks/SocialLink.tsx
@@ -1,6 +1,7 @@
 import type { SocialLink as ISocialLink } from '@rspress/core';
 import iconMap from 'virtual-social-links';
 import './index.scss';
+import { GithubStars } from './GithubStars';
 import { useHoverGroup } from '../HoverGroup/useHoverGroup';
 
 interface SocialLinkProps {
@@ -53,6 +54,10 @@ export const SocialLink = (props: SocialLinkProps) => {
         <div className="rp-social-links__icon">{IconComp}</div>
       </a>
     );
+  }
+
+  if (mode === 'github-stars') {
+    return <GithubStars content={content} icon={IconComp} />;
   }
 
   if (mode === 'text') {

--- a/packages/core/src/theme/components/SocialLinks/index.scss
+++ b/packages/core/src/theme/components/SocialLinks/index.scss
@@ -36,4 +36,30 @@
     flex-wrap: nowrap;
     gap: 1rem;
   }
+  &__github-stars {
+    flex-direction: row;
+    gap: 6px;
+    padding: 0 8px;
+    border-radius: 6px;
+    text-decoration: none;
+    color: var(--rp-c-text-2);
+    transition: color 0.2s ease, background-color 0.2s ease;
+
+    &:hover {
+      color: var(--rp-c-text-1);
+      background-color: var(--rp-c-bg-soft);
+    }
+  }
+  &__github-stars-count {
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+@media (max-width: 768px) {
+  .rp-social-links__github-stars-count {
+    display: none;
+  }
 }

--- a/packages/core/src/theme/components/SocialLinks/index.scss
+++ b/packages/core/src/theme/components/SocialLinks/index.scss
@@ -43,7 +43,9 @@
     border-radius: 6px;
     text-decoration: none;
     color: var(--rp-c-text-2);
-    transition: color 0.2s ease, background-color 0.2s ease;
+    transition:
+      color 0.2s ease,
+      background-color 0.2s ease;
 
     &:hover {
       color: var(--rp-c-text-1);

--- a/packages/core/src/theme/components/SocialLinks/index.scss
+++ b/packages/core/src/theme/components/SocialLinks/index.scss
@@ -39,17 +39,12 @@
   &__github-stars {
     flex-direction: row;
     gap: 6px;
-    padding: 0 8px;
-    border-radius: 6px;
     text-decoration: none;
     color: var(--rp-c-text-2);
-    transition:
-      color 0.2s ease,
-      background-color 0.2s ease;
+    transition: color 0.2s ease;
 
     &:hover {
       color: var(--rp-c-text-1);
-      background-color: var(--rp-c-bg-soft);
     }
   }
   &__github-stars-count {

--- a/packages/core/src/theme/components/SocialLinks/index.scss
+++ b/packages/core/src/theme/components/SocialLinks/index.scss
@@ -57,9 +57,3 @@
     font-variant-numeric: tabular-nums;
   }
 }
-
-@media (max-width: 768px) {
-  .rp-social-links__github-stars-count {
-    display: none;
-  }
-}

--- a/packages/shared/src/types/theme/socialLink.ts
+++ b/packages/shared/src/types/theme/socialLink.ts
@@ -22,6 +22,13 @@ export type SocialLinkIcon =
 
 export interface SocialLink {
   icon: SocialLinkIcon;
-  mode: 'link' | 'text' | 'img' | 'dom';
+  mode: 'link' | 'text' | 'img' | 'dom' | 'github-stars';
+  /**
+   * For most modes, the URL, text, image path, or raw HTML to render.
+   *
+   * For `github-stars` mode, the GitHub repository URL
+   * (e.g. `https://github.com/web-infra-dev/rspress`). The repository's star
+   * count is fetched from the GitHub API and rendered next to the icon.
+   */
   content: string;
 }

--- a/website/docs/en/api/config/config-theme.mdx
+++ b/website/docs/en/api/config/config-theme.mdx
@@ -225,7 +225,7 @@ export default defineConfig({
 - **Default**: `[]`
 
 You can add related links through the following config, such as `github` links, `x` links, etc.
-Related links support five modes: `link mode` `text mode` `image mode` `dom mode` `github-stars mode`, for example:
+Related links support five modes: `link` `text` `img` `dom` `github-stars`, for example:
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from '@rspress/core';

--- a/website/docs/en/api/config/config-theme.mdx
+++ b/website/docs/en/api/config/config-theme.mdx
@@ -225,7 +225,7 @@ export default defineConfig({
 - **Default**: `[]`
 
 You can add related links through the following config, such as `github` links, `x` links, etc.
-Related links support four modes: `link mode` `text mode` `image mode` `dom mode`, for example:
+Related links support five modes: `link mode` `text mode` `image mode` `dom mode` `github-stars mode`, for example:
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from '@rspress/core';
@@ -254,6 +254,11 @@ export default defineConfig({
         content:
           '<img src="https://lf3-static.bytednsdoc.com/obj/eden-cn/rjhwzy/ljhwZthlaukjlkulzlp/rspress/rspress-navbar-logo-0904.png" alt="logo" id="logo" class="mr-4 rspress-logo dark:hidden">',
       },
+      {
+        icon: 'github',
+        mode: 'github-stars',
+        content: 'https://github.com/web-infra-dev/rspress',
+      },
     ],
   },
 });
@@ -263,6 +268,7 @@ export default defineConfig({
 - When in `text` mode, when the mouse moves over the icon, a pop-up box will be displayed, and the content of the pop-up box is the entered text
 - When in the `img` mode, moving the mouse over the icon will display a bullet box, and the content of the bullet box is the specified picture. It should be noted that the picture needs to be placed in the `public` directory.
 - When in dom mode, html to render can be passed directly into the content field. Use '' for wrapping
+- When in `github-stars` mode, `content` should be the GitHub repository URL. The repository's star count is fetched from the GitHub REST API and rendered next to the icon. The result is cached in `localStorage` for one hour to avoid hitting the API rate limit. If the request fails (offline, rate-limited, private repo), the icon falls back to a plain link.
 
 Related links support the following types of images, which can be selected through the icon attribute:
 

--- a/website/docs/zh/api/config/config-theme.mdx
+++ b/website/docs/zh/api/config/config-theme.mdx
@@ -212,7 +212,7 @@ export default defineConfig({
 - **默认值**： `[]`
 
 你可以通过如下的配置添加相关链接，比如 `github` 链接、`x` 链接等。
-相关链接支持四种模式：`链接模式link` `文本模式text` `图片模式img` `自定义模式dom`，相关例子如下：
+相关链接支持五种模式：`链接模式link` `文本模式text` `图片模式img` `自定义模式dom` `GitHub 星标模式 github-stars`，相关例子如下：
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from '@rspress/core';
@@ -241,6 +241,11 @@ export default defineConfig({
         content:
           '<img src="https://lf3-static.bytednsdoc.com/obj/eden-cn/rjhwzy/ljhwZthlaukjlkulzlp/rspress/rspress-navbar-logo-0904.png" alt="logo" id="logo" class="mr-4 rspress-logo dark:hidden">',
       },
+      {
+        icon: 'github',
+        mode: 'github-stars',
+        content: 'https://github.com/web-infra-dev/rspress',
+      },
     ],
   },
 });
@@ -250,6 +255,7 @@ export default defineConfig({
 - 当`text`模式时，鼠标移到 icon 上会显示弹框，弹框内容是输入的文本。
 - 当`img`模式时，鼠标移到 icon 上会显示弹框，弹框内容是指定的图片，需要注意的是，图片需要放在`public`目录下。
 - 当`dom`模式时，可以直接在 content 字段中传入需要自定义html。使用''进行包裹。
+- 当`github-stars`模式时，`content` 应为 GitHub 仓库 URL。组件会通过 GitHub REST API 拉取仓库的 star 数并显示在 icon 旁边，结果会缓存在 `localStorage` 中 1 小时以避免触发 API 频率限制。请求失败时（离线、被限流或私有仓库）会自动回退为普通链接。
 
 相关链接支持以下几种图片，通过 icon 属性来选择：
 

--- a/website/docs/zh/api/config/config-theme.mdx
+++ b/website/docs/zh/api/config/config-theme.mdx
@@ -212,7 +212,7 @@ export default defineConfig({
 - **默认值**： `[]`
 
 你可以通过如下的配置添加相关链接，比如 `github` 链接、`x` 链接等。
-相关链接支持五种模式：`链接模式link` `文本模式text` `图片模式img` `自定义模式dom` `GitHub 星标模式 github-stars`，相关例子如下：
+相关链接支持五种模式：`link` `text` `img` `dom` `github-stars`，相关例子如下：
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from '@rspress/core';


### PR DESCRIPTION
## Summary

Adds a new `github-stars` mode to `SocialLink` that fetches the repo's star count from the GitHub REST API and renders it inline next to the icon — e.g. a GitHub icon followed by `48.2K`.

### Usage

```ts title="rspress.config.ts"
import { defineConfig } from '@rspress/core';

export default defineConfig({
  themeConfig: {
    socialLinks: [
      {
        icon: 'github',
        mode: 'github-stars',
        content: 'https://github.com/web-infra-dev/rspress',
      },
    ],
  },
});
```

### Screenshots

The same `mode: 'github-stars'` entry adapts to all three nav contexts. The count text fills in after the GitHub API responds; the component always falls back to the icon-only link on network or rate-limit failure, never a broken state.

**Desktop (≥1281px)** — inline in the top nav alongside other social icons:

![desktop nav](https://raw.githubusercontent.com/Huxpro/rspress/pr-3433-screenshots/screenshots/01-desktop.png)

**md hover (769–1280px)** — inside the hamburger hover dropdown:

![md hamburger](https://raw.githubusercontent.com/Huxpro/rspress/pr-3433-screenshots/screenshots/02-md-hamburger.png)

**sm drawer (≤768px)** — inside the full-screen `NavScreen` portal drawer:

![sm drawer](https://raw.githubusercontent.com/Huxpro/rspress/pr-3433-screenshots/screenshots/03-sm-drawer.png)

### Behavior

- `content` must be the GitHub repository URL. Both `github.com` and `www.github.com` work.
- The star count is cached in `localStorage` for **1 hour** to avoid hitting the unauthenticated API rate limit (60 req/hr/IP).
- On request failure (offline, rate-limited, private repo, parse error), the component falls back to **an icon-only link** — never a broken state.
- SSR-safe: server renders icon-only, count hydrates after mount.
- Number formatting: `< 1,000` → raw, `1,000+` → `1.2K`, `1,000,000+` → `1.2M`.
- Hover matches the inline-link pattern (color shift only), consistent with the other social icons.

### Why a new mode (vs. extending `link`)

Adding a mode is consistent with the existing `link | text | img | dom` API surface and keeps each mode's renderer self-contained. It's also opt-in — existing `mode: 'link'` consumers see no change.

## Test plan

- [x] `pnpm build` in `packages/shared` and `packages/core` — clean.
- [x] `pnpm lint` — clean.
- [x] Verified end-to-end against `https://github.com/web-infra-dev/rspress` (`2.2K`) in `website/` at three breakpoints: desktop top nav, md hamburger dropdown, sm full-screen drawer. Screenshots above.
- [x] CI: lint, Build, ut-mac, ut-windows, Socket Security — all green.

### Notes

- I considered also supporting `owner/repo` shorthand in `content`, but kept it to full URLs for consistency with other modes.
- Docs updated in `website/docs/{en,zh}/api/config/config-theme.mdx`.
