### PR TITLE
feat(search): Allow excluding pages from default search via frontmatter

### DIFF
--- a/e2e/fixtures/search/doc/excluded.mdx
+++ b/e2e/fixtures/search/doc/excluded.mdx
@@ -1,0 +1,7 @@
+---
+search: false
+---
+
+# Excluded
+
+This page uses `search: false` so the Quux keyword should not show up in search.

--- a/e2e/fixtures/search/index.test.ts
+++ b/e2e/fixtures/search/index.test.ts
@@ -82,6 +82,29 @@ test.describe('search keyboard', async () => {
     expect(searchPanel).toBeNull();
   });
 
+  test('page with search: false should be excluded from the index', async ({
+    page,
+  }) => {
+    await page.goto(`http://localhost:${appPort}/base/`, {
+      waitUntil: 'networkidle',
+    });
+
+    // Open search panel
+    const searchButton = await page.$('.rp-search-button');
+    await searchButton?.click();
+    await page.waitForSelector('.rp-search-panel__input');
+
+    // The Quux keyword only lives on the excluded page, so searching for it
+    // should not return any suggestions.
+    const searchInput = await page.$('.rp-search-panel__input');
+    await searchInput?.focus();
+    await page.keyboard.type('Quux');
+    await page.waitForTimeout(400);
+
+    const suggestItems = await page.$$('.rp-suggest-item');
+    expect(suggestItems.length).toBe(0);
+  });
+
   test('ESC key should close search panel', async ({ page }) => {
     await page.goto(`http://localhost:${appPort}/base/`, {
       waitUntil: 'networkidle',

--- a/e2e/fixtures/search/index.test.ts
+++ b/e2e/fixtures/search/index.test.ts
@@ -89,20 +89,16 @@ test.describe('search keyboard', async () => {
       waitUntil: 'networkidle',
     });
 
-    // Open search panel
-    const searchButton = await page.$('.rp-search-button');
-    await searchButton?.click();
-    await page.waitForSelector('.rp-search-panel__input');
+    await page.locator('.rp-search-button').click();
 
     // The Quux keyword only lives on the excluded page, so searching for it
     // should not return any suggestions.
-    const searchInput = await page.$('.rp-search-panel__input');
-    await searchInput?.focus();
-    await page.keyboard.type('Quux');
-    await page.waitForTimeout(400);
+    const searchInput = page.locator('.rp-search-panel__input');
+    await expect(searchInput).toBeVisible();
+    await searchInput.fill('Quux');
 
-    const suggestItems = await page.$$('.rp-suggest-item');
-    expect(suggestItems.length).toBe(0);
+    await expect(page.locator('.rp-no-search-result')).toBeVisible();
+    await expect(page.locator('.rp-suggest-item')).toHaveCount(0);
   });
 
   test('ESC key should close search panel', async ({ page }) => {

--- a/packages/core/src/node/runtimeModule/pageData/createPageData.ts
+++ b/packages/core/src/node/runtimeModule/pageData/createPageData.ts
@@ -66,6 +66,11 @@ export async function createPageData(context: FactoryContext): Promise<{
       return 'noindex';
     }
 
+    // allow a page to opt out of search with `search: false` in its frontmatter
+    if (page.frontmatter?.search === false) {
+      return 'noindex';
+    }
+
     const version = versioned ? page.version : '';
     const lang = page.lang || '';
 

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -470,6 +470,8 @@ export interface FrontMatterMeta {
   titleSuffix?: string;
   head?: [string, Record<string, string>][];
   context?: string;
+  // set to false to exclude the page from the built-in search index
+  search?: boolean;
   [key: string]: unknown;
 }
 

--- a/website/docs/en/api/config/config-basic.mdx
+++ b/website/docs/en/api/config/config-basic.mdx
@@ -440,6 +440,10 @@ type SearchOptions = {
 };
 ```
 
+:::tip
+To exclude an individual page from the search index, set [`search: false`](/api/config/config-frontmatter#search) in its front matter.
+:::
+
 ### searchHooks
 
 - **Type**: `string`

--- a/website/docs/en/api/config/config-frontmatter.mdx
+++ b/website/docs/en/api/config/config-frontmatter.mdx
@@ -184,6 +184,21 @@ The DOM structure of the final generated sidebar is abbreviated as follows:
 </div>
 ```
 
+## search
+
+- **Type**: `boolean`
+- **Default**: `true`
+
+Whether to include the current page in the built-in search index. By default every `doc` page is indexed for full-text search. If you want to exclude a specific page from the search results, set `search` to `false`:
+
+```yaml
+---
+search: false
+---
+```
+
+This only affects the built-in search. Pages with `pageType: home` are always excluded from the search index regardless of this field.
+
 ## head
 
 - **Type**: `[string, Record<string, string>][]`

--- a/website/docs/zh/api/config/config-basic.mdx
+++ b/website/docs/zh/api/config/config-basic.mdx
@@ -440,6 +440,10 @@ type SearchOptions = {
 };
 ```
 
+:::tip
+如果需要从搜索索引中排除某个页面，可以在该页面的 front matter 中设置 [`search: false`](/zh/api/config/config-frontmatter#search)。
+:::
+
 ### searchHooks
 
 - **类型**： `string`

--- a/website/docs/zh/api/config/config-frontmatter.mdx
+++ b/website/docs/zh/api/config/config-frontmatter.mdx
@@ -184,6 +184,21 @@ context: 'context-bar'
 </div>
 ```
 
+## search
+
+- **类型**： `boolean`
+- **默认值**： `true`
+
+是否将当前页面加入内置搜索索引。默认情况下，每个 `doc` 页面都会被加入全文搜索索引。如果想从搜索结果中排除某个页面，可以将 `search` 设置为 `false`：
+
+```yaml
+---
+search: false
+---
+```
+
+该配置只影响内置搜索。设置了 `pageType: home` 的页面无论是否配置该字段，都会从搜索索引中排除。
+
 ## head
 
 - **类型**： `[string, Record<string, string>][]`


### PR DESCRIPTION
## Summary

This just adds support for a `search: false` field in frontmatter which makes it so that pages can be easily excluded from the default built in search. Other search providers such as algolia or typesense would need to be handled differently.

## Related Issue

N/A

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
