### PR TITLE
fix(mdx): normalize rule ids from `MDX` to oneOf `mdx` and `mdx-raw`

### DIFF
--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -344,18 +344,18 @@ async function createInternalBuildConfig(
           .get('options');
 
         chain.module
-          .rule('MDX')
+          .rule('mdx')
           .test(MDX_OR_MD_REGEXP)
           .resolve.merge({
             conditionNames: jsModuleRule.resolve.conditionNames.values(),
             mainFields: jsModuleRule.resolve.mainFields.values(),
           })
           .end()
-          .oneOf('MDXRaw')
+          .oneOf('mdx-raw')
           .type('asset/source')
           .resourceQuery(RAW_QUERY_REGEXP)
           .end()
-          .oneOf('MDXCompile')
+          .oneOf('mdx')
           .type('javascript/auto')
           .use('builtin:swc-loader')
           .loader('builtin:swc-loader')


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/web-infra-dev/rspress/pull/3434. This PR normalizes the internal Rsbuild/Rspack chain ids for the Markdown/MDX rule: the top-level rule is now `mdx`, the normal compile branch is `mdx`, and the raw-query branch is `mdx-raw`. There is no intended behavior change.

Validation:

- `pnpm --dir e2e/fixtures/basic run build`
- `pnpm exec playwright test e2e/fixtures/basic/index.test.ts --grep "raw query"`
- `pnpm --dir packages/core run build` was attempted, but current `origin/main` fails during declaration generation in `src/theme/components/SocialLinks/SocialLink.tsx:59` because `github-stars` is not in the mode union.

## Related Issue

Follow-up to https://github.com/web-infra-dev/rspress/pull/3434

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
