### PR TITLE
docs: use github-stars social link

### DIFF
--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -181,7 +181,7 @@ export default defineConfig({
     socialLinks: [
       {
         icon: 'github',
-        mode: 'link',
+        mode: 'github-stars',
         content: 'https://github.com/web-infra-dev/rspress',
       },
       {


### PR DESCRIPTION
## Summary

This PR switches the website GitHub social link to the new `github-stars` mode so the docs navbar can show the repository star count instead of an icon-only link.

Validation:

- `pnpm exec prettier website/rspress.config.ts --check`
- `pnpm exec rslint website/rspress.config.ts`

## Related Issue

Related GitHub star PR index:

- https://github.com/web-infra-dev/rspress/pull/3433 - adds `github-stars` mode to `themeConfig.socialLinks`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).