### PR TITLE
feat(mdx): support markdown `?raw` query imports

### DIFF
--- a/e2e/fixtures/basic/doc/_raw-content.md
+++ b/e2e/fixtures/basic/doc/_raw-content.md
@@ -1,0 +1,3 @@
+# Raw Markdown
+
+This file should be imported as source text.

--- a/e2e/fixtures/basic/doc/index.mdx
+++ b/e2e/fixtures/basic/doc/index.mdx
@@ -1,3 +1,5 @@
+import rawContent from './_raw-content.md?raw';
+
 # Hello world
 
 :::tip TIP
@@ -7,3 +9,5 @@ This is a TIP.
 :::
 
 [link](https://example/com)
+
+<pre data-testid="raw-markdown-content">{rawContent}</pre>

--- a/e2e/fixtures/basic/index.test.ts
+++ b/e2e/fixtures/basic/index.test.ts
@@ -74,6 +74,20 @@ test.describe('basic test', async () => {
     const link = page.locator('.rp-doc a').first();
     await expect(link).toHaveCSS('color', 'rgb(255, 165, 0)');
   });
+
+  test('importing markdown with raw query should return source text', async ({
+    page,
+  }) => {
+    await page.goto(`http://localhost:${appPort}`, {
+      waitUntil: 'networkidle',
+    });
+    await expect(page.getByTestId('raw-markdown-content')).toContainText(
+      '# Raw Markdown',
+    );
+    await expect(page.getByTestId('raw-markdown-content')).toContainText(
+      'This file should be imported as source text.',
+    );
+  });
 });
 
 test.describe('CLI base option', async () => {

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -68,6 +68,7 @@ function isPluginIncluded(config: UserConfig, pluginName: string): boolean {
 }
 
 const require = createRequire(import.meta.url);
+const RAW_QUERY_REGEXP = /[?&]raw(?:&|=|$)/;
 
 async function getVirtualModulesFromPlugins(
   pluginDriver: PluginDriver,
@@ -344,14 +345,18 @@ async function createInternalBuildConfig(
 
         chain.module
           .rule('MDX')
-          .type('javascript/auto')
           .test(MDX_OR_MD_REGEXP)
           .resolve.merge({
             conditionNames: jsModuleRule.resolve.conditionNames.values(),
             mainFields: jsModuleRule.resolve.mainFields.values(),
           })
           .end()
+          .oneOf('MDXRaw')
+          .type('asset/source')
+          .resourceQuery(RAW_QUERY_REGEXP)
+          .end()
           .oneOf('MDXCompile')
+          .type('javascript/auto')
           .use('builtin:swc-loader')
           .loader('builtin:swc-loader')
           .options(swcLoaderOptions)


### PR DESCRIPTION
## Summary

This PR supports Markdown and MDX imports with `?raw` so they resolve to source text instead of being compiled by the MDX loader.

A docs page was following the documented raw-import pattern:

```ts
import promptContent from './_migration.prompt.md?raw';
```

The imported value unexpectedly contained MDX-compiled runtime code instead of the original Markdown source. The copied `?raw` value looked like this sanitized MDX output instead of Markdown text:

```ts
function MDXContent() {
  let props = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {};
  const { wrapper: MDXLayout } = {
    ..._mdx_js_react__rspack_import_1.useMDXComponents(),
    ...props.components,
  };
  return MDXLayout
    ? (0, react_jsx_runtime__rspack_import_0.jsx)(MDXLayout, {
        ...props,
        children: (0, react_jsx_runtime__rspack_import_0.jsx)(createMdxContent, {
          ...props,
        }),
      })
    : createMdxContent(props);
}
```

It also surfaced as a TypeScript error:

```txt
Cannot find name 'createMdxContent'.
```

This happened because the Rspress MDX rule matched the file before the raw query could be handled. The fix adds a raw-query branch for Markdown/MDX files and keeps normal Markdown/MDX imports on the existing MDX compile path.

A basic fixture regression verifies that a private Markdown file imported with `?raw` renders the original source text.

## Related Issue

https://github.com/web-infra-dev/rsbuild/pull/5353

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
