### PR TITLE
perf(auto-nav-sidebar): cache site data module in production

### DIFF
--- a/packages/core/src/node/runtimeModule/siteData/rsbuildPlugin.ts
+++ b/packages/core/src/node/runtimeModule/siteData/rsbuildPlugin.ts
@@ -1,41 +1,94 @@
+import { isProduction } from '@rspress/shared';
 import { logger } from '@rspress/shared/logger';
 import { modifyConfigWithAutoNavSide } from '../../auto-nav-sidebar';
 import { RuntimeModuleID, type VirtualModulePlugin } from '../types';
 import { createSiteData } from './createSiteData';
 
+type SiteDataModule = {
+  code: string;
+  metaFileSet: Set<string>;
+  mdFileSet: Set<string>;
+};
+
 export const siteDataVMPlugin: VirtualModulePlugin = context => {
   const { config, pluginDriver } = context;
+  // Production builds can request siteData from multiple compiler targets.
+  // Cache the generation work to avoid repeated auto-nav/sidebar scans.
+  let siteDataModulePromise: Promise<SiteDataModule> | undefined;
+
+  const createSiteDataModule = async (
+    metaFileSet = new Set<string>(),
+    mdFileSet = new Set<string>(),
+  ): Promise<SiteDataModule> => {
+    const force = !pluginDriver.haveNavSidebarConfig;
+
+    const now = performance.now();
+
+    try {
+      await modifyConfigWithAutoNavSide(config, metaFileSet, mdFileSet, force);
+    } finally {
+      logger.debug(
+        `modifyConfigWithAutoNavSide - size: ${mdFileSet.size} cost: ${performance.now() - now}ms`,
+      );
+    }
+
+    const { siteData } = await createSiteData(config);
+    return {
+      code: `export default ${JSON.stringify(siteData, null, 2)}`,
+      metaFileSet,
+      mdFileSet,
+    };
+  };
+
+  const getSiteDataModule = (
+    metaFileSet: Set<string>,
+    mdFileSet: Set<string>,
+  ) => {
+    // Development keeps regenerating siteData so dependencies stay fresh for HMR.
+    if (!isProduction()) {
+      return createSiteDataModule(metaFileSet, mdFileSet);
+    }
+    siteDataModulePromise ??= createSiteDataModule(
+      metaFileSet,
+      mdFileSet,
+    ).catch(error => {
+      siteDataModulePromise = undefined;
+      throw error;
+    });
+    return siteDataModulePromise;
+  };
+
+  const addSiteDataDependencies = (
+    addDependency: (file: string) => void,
+    metaFileSet: Set<string>,
+    mdFileSet: Set<string>,
+  ) => {
+    for (const metaFile of metaFileSet) {
+      addDependency(metaFile);
+    }
+    // TODO: incremental
+    // perf issue of add too much md files to dependencies, trigger auto-nav-sidebar too often
+    for (const mdFile of mdFileSet) {
+      addDependency(mdFile);
+    }
+  };
+
   return {
     [RuntimeModuleID.SiteData]: async ({ addDependency }) => {
-      const force = !pluginDriver.haveNavSidebarConfig;
       const metaFileSet = new Set<string>();
       const mdFileSet = new Set<string>();
-
-      const now = performance.now();
+      let siteDataModule: SiteDataModule | undefined;
 
       try {
-        await modifyConfigWithAutoNavSide(
-          config,
-          metaFileSet,
-          mdFileSet,
-          force,
-        );
+        siteDataModule = await getSiteDataModule(metaFileSet, mdFileSet);
+        return siteDataModule.code;
       } finally {
-        for (const metaFile of metaFileSet) {
-          addDependency(metaFile);
-        }
-        // TODO: incremental
-        // perf issue of add too much md files to dependencies, trigger auto-nav-sidebar too often
-        for (const mdFile of mdFileSet) {
-          addDependency(mdFile);
-        }
-        logger.debug(
-          `modifyConfigWithAutoNavSide - size: ${mdFileSet.size} cost: ${performance.now() - now}ms`,
+        addSiteDataDependencies(
+          addDependency,
+          siteDataModule?.metaFileSet ?? metaFileSet,
+          siteDataModule?.mdFileSet ?? mdFileSet,
         );
       }
-
-      const { siteData } = await createSiteData(config);
-      return `export default ${JSON.stringify(siteData, null, 2)}`;
     },
   };
 };


### PR DESCRIPTION
## Summary

This PR caches the generated siteData virtual module during production builds so multiple compiler targets can reuse the same auto-nav/sidebar and site data generation work. Development builds still regenerate the module to keep dependency tracking and HMR behavior unchanged.

## Performance

Measured with temporary siteData instrumentation on this PR branch, comparing the current cache behavior against the same code with cache disabled by `RSPRESS_SITE_DATA_CACHE_BENCH_NO_CACHE=1`. `@rspress/core` was rebuilt before measuring, and each benchmark removed `doc_build` and `node_modules/.cache` before every run. `pluginOg` was disabled for the website benchmark to reduce unrelated work.

The instrumentation confirms the cache is working: the same production build still requests `siteData` once per compiler target, but the expensive generation step only runs once when the cache is enabled.

| Target | Requests | Generates with cache | Generates without cache | Cached generation total | Uncached generation total | Saved generation work |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `website` siteData generation (5 runs) | 3 | 1 | 3 | `9.627s` avg | `22.182s` avg | `12.555s` / `56.6%` |
| `e2e/fixtures/auto-nav-sidebar` siteData generation (10 runs) | 2 | 1 | 2 | `493.9ms` avg | `648.5ms` avg | `154.6ms` / `23.8%` |

This is a direct benchmark of the cached siteData generation phase. The full build wall-clock benchmark did not show stable positive savings in this run because duplicated generation across compiler targets can overlap and total build time has high variance.

## Related Issue

None

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).