### PR TITLE
refactor(search): extract helper and add idle callback cleanup ♻️ 

### DIFF
--- a/packages/core/src/theme/components/Search/SearchPanel.tsx
+++ b/packages/core/src/theme/components/Search/SearchPanel.tsx
@@ -51,6 +51,22 @@ const useDebounce = <T extends (...args: any[]) => any>(cb: T) => {
   return debounced;
 };
 
+const normalizeSuggestions = (
+  suggestions: DefaultMatchResult['result'],
+): Map<string, DefaultMatchResultItem[]> => {
+  return suggestions.reduce(
+    (groups, item) => {
+      const group = item.title;
+      if (!groups.has(group)) {
+        groups.set(group, []);
+      }
+      groups.get(group)!.push(item);
+      return groups;
+    },
+    new Map() as Map<string, DefaultMatchResult['result']>,
+  );
+};
+
 export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
   const [query, setQuery] = useState('');
   const [searchResult, setSearchResult] = useState<MatchResult>([]);
@@ -363,22 +379,6 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
   };
 
   const handleQueryChange = useDebounce(handleQueryChangedImpl);
-
-  const normalizeSuggestions = (
-    suggestions: DefaultMatchResult['result'],
-  ): Map<string, DefaultMatchResultItem[]> => {
-    return suggestions.reduce(
-      (groups, item) => {
-        const group = item.title;
-        if (!groups.has(group)) {
-          groups.set(group, []);
-        }
-        groups.get(group)!.push(item);
-        return groups;
-      },
-      new Map() as Map<string, DefaultMatchResult['result']>,
-    );
-  };
 
   const renderSearchResult = (result: MatchResult, isSearching: boolean) => {
     if (result.length === 1) {

--- a/packages/core/src/theme/components/Search/SearchPanel.tsx
+++ b/packages/core/src/theme/components/Search/SearchPanel.tsx
@@ -277,12 +277,18 @@ export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
 
   // Prefetch the search index when the page is idle
   useEffect(() => {
+    let idleCallbackID: number | undefined;
     if ('requestIdleCallback' in window && !pageSearcherRef.current) {
-      window.requestIdleCallback(() => {
+      idleCallbackID = window.requestIdleCallback(() => {
         const searcher = createSearcher();
         searcher.fetchSearchIndex();
       });
     }
+    return () => {
+      if (idleCallbackID !== undefined && 'cancelIdleCallback' in window) {
+        window.cancelIdleCallback(idleCallbackID);
+      }
+    };
   }, []);
 
   // init pageSearcher again when lang or version changed


### PR DESCRIPTION

## Summary
This pull request introduces two minor optimizations to improve memory management and resource cleanup:
1. **Moved the helper function `normalizeSuggestions` outside the component scope.**
2. **Added a cleanup function to cancel scheduled idle callbacks on component unmount.**

---

## Changes and Benefits

### 1. Moving `normalizeSuggestions` outside the component
* **Before:** The utility function was defined inside the component, meaning it was recreated in memory on every single render.
* **After:** It is now defined outside the component.
* **Benefits:** 
  * **Memory footprint:** The function is instantiated only once when the module is loaded, rather than repeatedly.
  * **Reduced Garbage Collection (GC) pressure:** Since the browser doesn't have to clean up discarded function instances after each render, it reduces the workload on the JS engine, resulting in smoother rendering performance (particularly during frequent state updates).

### 2. Adding `cancelIdleCallback` in the `useEffect` cleanup
* **Before:** If the component unmounted before the scheduled background searcher initialization finished, the callback would still execute in the background.
* **After:** The cleanup function saves the `idleCallbackID` and cancels the scheduled task upon unmount.
* **Benefits:**
  * **Resource safety:** Prevents unnecessary background API requests (`fetchSearchIndex`) and CPU usage for components that are no longer active in the DOM.
  * **Memory leak prevention:** Ensures that references to component-scoped elements (such as refs or functions within the callback) can be garbage collected as soon as the component unmounts.

---

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
