### PR TITLE
fix(theme/Banner): keep mobile banner single-line

### DIFF
--- a/e2e/fixtures/banner/index.test.ts
+++ b/e2e/fixtures/banner/index.test.ts
@@ -33,4 +33,41 @@ test.describe('tabs-component test', async () => {
     );
     expect(stored).toBe('true');
   });
+
+  test('Banner message stays single line on narrow viewport', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto(`http://localhost:${appPort}`, {
+      waitUntil: 'networkidle',
+    });
+    await page.waitForSelector('.rp-banner');
+
+    const layout = await page.locator('.rp-banner').evaluate(element => {
+      const link = element.querySelector('.rp-banner__link');
+      const close = element.querySelector('.rp-banner__close');
+
+      if (!link || !close) {
+        throw new Error('Banner link or close button not found');
+      }
+
+      const linkStyle = window.getComputedStyle(link);
+      const bannerRect = element.getBoundingClientRect();
+      const linkRect = link.getBoundingClientRect();
+      const closeRect = close.getBoundingClientRect();
+
+      return {
+        bannerHeight: bannerRect.height,
+        closeLeft: closeRect.left,
+        linkHeight: linkRect.height,
+        linkRight: linkRect.right,
+        whiteSpace: linkStyle.whiteSpace,
+      };
+    });
+
+    expect(layout.bannerHeight).toBe(36);
+    expect(layout.linkHeight).toBeLessThanOrEqual(layout.bannerHeight);
+    expect(layout.linkRight).toBeLessThanOrEqual(layout.closeLeft);
+    expect(layout.whiteSpace).toBe('nowrap');
+  });
 });

--- a/packages/core/src/theme/components/Banner/index.scss
+++ b/packages/core/src/theme/components/Banner/index.scss
@@ -17,11 +17,22 @@
   z-index: 999;
   background: var(--rp-banner-background);
   height: 36px;
+  box-sizing: border-box;
+  padding: 0 3.5rem;
 
   &__link {
+    display: block;
+    flex: 1 1 auto;
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
     color: #fff;
     font-weight: 700;
+    line-height: 36px;
+    text-align: center;
     text-decoration: none;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 
     &:hover {
       text-decoration: underline;

--- a/packages/core/src/theme/components/Banner/index.tsx
+++ b/packages/core/src/theme/components/Banner/index.tsx
@@ -97,7 +97,11 @@ export const Banner = forwardRef<HTMLDivElement, BannerProps>(
         <div className={clsx('rp-banner', className)} ref={ref}>
           {customChildren ?? (
             <>
-              <Link href={href} className="rp-banner__link">
+              <Link
+                href={href}
+                className="rp-banner__link"
+                title={typeof message === 'string' ? message : undefined}
+              >
                 {message}
               </Link>
               <SvgWrapper


### PR DESCRIPTION
## Summary

This PR fixes mobile banner wrapping by keeping the default Banner message on a single line with ellipsis, while preserving a stable click area for the close button. It also adds a narrow viewport e2e assertion to prevent regressions.

### Original Screenshot

<img width="423" height="617" alt="image" src="https://raw.githubusercontent.com/SoonIter/rspress/pr-3439-assets/assets/pr-3439/mobile-banner-before.png" />



### After

<img width="423" height="617" alt="image" src="https://github.com/user-attachments/assets/9a9f5625-0859-4dd4-8bae-0537a2df6c7e" />


## Related Issue

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).