### PR TITLE
fix(auto-nav-sidebar): isolate global sidebar by version

### DIFF
--- a/e2e/fixtures/multi-version-global-sidebar/docs/v1/_meta.json
+++ b/e2e/fixtures/multi-version-global-sidebar/docs/v1/_meta.json
@@ -1,0 +1,1 @@
+["index", "guide"]

--- a/e2e/fixtures/multi-version-global-sidebar/docs/v1/_nav.json
+++ b/e2e/fixtures/multi-version-global-sidebar/docs/v1/_nav.json
@@ -1,0 +1,6 @@
+[
+  {
+    "text": "Version One",
+    "link": "/"
+  }
+]

--- a/e2e/fixtures/multi-version-global-sidebar/docs/v1/guide.md
+++ b/e2e/fixtures/multi-version-global-sidebar/docs/v1/guide.md
@@ -1,0 +1,1 @@
+# Version one guide

--- a/e2e/fixtures/multi-version-global-sidebar/docs/v1/index.md
+++ b/e2e/fixtures/multi-version-global-sidebar/docs/v1/index.md
@@ -1,0 +1,1 @@
+# Version one

--- a/e2e/fixtures/multi-version-global-sidebar/docs/v2/_meta.json
+++ b/e2e/fixtures/multi-version-global-sidebar/docs/v2/_meta.json
@@ -1,0 +1,1 @@
+["index", "guide"]

--- a/e2e/fixtures/multi-version-global-sidebar/docs/v2/_nav.json
+++ b/e2e/fixtures/multi-version-global-sidebar/docs/v2/_nav.json
@@ -1,0 +1,6 @@
+[
+  {
+    "text": "Version Two",
+    "link": "/"
+  }
+]

--- a/e2e/fixtures/multi-version-global-sidebar/docs/v2/guide.md
+++ b/e2e/fixtures/multi-version-global-sidebar/docs/v2/guide.md
@@ -1,0 +1,1 @@
+# Version two guide

--- a/e2e/fixtures/multi-version-global-sidebar/docs/v2/index.md
+++ b/e2e/fixtures/multi-version-global-sidebar/docs/v2/index.md
@@ -1,0 +1,1 @@
+# Version two

--- a/e2e/fixtures/multi-version-global-sidebar/index.test.ts
+++ b/e2e/fixtures/multi-version-global-sidebar/index.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test';
+import { getSidebarTexts } from '../../utils/getSideBar';
+import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
+
+test.describe('Multi version global sidebar test', async () => {
+  let appPort: number;
+  let app: Awaited<ReturnType<typeof runDevCommand>>;
+  test.beforeAll(async () => {
+    const appDir = import.meta.dirname;
+    appPort = await getPort();
+    app = await runDevCommand(appDir, appPort);
+  });
+
+  test.afterAll(async () => {
+    if (app) {
+      await killProcess(app);
+    }
+  });
+
+  test('Should keep global sidebar isolated by version', async ({ page }) => {
+    await page.goto(`http://localhost:${appPort}/`, {
+      waitUntil: 'networkidle',
+    });
+    await expect(page.locator('h1')).toContainText('Version One');
+    expect(await getSidebarTexts(page)).toEqual([
+      'Version One',
+      'Version One Guide',
+    ]);
+
+    await page.goto(`http://localhost:${appPort}/v2/`, {
+      waitUntil: 'networkidle',
+    });
+    await expect(page.locator('h1')).toContainText('Version Two');
+    expect(await getSidebarTexts(page)).toEqual([
+      'Version Two',
+      'Version Two Guide',
+    ]);
+  });
+});

--- a/e2e/fixtures/multi-version-global-sidebar/index.test.ts
+++ b/e2e/fixtures/multi-version-global-sidebar/index.test.ts
@@ -21,19 +21,19 @@ test.describe('Multi version global sidebar test', async () => {
     await page.goto(`http://localhost:${appPort}/`, {
       waitUntil: 'networkidle',
     });
-    await expect(page.locator('h1')).toContainText('Version One');
+    await expect(page.locator('h1')).toContainText('Version one');
     expect(await getSidebarTexts(page)).toEqual([
-      'Version One',
-      'Version One Guide',
+      'Version one',
+      'Version one guide',
     ]);
 
     await page.goto(`http://localhost:${appPort}/v2/`, {
       waitUntil: 'networkidle',
     });
-    await expect(page.locator('h1')).toContainText('Version Two');
+    await expect(page.locator('h1')).toContainText('Version two');
     expect(await getSidebarTexts(page)).toEqual([
-      'Version Two',
-      'Version Two Guide',
+      'Version two',
+      'Version two guide',
     ]);
   });
 });

--- a/e2e/fixtures/multi-version-global-sidebar/package.json
+++ b/e2e/fixtures/multi-version-global-sidebar/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@rspress-fixture/multi-version-global-sidebar",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rspress build",
+    "dev": "rspress dev",
+    "preview": "rspress preview"
+  },
+  "dependencies": {
+    "@rspress/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.8.1"
+  }
+}

--- a/e2e/fixtures/multi-version-global-sidebar/rspress.config.ts
+++ b/e2e/fixtures/multi-version-global-sidebar/rspress.config.ts
@@ -1,0 +1,10 @@
+import * as path from 'node:path';
+import { defineConfig } from '@rspress/core';
+
+export default defineConfig({
+  root: path.join(import.meta.dirname, 'docs'),
+  multiVersion: {
+    default: 'v1',
+    versions: ['v1', 'v2'],
+  },
+});

--- a/e2e/fixtures/multi-version-global-sidebar/tsconfig.json
+++ b/e2e/fixtures/multi-version-global-sidebar/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["DOM", "ES2023"],
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "bundler",
+    "useDefineForClassFields": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["docs", "theme", "rspress.config.ts"],
+  "mdx": {
+    "checkMdx": true
+  }
+}

--- a/packages/core/src/node/auto-nav-sidebar/walk.ts
+++ b/packages/core/src/node/auto-nav-sidebar/walk.ts
@@ -65,7 +65,7 @@ export async function walk(
     return {
       nav: navConfig,
       sidebar: {
-        '/': await scanSideMeta(
+        [addRoutePrefix(workDir, docsDir, '/')]: await scanSideMeta(
           workDir,
           docsDir,
           extensions,
@@ -119,7 +119,7 @@ export async function walk(
   return {
     nav: [],
     sidebar: {
-      '/': await scanSideMeta(
+      [addRoutePrefix(workDir, docsDir, '/')]: await scanSideMeta(
         workDir,
         docsDir,
         extensions,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,6 +401,16 @@ importers:
         specifier: ^22.8.1
         version: 22.19.15
 
+  e2e/fixtures/multi-version-global-sidebar:
+    dependencies:
+      '@rspress/core':
+        specifier: workspace:*
+        version: link:../../../packages/core
+    devDependencies:
+      '@types/node':
+        specifier: ^22.8.1
+        version: 22.19.15
+
   e2e/fixtures/multi-version-llms:
     dependencies:
       '@rspress/core':


### PR DESCRIPTION
## Summary

This PR fixes auto-generated global sidebar keys when multiVersion is enabled. Version roots that use both `_nav.json` and `_meta.json` now generate sidebar keys with the route prefix instead of all writing to `/`, so switching versions keeps version-specific sidebars. It also adds an e2e fixture covering version-root global sidebars.

## Related Issue

https://github.com/web-infra-dev/rspress/discussions/3452

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).