### PR TITLE
perf(ssg): avoid eager asset source reads

### DIFF
--- a/packages/core/src/node/ssg-md/rsbuildPluginSSGMD.ts
+++ b/packages/core/src/node/ssg-md/rsbuildPluginSSGMD.ts
@@ -55,8 +55,11 @@ export const rsbuildPluginSSGMD = ({
 
           await mkdir(ssgFolderPath, { recursive: true });
           await Promise.all(
-            Object.entries(assets).map(async ([assetName, assetSource]) => {
+            // Rspack resolves `assets[name]` through the Rust-JS bridge, so
+            // keep enumeration to names and read the Source only after match.
+            Object.keys(assets).map(async assetName => {
               if (assetName.startsWith(`${NODE_SSG_MD_BUNDLE_FOLDER}/`)) {
+                const assetSource = assets[assetName];
                 const fileAbsolutePath = join(distPath, assetName);
                 await writeFile(
                   fileAbsolutePath,

--- a/packages/core/src/node/ssg/rsbuildPluginCSR.ts
+++ b/packages/core/src/node/ssg/rsbuildPluginCSR.ts
@@ -31,8 +31,11 @@ export const rsbuildPluginCSR = ({
           };
 
           let htmlTemplate: string = '';
-          for (const [assetName, assetSource] of Object.entries(assets)) {
+          // Rspack resolves `assets[name]` through the Rust-JS bridge, so keep
+          // enumeration to names and read the Source only after match.
+          for (const assetName of Object.keys(assets)) {
             if (assetName === 'index.html') {
+              const assetSource = assets[assetName];
               htmlTemplate = assetSource.source().toString();
               compilation.deleteAsset(assetName);
               break;

--- a/packages/core/src/node/ssg/rsbuildPluginSSG.ts
+++ b/packages/core/src/node/ssg/rsbuildPluginSSG.ts
@@ -48,8 +48,11 @@ export const rsbuildPluginSSG = ({
                 return;
               }
 
-              for (const [assetName, assetSource] of Object.entries(assets)) {
+              // Rspack resolves `assets[name]` through the Rust-JS bridge, so
+              // keep enumeration to names and read the Source only after match.
+              for (const assetName of Object.keys(assets)) {
                 if (assetName === 'index.html') {
+                  const assetSource = assets[assetName];
                   htmlTemplate = assetSource.source().toString();
                   compilation.deleteAsset(assetName);
                   resolveOnce();
@@ -96,8 +99,11 @@ export const rsbuildPluginSSG = ({
 
           await mkdir(ssgFolderPath, { recursive: true });
           await Promise.all(
-            Object.entries(assets).map(async ([assetName, assetSource]) => {
+            // Rspack resolves `assets[name]` through the Rust-JS bridge, so
+            // keep enumeration to names and read the Source only after match.
+            Object.keys(assets).map(async assetName => {
               if (assetName.startsWith(`${NODE_SSG_BUNDLE_FOLDER}/`)) {
+                const assetSource = assets[assetName];
                 const fileAbsolutePath = join(distPath, assetName);
                 await writeFile(
                   fileAbsolutePath,


### PR DESCRIPTION
## Summary

- Replace `Object.entries(assets)` with `Object.keys(assets)` in SSG, CSR, and SSG-MD asset handling.
- Read `assets[assetName]` only after matching the target asset to avoid unnecessary Rspack Source retrieval.
- Add comments explaining that Rspack resolves `assets[name]` through the Rust-JS bridge, so eager Source access adds extra communication and memory cost.

## Related Issue

<!--- Provide link of related issues -->
https://github.com/web-infra-dev/rspress/issues/3376

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
