### PR TITLE
feat(core): support siteOrigin config to set absoluteUrl cases

### DIFF
--- a/e2e/fixtures/plugin-llms/index.test.ts
+++ b/e2e/fixtures/plugin-llms/index.test.ts
@@ -52,17 +52,25 @@ test.describe('plugin-llms', async () => {
     expect(llmsTxt).toContain('## Guide');
     expect(llmsTxt).toContain('## Api');
     // Guide routes should be grouped under Guide section
-    expect(llmsTxt).toContain('- [Guide](/guide/index.md)');
+    expect(llmsTxt).toContain(
+      '- [Guide](https://example.com/docs/guide/index.md)',
+    );
     // Api routes should be grouped under Api section
-    expect(llmsTxt).toContain('- [Commands](/api/commands.md)');
+    expect(llmsTxt).toContain(
+      '- [Commands](https://example.com/docs/api/commands.md)',
+    );
 
     // Verify llms-full.txt has markdown content with url frontmatter
     const llmsFullTxt = await readFile(
       path.resolve(appDir, 'doc_build', 'llms-full.txt'),
       'utf-8',
     );
-    expect(llmsFullTxt).toContain('url: /guide/index.md');
-    expect(llmsFullTxt).toContain('url: /api/commands.md');
+    expect(llmsFullTxt).toContain(
+      'url: https://example.com/docs/guide/index.md',
+    );
+    expect(llmsFullTxt).toContain(
+      'url: https://example.com/docs/api/commands.md',
+    );
   });
 
   test('should order llms.txt entries according to _meta.json', async () => {

--- a/e2e/fixtures/plugin-llms/rspress.config.ts
+++ b/e2e/fixtures/plugin-llms/rspress.config.ts
@@ -4,6 +4,8 @@ import { pluginLlms } from '@rspress/plugin-llms';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc'),
+  base: '/docs/',
+  siteOrigin: 'https://example.com',
   ssg: false,
   plugins: [pluginLlms()],
   title: 'Plugin LLMS',

--- a/e2e/fixtures/plugin-rss/fixture.json
+++ b/e2e/fixtures/plugin-rss/fixture.json
@@ -1,5 +1,4 @@
 {
   "base": "/sub/",
-  "siteUrl": "http://localhost:4173/sub/",
   "title": "FooBar"
 }

--- a/e2e/fixtures/plugin-rss/index.test.ts
+++ b/e2e/fixtures/plugin-rss/index.test.ts
@@ -8,7 +8,7 @@ import {
 import fixture from './fixture.json' with { type: 'json' };
 
 const appDir = import.meta.dirname;
-const { siteUrl } = fixture;
+const feedUrl = `${fixture.base}rss/blog.xml`;
 
 test.describe('plugin rss test', async () => {
   let appPort: number;
@@ -32,9 +32,7 @@ test.describe('plugin rss test', async () => {
 
     const link = page.locator('link[rel="alternate"]', {});
 
-    await expect(link.getAttribute('href')).resolves.toBe(
-      `${siteUrl}rss/blog.xml`,
-    );
+    await expect(link.getAttribute('href')).resolves.toBe(feedUrl);
   });
 
   test('should add rss <link> to pages matched', async ({ page }) => {
@@ -42,9 +40,7 @@ test.describe('plugin rss test', async () => {
 
     const link = page.locator('link[rel="alternate"]', {});
 
-    await expect(link.getAttribute('href')).resolves.toBe(
-      `${siteUrl}rss/blog.xml`,
-    );
+    await expect(link.getAttribute('href')).resolves.toBe(feedUrl);
   });
 
   test('should change output dir if dir is given', async ({ page }) => {
@@ -82,7 +78,7 @@ test.describe('plugin rss test', async () => {
 
       await expect(
         page.locator('rss>channel>link').textContent(),
-      ).resolves.toBe(fixture.siteUrl);
+      ).resolves.toBe(fixture.base);
 
       const foo = page
         .locator('rss>channel>item')

--- a/e2e/fixtures/plugin-rss/rspress.config.ts
+++ b/e2e/fixtures/plugin-rss/rspress.config.ts
@@ -9,7 +9,6 @@ export default defineConfig({
   base: fixture.base,
   plugins: [
     pluginRss({
-      siteUrl: fixture.siteUrl,
       feed: [
         {
           id: 'blog',

--- a/e2e/fixtures/ssg-md/index.test.ts
+++ b/e2e/fixtures/ssg-md/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { runBuildCommand } from '../../utils/runCommands';
 
 test('llms should be successful', async () => {
@@ -17,6 +17,12 @@ test('llms should be successful', async () => {
       throw new Error(`Expected non-empty file: ${filePath}`);
     }
   }
+
+  const llmsFullTxt = await fs.readFile(
+    path.join(docBuildDir, 'llms-full.txt'),
+    'utf-8',
+  );
+  expect(llmsFullTxt).toContain('url: https://example.com/docs/index.md');
 });
 
 test('csr should be successful', async () => {

--- a/e2e/fixtures/ssg-md/rspress.config.ts
+++ b/e2e/fixtures/ssg-md/rspress.config.ts
@@ -3,6 +3,8 @@ import { defineConfig } from '@rspress/core';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc'),
+  base: '/docs/',
+  siteOrigin: 'https://example.com',
   ssg: true,
   llms: true,
   title: 'Rspress SSG MDX Test',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,7 @@ export {
   RSPRESS_TEMP_DIR,
   removeTrailingSlash,
   withBase,
+  withSiteOrigin,
 } from '@rspress/shared';
 export { logger } from '@rspress/shared/logger';
 export {

--- a/packages/core/src/node/runtimeModule/siteData/createSiteData.ts
+++ b/packages/core/src/node/runtimeModule/siteData/createSiteData.ts
@@ -15,6 +15,7 @@ export async function createSiteData(userConfig: UserConfig): Promise<{
 
   const siteData: Omit<SiteData, 'root' | 'pages'> = {
     base: userConfig.base ?? '/',
+    siteOrigin: userConfig.siteOrigin ?? '',
     title: userConfig?.title || '',
     description: userConfig?.description || '',
     icon: getIconUrlPath(userConfig?.icon) || '',

--- a/packages/core/src/node/ssg-md/llms/emitLlmsTxt.ts
+++ b/packages/core/src/node/ssg-md/llms/emitLlmsTxt.ts
@@ -112,6 +112,7 @@ export async function emitLlmsTxt(
       config.title,
       config.description,
       config.base!,
+      config.siteOrigin,
       routeService,
     );
 
@@ -120,6 +121,7 @@ export async function emitLlmsTxt(
       navList,
       others,
       base,
+      config.siteOrigin,
       mdContents,
     );
 
@@ -142,7 +144,11 @@ export async function emitLlmsTxt(
 
 function flatSidebar(
   sidebar: (
-    SidebarGroup | SidebarItem | SidebarDivider | SidebarSectionHeader | string
+    | SidebarGroup
+    | SidebarItem
+    | SidebarDivider
+    | SidebarSectionHeader
+    | string
   )[],
 ): string[] {
   if (!sidebar) {

--- a/packages/core/src/node/ssg-md/llms/emitLlmsTxt.ts
+++ b/packages/core/src/node/ssg-md/llms/emitLlmsTxt.ts
@@ -144,11 +144,7 @@ export async function emitLlmsTxt(
 
 function flatSidebar(
   sidebar: (
-    | SidebarGroup
-    | SidebarItem
-    | SidebarDivider
-    | SidebarSectionHeader
-    | string
+    SidebarGroup | SidebarItem | SidebarDivider | SidebarSectionHeader | string
   )[],
 ): string[] {
   if (!sidebar) {

--- a/packages/core/src/node/ssg-md/llms/llmsTxt.ts
+++ b/packages/core/src/node/ssg-md/llms/llmsTxt.ts
@@ -1,13 +1,22 @@
-import { type NavItemWithLink, normalizeHref, withBase } from '@rspress/shared';
+import {
+  type NavItemWithLink,
+  normalizeHref,
+  withBase,
+  withSiteOrigin,
+} from '@rspress/shared';
 import { logger } from '@rspress/shared/logger';
 import { extractInfoFromFrontmatterWithAbsolutePath } from '../../auto-nav-sidebar/utils';
 import type { RouteService } from '../../route/RouteService';
 
-function routePathToMdPath(routePath: string, base: string): string {
+function routePathToMdPath(
+  routePath: string,
+  base: string,
+  siteOrigin?: string,
+): string {
   let url: string = routePath;
   url = normalizeHref(url, false);
   url = url.replace(/\.html$/, '.md');
-  return withBase(url, base);
+  return withSiteOrigin(withBase(url, base), siteOrigin);
 }
 
 async function generateLlmsTxt(
@@ -17,6 +26,7 @@ async function generateLlmsTxt(
   title: string | undefined,
   description: string | undefined,
   base: string,
+  siteOrigin: string | undefined,
   routeService: RouteService,
 ): Promise<string> {
   const lines: string[] = [];
@@ -68,7 +78,7 @@ async function generateLlmsTxt(
             description = info.description;
           }
 
-          return `- [${title}](${routePathToMdPath(routePath, base)})${description ? `: ${description}` : ''}`;
+          return `- [${title}](${routePathToMdPath(routePath, base, siteOrigin)})${description ? `: ${description}` : ''}`;
         }),
       )
     ).filter((i): i is string => Boolean(i));
@@ -113,6 +123,7 @@ function generateLlmsFullTxt(
   navList: (NavItemWithLink & { lang: string })[],
   others: string[],
   base: string,
+  siteOrigin: string | undefined,
   mdContents: Map<string, string>,
 ): string {
   const lines: string[] = [];
@@ -124,7 +135,7 @@ function generateLlmsFullTxt(
     }
     for (const routePath of routeGroup) {
       lines.push(`---
-url: ${routePathToMdPath(routePath, base)}
+url: ${routePathToMdPath(routePath, base, siteOrigin)}
 ---
 `);
       lines.push(mdContents.get(routePath) ?? '');
@@ -133,7 +144,7 @@ url: ${routePathToMdPath(routePath, base)}
   }
   for (const routePath of others) {
     lines.push(`---
-url: ${routePathToMdPath(routePath, base)}
+url: ${routePathToMdPath(routePath, base, siteOrigin)}
 ---
 `);
     lines.push(mdContents.get(routePath) ?? '');

--- a/packages/plugin-llms/src/llmsTxt.ts
+++ b/packages/plugin-llms/src/llmsTxt.ts
@@ -4,14 +4,19 @@ import {
   normalizeHref,
   type PageIndexInfo,
   withBase,
+  withSiteOrigin,
 } from '@rspress/core';
 import type { LlmsTxt } from './types';
 
-function routePathToMdPath(routePath: string, base: string): string {
+function routePathToMdPath(
+  routePath: string,
+  base: string,
+  siteOrigin?: string,
+): string {
   let url: string = routePath;
   url = normalizeHref(url, false);
   url = url.replace(/\.html$/, '.md');
-  return withBase(url, base);
+  return withSiteOrigin(withBase(url, base), siteOrigin);
 }
 
 function generateLlmsTxt(
@@ -22,6 +27,7 @@ function generateLlmsTxt(
   title: string | undefined,
   description: string | undefined,
   base: string,
+  siteOrigin: string | undefined,
 ): string {
   const lines: string[] = [];
   const { onAfterLlmsTxtGenerate, onLineGenerate, onTitleGenerate } =
@@ -57,7 +63,7 @@ function generateLlmsTxt(
 
       const line = onLineGenerate
         ? onLineGenerate(page)
-        : `- [${title}](${routePathToMdPath(routePath, base)})${description ? `: ${description}` : ''}`;
+        : `- [${title}](${routePathToMdPath(routePath, base, siteOrigin)})${description ? `: ${description}` : ''}`;
       lines.push(line);
     }
   }
@@ -73,7 +79,7 @@ function generateLlmsTxt(
     }
     const line = onLineGenerate
       ? onLineGenerate(page)
-      : `- [${title}](${routePathToMdPath(routePath, base)})${description ? `: ${description}` : ''}`;
+      : `- [${title}](${routePathToMdPath(routePath, base, siteOrigin)})${description ? `: ${description}` : ''}`;
     otherLines.push(line);
     hasOthers = true;
   }
@@ -96,6 +102,7 @@ function generateLlmsFullTxt(
   navList: (NavItemWithLink & { lang: string })[],
   others: PageIndexInfo[],
   base: string,
+  siteOrigin: string | undefined,
 ): string {
   const lines: string[] = [];
   // generate llms.txt with obj
@@ -106,7 +113,7 @@ function generateLlmsFullTxt(
     }
     for (const page of pages) {
       lines.push(`---
-url: ${routePathToMdPath(page.routePath, base)}
+url: ${routePathToMdPath(page.routePath, base, siteOrigin)}
 ---
 `);
       lines.push(
@@ -117,7 +124,7 @@ url: ${routePathToMdPath(page.routePath, base)}
   }
   for (const page of others) {
     lines.push(`---
-url: ${routePathToMdPath(page.routePath, base)}
+url: ${routePathToMdPath(page.routePath, base, siteOrigin)}
 ---
 `);
     lines.push((page as any).mdContent ?? page._flattenContent ?? page.content);

--- a/packages/plugin-llms/src/plugin.ts
+++ b/packages/plugin-llms/src/plugin.ts
@@ -280,11 +280,7 @@ function mergeRouteMetaWithPageData(
 
 function flatSidebar(
   sidebar: (
-    | SidebarGroup
-    | SidebarItem
-    | SidebarDivider
-    | SidebarSectionHeader
-    | string
+    SidebarGroup | SidebarItem | SidebarDivider | SidebarSectionHeader | string
   )[],
 ): string[] {
   if (!sidebar) {

--- a/packages/plugin-llms/src/plugin.ts
+++ b/packages/plugin-llms/src/plugin.ts
@@ -59,6 +59,7 @@ const rsbuildPluginLlms = ({
   titleRef,
   descriptionRef,
   langRef,
+  siteOriginRef,
   sidebar,
   routeServiceRef,
   nav,
@@ -187,6 +188,7 @@ const rsbuildPluginLlms = ({
             titleRef.current,
             descriptionRef.current,
             baseRef.current,
+            siteOriginRef.current,
           );
           api.processAssets(
             {
@@ -207,6 +209,7 @@ const rsbuildPluginLlms = ({
             navList,
             others,
             baseRef.current,
+            siteOriginRef.current,
           );
           api.processAssets(
             { targets: disableSSG ? ['web'] : ['node'], stage: 'additional' },
@@ -277,7 +280,11 @@ function mergeRouteMetaWithPageData(
 
 function flatSidebar(
   sidebar: (
-    SidebarGroup | SidebarItem | SidebarDivider | SidebarSectionHeader | string
+    | SidebarGroup
+    | SidebarItem
+    | SidebarDivider
+    | SidebarSectionHeader
+    | string
   )[],
 ): string[] {
   if (!sidebar) {
@@ -372,6 +379,7 @@ export function pluginLlms(options?: RspressPluginLlmsOptions): RspressPlugin {
   const titleRef: { current: string | undefined } = { current: '' };
   const descriptionRef: { current: string | undefined } = { current: '' };
   const langRef: { current: string | undefined } = { current: '' };
+  const siteOriginRef: { current: string | undefined } = { current: '' };
   const pageDataList: PageIndexInfo[] = [];
   const routes: RouteMeta[] = [];
   const sidebar: Sidebar = {};
@@ -424,6 +432,8 @@ export function pluginLlms(options?: RspressPluginLlmsOptions): RspressPlugin {
       }
 
       const docDirectory = config.root!;
+      baseRef.current = config.base ?? '/';
+      siteOriginRef.current = config.siteOrigin;
 
       config.builderConfig.plugins.push(
         ...(Array.isArray(mergedOptions)
@@ -435,6 +445,7 @@ export function pluginLlms(options?: RspressPluginLlmsOptions): RspressPlugin {
                 titleRef,
                 descriptionRef,
                 langRef,
+                siteOriginRef,
                 sidebar,
                 routeServiceRef,
                 nav,
@@ -454,6 +465,7 @@ export function pluginLlms(options?: RspressPluginLlmsOptions): RspressPlugin {
                 titleRef,
                 descriptionRef,
                 langRef,
+                siteOriginRef,
                 sidebar,
                 routeServiceRef,
                 nav,
@@ -497,6 +509,7 @@ export function pluginLlms(options?: RspressPluginLlmsOptions): RspressPlugin {
       titleRef.current = config.title;
       descriptionRef.current = config.description;
       langRef.current = config.lang ?? '';
+      siteOriginRef.current = config.siteOrigin;
       baseRef.current = config.base ?? '/';
       docDirectoryRef.current = config.root ?? 'docs';
 

--- a/packages/plugin-llms/src/types.ts
+++ b/packages/plugin-llms/src/types.ts
@@ -75,6 +75,7 @@ export interface rsbuildPluginLlmsOptions {
   descriptionRef: { current: string | undefined };
   langRef: { current: string | undefined };
   baseRef: { current: string };
+  siteOriginRef: { current: string | undefined };
   pageDataList: PageIndexInfo[];
   routeServiceRef: { current: RouteService | undefined };
   routes: RouteMeta[];

--- a/packages/plugin-rss/src/options.ts
+++ b/packages/plugin-rss/src/options.ts
@@ -77,7 +77,7 @@ export function getOutputInfo(
   {
     siteUrl,
     output: globalOutput,
-  }: Pick<PluginRssOptions, 'output' | 'siteUrl'>,
+  }: { siteUrl: string; output?: PluginRssOptions['output'] },
 ): ResolvedOutput {
   const type = output?.type || globalOutput?.type || 'atom';
   const { extension, mime, getContent } = getFeedFileType(type);

--- a/packages/plugin-rss/src/options.ts
+++ b/packages/plugin-rss/src/options.ts
@@ -56,6 +56,10 @@ export function getFeedFileType(type: FeedOutputType) {
   }
 }
 
+function ensureTrailingSlash(url: string) {
+  return url.endsWith('/') ? url : `${url}/`;
+}
+
 export async function renderFeedContent(
   feed: Feed,
   channel: FeedChannel,
@@ -83,7 +87,9 @@ export function getOutputInfo(
   const { extension, mime, getContent } = getFeedFileType(type);
   const filename = output?.filename || `${id}.${extension}`;
   const dir = output?.dir || globalOutput?.dir || 'rss';
-  const publicPath = output?.publicPath || globalOutput?.publicPath || siteUrl;
+  const publicPath = ensureTrailingSlash(
+    output?.publicPath || globalOutput?.publicPath || siteUrl,
+  );
   const url = [publicPath, `${dir}/`, filename].reduce((u, part) =>
     u ? resolveUrl(u, part) : part,
   );

--- a/packages/plugin-rss/src/plugin-rss.ts
+++ b/packages/plugin-rss/src/plugin-rss.ts
@@ -3,7 +3,7 @@
 import NodePath from 'node:path';
 import { resolve as resolveUrl } from 'node:url';
 import type { PageIndexInfo, RspressPlugin, UserConfig } from '@rspress/core';
-import { getIconUrlPath } from '@rspress/core';
+import { getIconUrlPath, withBase, withSiteOrigin } from '@rspress/core';
 import { Feed } from 'feed';
 
 import { createFeed, generateFeedItem } from './createFeed';
@@ -30,7 +30,7 @@ type TransformedFeedChannel = FeedChannel & { output: ResolvedOutput };
 class FeedsSet {
   feeds: TransformedFeedChannel[] = [];
   feedsMapById: Record<string, TransformedFeedChannel> = Object.create(null);
-  set({ feed, output, siteUrl }: PluginRssOptions, config: UserConfig) {
+  set({ feed, output }: PluginRssOptions, config: UserConfig, siteUrl: string) {
     this.feeds = (
       Array.isArray(feed) ? feed : [{ ...getDefaultFeedOption(), ...feed }]
     ).map(options => ({
@@ -59,6 +59,14 @@ class FeedsSet {
   }
 }
 
+function getSiteUrl(siteUrl: string | undefined, config: UserConfig) {
+  if (siteUrl) {
+    return siteUrl;
+  }
+  const base = withBase('/', config.base ?? '/');
+  return config.siteOrigin ? withSiteOrigin(base, config.siteOrigin) : base;
+}
+
 interface PageRssInfo {
   page: PageIndexInfo;
   channels: string[];
@@ -85,7 +93,9 @@ async function getRssItems(
   );
 }
 
-export function pluginRss(pluginRssOptions: PluginRssOptions): RspressPlugin {
+export function pluginRss(
+  pluginRssOptions: PluginRssOptions = {},
+): RspressPlugin {
   const feedsSet = new FeedsSet();
 
   /**
@@ -93,6 +103,7 @@ export function pluginRss(pluginRssOptions: PluginRssOptions): RspressPlugin {
    * Key: routePath, Value: PageRssInfo
    */
   let _pagesForRss: null | Map<string, PageRssInfo> = null;
+  let _siteUrl = '';
 
   return {
     name: PluginName,
@@ -113,7 +124,8 @@ export function pluginRss(pluginRssOptions: PluginRssOptions): RspressPlugin {
       }
 
       _pagesForRss = new Map();
-      feedsSet.set(pluginRssOptions, config);
+      _siteUrl = getSiteUrl(pluginRssOptions.siteUrl, config);
+      feedsSet.set(pluginRssOptions, config, _siteUrl);
     },
     async extendPageData(pageData) {
       if (!_pagesForRss) return;
@@ -170,7 +182,7 @@ export function pluginRss(pluginRssOptions: PluginRssOptions): RspressPlugin {
         const items = await getRssItems(
           channels.map(id => feedsSet.get(id)!),
           page,
-          pluginRssOptions.siteUrl,
+          _siteUrl,
           htmlContent,
         );
 
@@ -195,6 +207,7 @@ export function pluginRss(pluginRssOptions: PluginRssOptions): RspressPlugin {
       }
 
       _pagesForRss = null;
+      _siteUrl = '';
     },
   };
 }

--- a/packages/plugin-rss/src/plugin-rss.ts
+++ b/packages/plugin-rss/src/plugin-rss.ts
@@ -59,12 +59,34 @@ class FeedsSet {
   }
 }
 
+function ensureTrailingSlash(url: string) {
+  return url.endsWith('/') ? url : `${url}/`;
+}
+
+function normalizeSiteUrl(siteUrl: string): string {
+  try {
+    const url = new URL(siteUrl);
+    url.pathname = ensureTrailingSlash(url.pathname);
+    return url.href;
+  } catch {
+    throw new Error(
+      '[plugin-rss] `siteUrl` must be a valid absolute URL with protocol, such as `https://example.com/base/`.',
+    );
+  }
+}
+
 function getSiteUrl(siteUrl: string | undefined, config: UserConfig) {
   if (siteUrl) {
-    return siteUrl;
+    return normalizeSiteUrl(siteUrl);
   }
   const base = withBase('/', config.base ?? '/');
-  return config.siteOrigin ? withSiteOrigin(base, config.siteOrigin) : base;
+  try {
+    return config.siteOrigin ? withSiteOrigin(base, config.siteOrigin) : base;
+  } catch {
+    throw new Error(
+      '[plugin-rss] `siteOrigin` in rspress.config.ts must be a valid absolute URL origin with protocol, such as `https://example.com`.',
+    );
+  }
 }
 
 interface PageRssInfo {

--- a/packages/plugin-rss/src/type.ts
+++ b/packages/plugin-rss/src/type.ts
@@ -76,7 +76,10 @@ export interface FeedChannel extends PartialPartial<
    * if RegExp is given, it will match against the route path of each page
    **/
   test:
-    RegExp | string | (RegExp | string)[] | ((item: PageIndexInfo) => boolean);
+    | RegExp
+    | string
+    | (RegExp | string)[]
+    | ((item: PageIndexInfo) => boolean);
   /**
    * a function to modify feed item
    * @param item pre-generated feed item
@@ -100,7 +103,7 @@ export interface FeedChannel extends PartialPartial<
 export interface PluginRssOptions {
   /**
    * site url of this rspress site. it will be used in feed files and feed link.
-   * @default rspress `url` config with `base`
+   * @default rspress `siteOrigin` config with `base`, or `base` when `siteOrigin` is not configured
    */
   siteUrl?: string;
   /**

--- a/packages/plugin-rss/src/type.ts
+++ b/packages/plugin-rss/src/type.ts
@@ -76,10 +76,7 @@ export interface FeedChannel extends PartialPartial<
    * if RegExp is given, it will match against the route path of each page
    **/
   test:
-    | RegExp
-    | string
-    | (RegExp | string)[]
-    | ((item: PageIndexInfo) => boolean);
+    RegExp | string | (RegExp | string)[] | ((item: PageIndexInfo) => boolean);
   /**
    * a function to modify feed item
    * @param item pre-generated feed item

--- a/packages/plugin-rss/src/type.ts
+++ b/packages/plugin-rss/src/type.ts
@@ -100,9 +100,9 @@ export interface FeedChannel extends PartialPartial<
 export interface PluginRssOptions {
   /**
    * site url of this rspress site. it will be used in feed files and feed link.
-   * @requires
+   * @default rspress `url` config with `base`
    */
-  siteUrl: string;
+  siteUrl?: string;
   /**
    * Feed options for each rss. If array is given, this plugin will produce multiple feed files.
    * @default { id: 'blog', test: '/blog/' }

--- a/packages/plugin-rss/tests/output.test.ts
+++ b/packages/plugin-rss/tests/output.test.ts
@@ -118,4 +118,14 @@ describe('plugin-rss output transform', () => {
     expect(content).toContain('<feed:id>local</feed:id>');
     expect(content).not.toContain('<folo:id>blog-rss</folo:id>');
   });
+
+  test('should preserve base path when siteUrl has no trailing slash', () => {
+    const channel = createChannel('rss');
+    const output = getOutputInfo(channel, {
+      siteUrl: 'https://example.com/base',
+    });
+
+    expect(output.publicPath).toBe('https://example.com/base/');
+    expect(output.url).toBe('https://example.com/base/rss/blog-rss.rss');
+  });
 });

--- a/packages/plugin-sitemap/src/index.ts
+++ b/packages/plugin-sitemap/src/index.ts
@@ -49,12 +49,34 @@ export interface PluginSitemapOptions {
   defaultChangeFreq?: ChangeFreq;
 }
 
+function ensureTrailingSlash(url: string) {
+  return url.endsWith('/') ? url : `${url}/`;
+}
+
+function normalizeSiteUrl(siteUrl: string): string {
+  try {
+    const url = new URL(siteUrl);
+    url.pathname = ensureTrailingSlash(url.pathname);
+    return url.href;
+  } catch {
+    throw new Error(
+      '[plugin-sitemap] `siteUrl` must be a valid absolute URL with protocol, such as `https://example.com/base/`.',
+    );
+  }
+}
+
 function getSiteUrl(siteUrl: string | undefined, config: UserConfig) {
   if (siteUrl) {
-    return siteUrl;
+    return normalizeSiteUrl(siteUrl);
   }
   const base = withBase('/', config.base ?? '/');
-  return config.siteOrigin ? withSiteOrigin(base, config.siteOrigin) : base;
+  try {
+    return config.siteOrigin ? withSiteOrigin(base, config.siteOrigin) : base;
+  } catch {
+    throw new Error(
+      '[plugin-sitemap] `siteOrigin` in rspress.config.ts must be a valid absolute URL origin with protocol, such as `https://example.com`.',
+    );
+  }
 }
 
 const generateNode = (sitemap: Sitemap): string => {

--- a/packages/plugin-sitemap/src/index.ts
+++ b/packages/plugin-sitemap/src/index.ts
@@ -1,9 +1,21 @@
 import { mkdir, stat, writeFile } from 'node:fs/promises';
 import { dirname, isAbsolute } from 'node:path';
-import { logger, type RspressPlugin } from '@rspress/core';
+import {
+  logger,
+  type RspressPlugin,
+  type UserConfig,
+  withBase,
+  withSiteOrigin,
+} from '@rspress/core';
 
 type ChangeFreq =
-  'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never';
+  | 'always'
+  | 'hourly'
+  | 'daily'
+  | 'weekly'
+  | 'monthly'
+  | 'yearly'
+  | 'never';
 
 type Priority =
   | '0.0'
@@ -31,10 +43,18 @@ interface CustomMaps {
 }
 
 export interface PluginSitemapOptions {
-  siteUrl: string;
+  siteUrl?: string;
   customMaps?: CustomMaps;
   defaultPriority?: Priority;
   defaultChangeFreq?: ChangeFreq;
+}
+
+function getSiteUrl(siteUrl: string | undefined, config: UserConfig) {
+  if (siteUrl) {
+    return siteUrl;
+  }
+  const base = withBase('/', config.base ?? '/');
+  return config.siteOrigin ? withSiteOrigin(base, config.siteOrigin) : base;
 }
 
 const generateNode = (sitemap: Sitemap): string => {
@@ -54,7 +74,9 @@ const generateXml = (sitemaps: Sitemap[]) => {
   )}</urlset>`;
 };
 
-export function pluginSitemap(options: PluginSitemapOptions): RspressPlugin {
+export function pluginSitemap(
+  options: PluginSitemapOptions = {},
+): RspressPlugin {
   const {
     siteUrl,
     customMaps = {},
@@ -63,15 +85,21 @@ export function pluginSitemap(options: PluginSitemapOptions): RspressPlugin {
   } = options;
   const sitemaps: Sitemap[] = [];
   const set = new Set();
+  let resolvedSiteUrl = '';
   return {
     name: '@rspress/plugin-sitemap',
+    beforeBuild(config, isProd) {
+      if (isProd) {
+        resolvedSiteUrl = getSiteUrl(siteUrl, config);
+      }
+    },
     async extendPageData(pageData, isProd) {
       if (isProd) {
         if (!set.has(pageData.routePath)) {
           set.add(pageData.routePath);
           sitemaps.push({
             // @ts-expect-error
-            loc: `${siteUrl.replace(/\/$/, '')}${pageData.routePath}`,
+            loc: `${resolvedSiteUrl.replace(/\/$/, '')}${pageData.routePath}`,
             lastmod: (await stat(pageData._filepath)).mtime.toISOString(),
             priority: pageData.routePath === '/' ? '1.0' : defaultPriority,
             changefreq: defaultChangeFreq,

--- a/packages/plugin-sitemap/src/index.ts
+++ b/packages/plugin-sitemap/src/index.ts
@@ -9,13 +9,7 @@ import {
 } from '@rspress/core';
 
 type ChangeFreq =
-  | 'always'
-  | 'hourly'
-  | 'daily'
-  | 'weekly'
-  | 'monthly'
-  | 'yearly'
-  | 'never';
+  'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never';
 
 type Priority =
   | '0.0'

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -34,6 +34,7 @@ export {
   SEARCH_INDEX_NAME,
   slash,
   withBase,
+  withSiteOrigin,
   withoutLang,
 } from './runtime-utils/utils';
 export * from './types';

--- a/packages/shared/src/runtime-utils/utils.test.ts
+++ b/packages/shared/src/runtime-utils/utils.test.ts
@@ -8,6 +8,7 @@ import {
   replaceLang,
   replaceVersion,
   withBase,
+  withSiteOrigin,
   withoutLang,
 } from './utils';
 
@@ -31,6 +32,22 @@ describe('test shared utils', () => {
     expect(firstResult).toBe('/my-base/guide/');
     const secondResult = withBase(firstResult, base);
     expect(secondResult).toBe('/my-base/guide/');
+  });
+
+  test('withSiteOrigin', () => {
+    expect(withSiteOrigin('/guide/index.md', 'https://example.com')).toBe(
+      'https://example.com/guide/index.md',
+    );
+    expect(withSiteOrigin('/base/guide/index.md', 'https://example.com/')).toBe(
+      'https://example.com/base/guide/index.md',
+    );
+    expect(withSiteOrigin('/', 'https://example.com')).toBe(
+      'https://example.com/',
+    );
+    expect(withSiteOrigin('https://example.com/guide/index.md', '/base/')).toBe(
+      'https://example.com/guide/index.md',
+    );
+    expect(withSiteOrigin('/guide/index.md')).toBe('/guide/index.md');
   });
 
   test('removeBase', () => {

--- a/packages/shared/src/runtime-utils/utils.test.ts
+++ b/packages/shared/src/runtime-utils/utils.test.ts
@@ -41,6 +41,9 @@ describe('test shared utils', () => {
     expect(withSiteOrigin('/base/guide/index.md', 'https://example.com/')).toBe(
       'https://example.com/base/guide/index.md',
     );
+    expect(withSiteOrigin('/foo:bar/index.md', 'https://example.com')).toBe(
+      'https://example.com/foo:bar/index.md',
+    );
     expect(withSiteOrigin('/', 'https://example.com')).toBe(
       'https://example.com/',
     );

--- a/packages/shared/src/runtime-utils/utils.ts
+++ b/packages/shared/src/runtime-utils/utils.ts
@@ -282,6 +282,13 @@ export function withBase(url: string, base: string): string {
   return `${normalizedBase}${normalizedUrl}`;
 }
 
+export function withSiteOrigin(url: string, siteOrigin?: string): string {
+  if (!siteOrigin || isExternalUrl(url)) {
+    return url;
+  }
+  return new URL(removeLeadingSlash(url), addTrailingSlash(siteOrigin)).href;
+}
+
 export function removeBase(url: string, base: string) {
   const normalizedUrl = addLeadingSlash(url);
   const normalizedBase = normalizeSlash(base);

--- a/packages/shared/src/runtime-utils/utils.ts
+++ b/packages/shared/src/runtime-utils/utils.ts
@@ -286,7 +286,7 @@ export function withSiteOrigin(url: string, siteOrigin?: string): string {
   if (!siteOrigin || isExternalUrl(url)) {
     return url;
   }
-  return new URL(removeLeadingSlash(url), addTrailingSlash(siteOrigin)).href;
+  return new URL(addLeadingSlash(url), addTrailingSlash(siteOrigin)).href;
 }
 
 export function removeBase(url: string, base: string) {

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -545,8 +545,7 @@ export type RemarkLinkOptions = {
    * @default true
    */
   checkDeadLinks?:
-    | boolean
-    | { excludes: string[] | ((url: string) => boolean) };
+    boolean | { excludes: string[] | ((url: string) => boolean) };
   /**
    * Whether to enable dead anchor checks
    * @default false
@@ -565,8 +564,7 @@ export type RemarkImageOptions = {
    * @default true
    */
   checkDeadImages?:
-    | boolean
-    | { excludes: string[] | ((url: string) => boolean) };
+    boolean | { excludes: string[] | ((url: string) => boolean) };
 };
 
 export interface MarkdownOptions {

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -152,6 +152,10 @@ export interface UserConfig {
    */
   base?: string;
   /**
+   * Origin of the site, such as `https://example.com`.
+   */
+  siteOrigin?: string;
+  /**
    * Path to html icon file.
    * @default ''
    */
@@ -354,6 +358,7 @@ export interface PageDataLegacy {
 
 export interface SiteData {
   base: string;
+  siteOrigin: string;
   lang: string;
   route: RouteOptions;
   locales: { lang: string; label: string }[];
@@ -540,7 +545,8 @@ export type RemarkLinkOptions = {
    * @default true
    */
   checkDeadLinks?:
-    boolean | { excludes: string[] | ((url: string) => boolean) };
+    | boolean
+    | { excludes: string[] | ((url: string) => boolean) };
   /**
    * Whether to enable dead anchor checks
    * @default false
@@ -559,7 +565,8 @@ export type RemarkImageOptions = {
    * @default true
    */
   checkDeadImages?:
-    boolean | { excludes: string[] | ((url: string) => boolean) };
+    | boolean
+    | { excludes: string[] | ((url: string) => boolean) };
 };
 
 export interface MarkdownOptions {

--- a/website/docs/en/api/config/config-basic.mdx
+++ b/website/docs/en/api/config/config-basic.mdx
@@ -39,6 +39,28 @@ export default defineConfig({
 });
 ```
 
+## siteOrigin
+
+- **Type**: `string`
+- **Default**: `""`
+
+The optional deployment origin of the site, for example `https://foo.github.io`.
+
+Rspress uses this value together with [`base`](#base) when generated files need absolute URLs, such as `llms.txt` links or plugin outputs. The full URL concatenation order is `siteOrigin + base + routePath`.
+
+If `siteOrigin` is not configured, Rspress uses `base + routePath` as the fallback.
+
+If your site is deployed to `https://foo.github.io/bar/`, set `siteOrigin` to `"https://foo.github.io"` and `base` to `"/bar/"`:
+
+```ts title="rspress.config.ts" twoslash
+import { defineConfig } from '@rspress/core';
+
+export default defineConfig({
+  siteOrigin: 'https://foo.github.io',
+  base: '/bar/',
+});
+```
+
 ## title
 
 - **Type**: `string`

--- a/website/docs/en/plugin/official-plugins/rss.mdx
+++ b/website/docs/en/plugin/official-plugins/rss.mdx
@@ -141,7 +141,7 @@ Plugin options.
 
 ```ts
 export interface PluginRssOptions {
-  siteUrl: string;
+  siteUrl?: string;
   feed?: Partial<FeedChannel> | FeedChannel[];
   output?: Omit<FeedOutputOptions, 'filename'>;
 }
@@ -150,11 +150,11 @@ export interface PluginRssOptions {
 #### `siteUrl`
 
 - **Type**: `string`
-- **Required**
+- **Default**: [`siteOrigin`](/api/config/config-basic#siteorigin) + [`base`](/api/config/config-basic#base), or `base` when `siteOrigin` is not configured
 
 The site URL of the current documentation site. It is used in the RSS file.
 
-When `base` is configured, `siteUrl` must include the `base` path. For example:
+When `base` is configured, plugin-level `siteUrl` must include the `base` path. If [`siteOrigin`](/api/config/config-basic#siteorigin) and [`base`](/api/config/config-basic#base) are configured in Rspress, you can omit the plugin-level `siteUrl`. The full URL concatenation order is `siteOrigin + base + routePath`.
 
 ```ts
 // rspress.config.ts
@@ -163,11 +163,11 @@ import { defineConfig } from '@rspress/core';
 import { pluginRss } from '@rspress/plugin-rss';
 
 export default defineConfig({
+  siteOrigin: 'https://example.com',
   base: '/base/',
   plugins: [
-    pluginRss({
-      siteUrl: 'https://example.com/base/',
-    }),
+    // siteUrl defaults to 'https://example.com/base/'
+    pluginRss(),
   ],
 });
 ```
@@ -196,7 +196,10 @@ RSS file options.
 export interface FeedChannel extends Partial<FeedOptions> {
   id: string;
   test:
-    RegExp | string | (RegExp | string)[] | ((item: PageIndexInfo) => boolean);
+    | RegExp
+    | string
+    | (RegExp | string)[]
+    | ((item: PageIndexInfo) => boolean);
   item?: (
     item: FeedItem,
     page: PageIndexInfo,

--- a/website/docs/en/plugin/official-plugins/rss.mdx
+++ b/website/docs/en/plugin/official-plugins/rss.mdx
@@ -196,10 +196,7 @@ RSS file options.
 export interface FeedChannel extends Partial<FeedOptions> {
   id: string;
   test:
-    | RegExp
-    | string
-    | (RegExp | string)[]
-    | ((item: PageIndexInfo) => boolean);
+    RegExp | string | (RegExp | string)[] | ((item: PageIndexInfo) => boolean);
   item?: (
     item: FeedItem,
     page: PageIndexInfo,

--- a/website/docs/en/plugin/official-plugins/rss.mdx
+++ b/website/docs/en/plugin/official-plugins/rss.mdx
@@ -154,7 +154,9 @@ export interface PluginRssOptions {
 
 The site URL of the current documentation site. It is used in the RSS file.
 
-When `base` is configured, plugin-level `siteUrl` must include the `base` path. If [`siteOrigin`](/api/config/config-basic#siteorigin) and [`base`](/api/config/config-basic#base) are configured in Rspress, you can omit the plugin-level `siteUrl`. The full URL concatenation order is `siteOrigin + base + routePath`.
+RSS links are consumed outside the documentation page context, so configure an absolute URL with protocol and domain, such as `https://example.com/base/`. When `base` is configured, plugin-level `siteUrl` must include the `base` path.
+
+If [`siteOrigin`](/api/config/config-basic#siteorigin) and [`base`](/api/config/config-basic#base) are configured in Rspress, you can omit the plugin-level `siteUrl`. The full URL concatenation order is `siteOrigin + base + routePath`. If neither plugin-level `siteUrl` nor `siteOrigin` is configured, the plugin falls back to `base`, which keeps existing relative path behavior but does not generate absolute RSS links.
 
 ```ts
 // rspress.config.ts

--- a/website/docs/en/plugin/official-plugins/sitemap.mdx
+++ b/website/docs/en/plugin/official-plugins/sitemap.mdx
@@ -35,13 +35,7 @@ This plugin accepts an options object with the following type:
 
 ```ts
 type ChangeFreq =
-  | 'always'
-  | 'hourly'
-  | 'daily'
-  | 'weekly'
-  | 'monthly'
-  | 'yearly'
-  | 'never';
+  'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never';
 
 type Priority =
   | '0.0'

--- a/website/docs/en/plugin/official-plugins/sitemap.mdx
+++ b/website/docs/en/plugin/official-plugins/sitemap.mdx
@@ -77,7 +77,9 @@ export interface PluginSitemapOptions {
 
 The site URL for deployment access, for example `https://example.com`.
 
-When `base` is configured, plugin-level `siteUrl` must include the `base` path. If [`siteOrigin`](/api/config/config-basic#siteorigin) and [`base`](/api/config/config-basic#base) are configured in Rspress, you can omit the plugin-level `siteUrl`. The full URL concatenation order is `siteOrigin + base + routePath`.
+Sitemap `<loc>` entries should be absolute URLs with protocol and domain, such as `https://example.com/base/`. When `base` is configured, plugin-level `siteUrl` must include the `base` path.
+
+If [`siteOrigin`](/api/config/config-basic#siteorigin) and [`base`](/api/config/config-basic#base) are configured in Rspress, you can omit the plugin-level `siteUrl`. The full URL concatenation order is `siteOrigin + base + routePath`. If neither plugin-level `siteUrl` nor `siteOrigin` is configured, the plugin falls back to `base`, which keeps existing relative path behavior but does not generate absolute sitemap URLs.
 
 ```ts
 // rspress.config.ts

--- a/website/docs/en/plugin/official-plugins/sitemap.mdx
+++ b/website/docs/en/plugin/official-plugins/sitemap.mdx
@@ -35,7 +35,13 @@ This plugin accepts an options object with the following type:
 
 ```ts
 type ChangeFreq =
-  'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never';
+  | 'always'
+  | 'hourly'
+  | 'daily'
+  | 'weekly'
+  | 'monthly'
+  | 'yearly'
+  | 'never';
 
 type Priority =
   | '0.0'
@@ -73,11 +79,11 @@ export interface PluginSitemapOptions {
 ### siteUrl
 
 - **Type**: `string`
-- **Required**
+- **Default**: [`siteOrigin`](/api/config/config-basic#siteorigin) + [`base`](/api/config/config-basic#base), or `base` when `siteOrigin` is not configured
 
 The site URL for deployment access, for example `https://example.com`.
 
-When `base` is configured, `siteUrl` must include the `base` path. For example:
+When `base` is configured, plugin-level `siteUrl` must include the `base` path. If [`siteOrigin`](/api/config/config-basic#siteorigin) and [`base`](/api/config/config-basic#base) are configured in Rspress, you can omit the plugin-level `siteUrl`. The full URL concatenation order is `siteOrigin + base + routePath`.
 
 ```ts
 // rspress.config.ts
@@ -86,11 +92,11 @@ import { defineConfig } from '@rspress/core';
 import { pluginSitemap } from '@rspress/plugin-sitemap';
 
 export default defineConfig({
+  siteOrigin: 'https://example.com',
   base: '/base/',
   plugins: [
-    pluginSitemap({
-      siteUrl: 'https://example.com/base/',
-    }),
+    // siteUrl defaults to 'https://example.com/base/'
+    pluginSitemap(),
   ],
 });
 ```

--- a/website/docs/zh/api/config/config-basic.mdx
+++ b/website/docs/zh/api/config/config-basic.mdx
@@ -39,6 +39,28 @@ export default defineConfig({
 });
 ```
 
+## siteOrigin
+
+- **类型**： `string`
+- **默认值**： `""`
+
+站点的可选部署 origin，例如 `https://foo.github.io`。
+
+Rspress 在生成需要绝对 URL 的文件时会结合该值和 [`base`](#base)，例如 `llms.txt` 链接或插件输出。完整 URL 拼接顺序是 `siteOrigin + base + routePath`。
+
+如果没有配置 `siteOrigin`，Rspress 会回退使用 `base + routePath`。
+
+如果你的站点部署到 `https://foo.github.io/bar/`，请将 `siteOrigin` 设置为 `"https://foo.github.io"`，并将 `base` 设置为 `"/bar/"`：
+
+```ts title="rspress.config.ts" twoslash
+import { defineConfig } from '@rspress/core';
+
+export default defineConfig({
+  siteOrigin: 'https://foo.github.io',
+  base: '/bar/',
+});
+```
+
 ## title
 
 - **类型**： `string`

--- a/website/docs/zh/plugin/official-plugins/rss.mdx
+++ b/website/docs/zh/plugin/official-plugins/rss.mdx
@@ -154,7 +154,9 @@ export interface PluginRssOptions {
 
 当前文档站点的站点 URL。将在 RSS 文件中使用。
 
-当存在 `base` 配置时，插件级 `siteUrl` 需要包含 `base` 的路径。如果已经在 Rspress 中配置了 [`siteOrigin`](/zh/api/config/config-basic#siteorigin) 和 [`base`](/zh/api/config/config-basic#base)，可以省略插件级 `siteUrl`。完整 URL 拼接顺序是 `siteOrigin + base + routePath`：
+RSS 链接会在文档页面上下文之外被消费，因此应配置包含协议和域名的绝对 URL，例如 `https://example.com/base/`。当存在 `base` 配置时，插件级 `siteUrl` 需要包含 `base` 的路径。
+
+如果已经在 Rspress 中配置了 [`siteOrigin`](/zh/api/config/config-basic#siteorigin) 和 [`base`](/zh/api/config/config-basic#base)，可以省略插件级 `siteUrl`。完整 URL 拼接顺序是 `siteOrigin + base + routePath`。如果既没有配置插件级 `siteUrl`，也没有配置 `siteOrigin`，插件会回退使用 `base`，这会保留已有的相对路径行为，但不会生成绝对 RSS 链接：
 
 ```ts
 // rspress.config.ts

--- a/website/docs/zh/plugin/official-plugins/rss.mdx
+++ b/website/docs/zh/plugin/official-plugins/rss.mdx
@@ -141,7 +141,7 @@ RSS 文件由两部分组成，一部分是 RSS 的基础信息，在 RSS 格式
 
 ```ts
 export interface PluginRssOptions {
-  siteUrl: string;
+  siteUrl?: string;
   feed?: Partial<FeedChannel> | FeedChannel[];
   output?: Omit<FeedOutputOptions, 'filename'>;
 }
@@ -150,11 +150,11 @@ export interface PluginRssOptions {
 #### `siteUrl`
 
 - **类型**： `string`
-- **必填**
+- **默认值**：[`siteOrigin`](/zh/api/config/config-basic#siteorigin) + [`base`](/zh/api/config/config-basic#base)，未配置 `siteOrigin` 时使用 `base`
 
 当前文档站点的站点 URL。将在 RSS 文件中使用。
 
-当存在 `base` 配置时，`siteUrl` 需要包含 `base` 的路径。例如：
+当存在 `base` 配置时，插件级 `siteUrl` 需要包含 `base` 的路径。如果已经在 Rspress 中配置了 [`siteOrigin`](/zh/api/config/config-basic#siteorigin) 和 [`base`](/zh/api/config/config-basic#base)，可以省略插件级 `siteUrl`。完整 URL 拼接顺序是 `siteOrigin + base + routePath`：
 
 ```ts
 // rspress.config.ts
@@ -163,11 +163,11 @@ import { defineConfig } from '@rspress/core';
 import { pluginRss } from '@rspress/plugin-rss';
 
 export default defineConfig({
+  siteOrigin: 'https://example.com',
   base: '/base/',
   plugins: [
-    pluginRss({
-      siteUrl: 'https://example.com/base/',
-    }),
+    // siteUrl 默认为 'https://example.com/base/'
+    pluginRss(),
   ],
 });
 ```
@@ -194,7 +194,10 @@ RSS 配置，多值数组可以生成多个 RSS 文件。
 export interface FeedChannel extends Partial<FeedOptions> {
   id: string;
   test:
-    RegExp | string | (RegExp | string)[] | ((item: PageIndexInfo) => boolean);
+    | RegExp
+    | string
+    | (RegExp | string)[]
+    | ((item: PageIndexInfo) => boolean);
   item?: (
     item: FeedItem,
     page: PageIndexInfo,

--- a/website/docs/zh/plugin/official-plugins/rss.mdx
+++ b/website/docs/zh/plugin/official-plugins/rss.mdx
@@ -194,10 +194,7 @@ RSS 配置，多值数组可以生成多个 RSS 文件。
 export interface FeedChannel extends Partial<FeedOptions> {
   id: string;
   test:
-    | RegExp
-    | string
-    | (RegExp | string)[]
-    | ((item: PageIndexInfo) => boolean);
+    RegExp | string | (RegExp | string)[] | ((item: PageIndexInfo) => boolean);
   item?: (
     item: FeedItem,
     page: PageIndexInfo,

--- a/website/docs/zh/plugin/official-plugins/sitemap.mdx
+++ b/website/docs/zh/plugin/official-plugins/sitemap.mdx
@@ -77,7 +77,9 @@ export interface PluginSitemapOptions {
 
 部署访问的站点 URL，例如 `https://example.com`。
 
-当存在 `base` 配置时，插件级 `siteUrl` 需要包含 `base` 的路径。如果已经在 Rspress 中配置了 [`siteOrigin`](/zh/api/config/config-basic#siteorigin) 和 [`base`](/zh/api/config/config-basic#base)，可以省略插件级 `siteUrl`。完整 URL 拼接顺序是 `siteOrigin + base + routePath`：
+sitemap 的 `<loc>` 应是包含协议和域名的绝对 URL，例如 `https://example.com/base/`。当存在 `base` 配置时，插件级 `siteUrl` 需要包含 `base` 的路径。
+
+如果已经在 Rspress 中配置了 [`siteOrigin`](/zh/api/config/config-basic#siteorigin) 和 [`base`](/zh/api/config/config-basic#base)，可以省略插件级 `siteUrl`。完整 URL 拼接顺序是 `siteOrigin + base + routePath`。如果既没有配置插件级 `siteUrl`，也没有配置 `siteOrigin`，插件会回退使用 `base`，这会保留已有的相对路径行为，但不会生成绝对 sitemap URL：
 
 ```ts
 // rspress.config.ts

--- a/website/docs/zh/plugin/official-plugins/sitemap.mdx
+++ b/website/docs/zh/plugin/official-plugins/sitemap.mdx
@@ -35,7 +35,13 @@ export default defineConfig({
 
 ```ts
 type ChangeFreq =
-  'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never';
+  | 'always'
+  | 'hourly'
+  | 'daily'
+  | 'weekly'
+  | 'monthly'
+  | 'yearly'
+  | 'never';
 
 type Priority =
   | '0.0'
@@ -73,11 +79,11 @@ export interface PluginSitemapOptions {
 ### siteUrl
 
 - **类型**： `string`
-- **必填**
+- **默认值**：[`siteOrigin`](/zh/api/config/config-basic#siteorigin) 与 [`base`](/zh/api/config/config-basic#base)，未配置 `siteOrigin` 时使用 `base`
 
 部署访问的站点 URL，例如 `https://example.com`。
 
-当存在 `base` 配置时，`siteUrl` 需要包含 `base` 的路径。例如：
+当存在 `base` 配置时，插件级 `siteUrl` 需要包含 `base` 的路径。如果已经在 Rspress 中配置了 [`siteOrigin`](/zh/api/config/config-basic#siteorigin) 和 [`base`](/zh/api/config/config-basic#base)，可以省略插件级 `siteUrl`。完整 URL 拼接顺序是 `siteOrigin + base + routePath`：
 
 ```ts
 // rspress.config.ts
@@ -86,11 +92,11 @@ import { defineConfig } from '@rspress/core';
 import { pluginSitemap } from '@rspress/plugin-sitemap';
 
 export default defineConfig({
+  siteOrigin: 'https://example.com',
   base: '/base/',
   plugins: [
-    pluginSitemap({
-      siteUrl: 'https://example.com/base/',
-    }),
+    // siteUrl 默认为 'https://example.com/base/'
+    pluginSitemap(),
   ],
 });
 ```

--- a/website/docs/zh/plugin/official-plugins/sitemap.mdx
+++ b/website/docs/zh/plugin/official-plugins/sitemap.mdx
@@ -35,13 +35,7 @@ export default defineConfig({
 
 ```ts
 type ChangeFreq =
-  | 'always'
-  | 'hourly'
-  | 'daily'
-  | 'weekly'
-  | 'monthly'
-  | 'yearly'
-  | 'never';
+  'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never';
 
 type Priority =
   | '0.0'

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -23,7 +23,7 @@ import pluginOg from 'rspress-plugin-og';
 
 // import { pluginFontOpenSans } from 'rspress-plugin-font-open-sans';
 
-const siteUrl = 'https://rspress.rs';
+const siteOrigin = 'https://rspress.rs';
 
 const commonRsdoctorConfig = {
   disableClientServer: true,
@@ -38,6 +38,7 @@ const commonRsdoctorConfig = {
 export default defineConfig({
   title: 'Rspress',
   description: 'Rsbuild based static site generator',
+  siteOrigin,
   lang: 'en',
   logo: 'https://assets.rspack.rs/rspress/rspress-logo.svg',
   logoText: 'Rspress',
@@ -95,14 +96,14 @@ export default defineConfig({
     pluginTwoslash(),
     // pluginFontOpenSans(), // removed this line for Rspress preview
     pluginSitemap({
-      siteUrl,
+      siteUrl: siteOrigin,
     }),
     pluginAlgolia({
       verificationContent: '8F5BFE50E65777F1',
     }),
     pluginFileTree(),
     pluginOg({
-      domain: 'https://rspress.rs',
+      domain: siteOrigin,
       maxTitleSizePerLine: 28,
       async resvgOptions() {
         // fetch font files to og-fonts
@@ -141,7 +142,7 @@ export default defineConfig({
       pluginSass(),
       pluginGoogleAnalytics({ id: 'G-66B2Z6KG0J' }),
       pluginOpenGraph({
-        url: siteUrl,
+        url: siteOrigin,
         description: 'Rsbuild based static site generator',
         twitter: {
           site: '@rspack_dev',


### PR DESCRIPTION
## Summary

- Adds optional top-level `siteOrigin` config as the deployment origin shared by generated URL output.
- Applies the `siteOrigin + base + routePath` order for core SSG-MD/llms output and `@rspress/plugin-llms` generated links.
- Lets RSS and sitemap plugins derive plugin `siteUrl` from `siteOrigin + base`, falling back to `base` when `siteOrigin` is omitted while preserving explicit plugin `siteUrl` overrides.
- Documents `siteOrigin` and the URL composition order in English and Chinese docs.

## Testing

- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm exec rstest run packages/shared/src/runtime-utils/utils.test.ts packages/plugin-rss/tests/output.test.ts`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm exec rslint --type-check`
- `NX_DAEMON=false PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm exec nx run-many -t build -p @rspress/shared @rspress/core @rspress/plugin-llms @rspress/plugin-rss @rspress/plugin-sitemap --skip-nx-cache`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm exec playwright test e2e/fixtures/plugin-llms/index.test.ts e2e/fixtures/plugin-rss/index.test.ts e2e/fixtures/ssg-md/index.test.ts`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm exec cspell website/docs/en/api/config/config-basic.mdx website/docs/en/plugin/official-plugins/rss.mdx website/docs/en/plugin/official-plugins/sitemap.mdx website/docs/zh/api/config/config-basic.mdx website/docs/zh/plugin/official-plugins/rss.mdx website/docs/zh/plugin/official-plugins/sitemap.mdx`
- `git diff --check`
