### PR TITLE
docs: mention dark mode CSS variable selectors

### DIFF
--- a/website/docs/en/ui/vars.mdx
+++ b/website/docs/en/ui/vars.mdx
@@ -6,6 +6,8 @@ description: List of Rspress built-in CSS variables for customizing brand colors
 
 Rspress exposes commonly used CSS variables, the simplest and most maintainable approach in [custom themes](/guide/basic/custom-theme). You can edit and preview in real time on this page, then copy the result to your project for style overriding. See [CSS variables](/guide/basic/custom-theme#css-variables) for how to override these styles.
 
+When overriding CSS variables in dark mode, both `html.rp-dark` and `html.dark` can be used as dark mode selectors.
+
 :::tip
 
 You can use the "Copy Markdown" feature on this page to let your AI Agent help you modify CSS variables.

--- a/website/docs/zh/ui/vars.mdx
+++ b/website/docs/zh/ui/vars.mdx
@@ -6,6 +6,8 @@ description: Rspress 内置 CSS 变量列表，用于自定义品牌色、代码
 
 Rspress 暴露了一些常用的 CSS 变量，[自定义主题](/guide/basic/custom-theme) 中最简单也最易维护的方式。你可以在该页面实时编辑和预览，然后复制到你的项目中进行样式覆盖。覆盖方式见 [CSS 变量](/guide/basic/custom-theme#css-variables)。
 
+覆盖暗黑模式下的 CSS 变量时，`html.rp-dark` 和 `html.dark` 都可以作为暗黑模式选择器。
+
 :::tip
 
 可以使用本页面的 "复制 Markdown" 功能，让你的 AI Agent 帮你修改 CSS 变量。


### PR DESCRIPTION
## Summary

- Document that both `html.rp-dark` and `html.dark` can be used as dark mode selectors when overriding CSS variables.
- Update both English and Chinese CSS variables docs.
- Validation: `pnpm exec prettier --check website/docs/zh/ui/vars.mdx website/docs/en/ui/vars.mdx`, `pnpm cspell website/docs/zh/ui/vars.mdx website/docs/en/ui/vars.mdx`, and `git diff --check`.

## Related Issue

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
