### PR TITLE
fix(mdx/title): strip inline markdown in h1 e.g: "# `__ReplaceElements`"

### DIFF
--- a/packages/core/src/node/mdx/rehypePlugins/__snapshots__/headerAnchor.test.ts.snap
+++ b/packages/core/src/node/mdx/rehypePlugins/__snapshots__/headerAnchor.test.ts.snap
@@ -157,7 +157,7 @@ export default function MDXContent(props = {}) {
 
 
 MDXContent.__RSPRESS_PAGE_META = {};
-MDXContent.__RSPRESS_PAGE_META["inline-code.mdx"] = {"toc":[],"title":"Hello World \`inline code\`","headingTitle":"Hello World \`inline code\`","frontmatter":{}};
+MDXContent.__RSPRESS_PAGE_META["inline-code.mdx"] = {"toc":[],"title":"Hello World inline code","headingTitle":"Hello World inline code","frontmatter":{}};
 "
 `;
 
@@ -200,7 +200,7 @@ export default function MDXContent(props = {}) {
 
 
 MDXContent.__RSPRESS_PAGE_META = {};
-MDXContent.__RSPRESS_PAGE_META["inline-code.mdx"] = {"toc":[],"title":"Hello World \`inline code\`","headingTitle":"Hello World \`inline code\`","frontmatter":{}};
+MDXContent.__RSPRESS_PAGE_META["inline-code.mdx"] = {"toc":[],"title":"Hello World inline code","headingTitle":"Hello World inline code","frontmatter":{}};
 "
 `;
 

--- a/packages/core/src/node/mdx/remarkPlugins/toc.test.ts
+++ b/packages/core/src/node/mdx/remarkPlugins/toc.test.ts
@@ -53,6 +53,22 @@ describe('parseToc', () => {
     expect(result.toc).toEqual([]);
   });
 
+  test('extracts plain title from h1 with inline code', () => {
+    const tree: MdastRoot = {
+      type: 'root',
+      children: [
+        {
+          type: 'heading',
+          depth: 1,
+          children: [{ type: 'inlineCode', value: '__ReplaceElements' }],
+        },
+      ],
+    };
+    const result = parseToc(tree);
+    expect(result.title).toBe('__ReplaceElements');
+    expect(result.toc).toEqual([]);
+  });
+
   test('extracts h2-h4 headings into toc', () => {
     const tree: MdastRoot = {
       type: 'root',

--- a/packages/core/src/node/mdx/remarkPlugins/toc.ts
+++ b/packages/core/src/node/mdx/remarkPlugins/toc.ts
@@ -24,24 +24,43 @@ interface Heading {
   children?: ChildNode[];
 }
 
-const extractChildText = (child: ChildNode): string => {
+const extractChildText = (
+  child: ChildNode,
+  preserveInlineMarkdown = true,
+): string => {
   if (child.type === 'link') {
-    return child.children?.map(extractChildText).join('') ?? '';
+    return (
+      child.children
+        ?.map(child => extractChildText(child, preserveInlineMarkdown))
+        .join('') ?? ''
+    );
   }
   if (child.type === 'strong') {
-    return `**${child.children?.map(extractChildText).join('') ?? ''}**`;
+    const text =
+      child.children
+        ?.map(child => extractChildText(child, preserveInlineMarkdown))
+        .join('') ?? '';
+    return preserveInlineMarkdown ? `**${text}**` : text;
   }
   if (child.type === 'emphasis') {
-    return `*${child.children?.map(extractChildText).join('') ?? ''}*`;
+    const text =
+      child.children
+        ?.map(child => extractChildText(child, preserveInlineMarkdown))
+        .join('') ?? '';
+    return preserveInlineMarkdown ? `*${text}*` : text;
   }
   if (child.type === 'delete') {
-    return `~~${child.children?.map(extractChildText).join('') ?? ''}~~`;
+    const text =
+      child.children
+        ?.map(child => extractChildText(child, preserveInlineMarkdown))
+        .join('') ?? '';
+    return preserveInlineMarkdown ? `~~${text}~~` : text;
   }
   if (child.type === 'text') {
     return child.value;
   }
   if (child.type === 'inlineCode') {
-    return `\`${child.value}\``;
+    return preserveInlineMarkdown ? `\`${child.value}\`` : child.value;
   }
   return '';
 };
@@ -69,9 +88,19 @@ export const parseToc = (tree: MdastRoot | HastRoot) => {
         })
         .join('')
         .trim();
+      const titleText = node.children
+        .map((child: ChildNode) => {
+          if (child.type === 'text') {
+            const [textPart] = extractTextAndId(child.value);
+            return textPart;
+          }
+          return extractChildText(child, false);
+        })
+        .join('')
+        .trim();
 
       if (node.depth === 1) {
-        if (!title) title = text;
+        if (!title) title = titleText;
       } else {
         const id = customId ? customId : slugger.slug(text);
         const { depth } = node;


### PR DESCRIPTION
## Summary

Fixes page titles generated from H1 headings that contain inline Markdown, such as ``# `__ReplaceElements` ``, so the HTML title becomes `__ReplaceElements - Site` instead of preserving raw backticks. The TOC text still preserves inline Markdown for rendered outline styling.

```
// docs/index.mdx
# ~~usePageData~~
```

before

<img width="264" height="40" alt="image" src="https://github.com/user-attachments/assets/14c4a1d1-ebca-4263-8130-60cfcf488d61" />

after

<img width="239" height="40" alt="image" src="https://github.com/user-attachments/assets/a102810c-d00a-4a72-b6b2-9d1b652202b5" />



## Related Issue

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
