### PR TITLE
fix(theme): Get default theme from window.RSPRESS_THEME

### DIFF
--- a/packages/core/src/theme/logic/useThemeState.test.ts
+++ b/packages/core/src/theme/logic/useThemeState.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, rs, test } from '@rstest/core';
-import { getResolvedTheme, getStoredThemeConfig } from './useThemeState';
+import { afterEach, describe, expect, rs, test } from '@rstest/core';
+import {
+  getDefaultThemeConfig,
+  getResolvedTheme,
+  getStoredThemeConfig,
+} from './useThemeState';
 
 rs.mock('@rspress/core/runtime', () => ({
   useSite: () => ({
@@ -33,5 +37,37 @@ describe('getResolvedTheme', () => {
   test('keeps explicit theme config', () => {
     expect(getResolvedTheme('dark', false)).toBe('dark');
     expect(getResolvedTheme('light', true)).toBe('light');
+  });
+});
+
+describe('getDefaultThemeConfig', () => {
+  const _globalThis = globalThis as { window?: { RSPRESS_THEME?: string } };
+
+  afterEach(() => {
+    delete _globalThis.window;
+  });
+
+  test('returns "auto" when window is not available', () => {
+    expect(getDefaultThemeConfig()).toBe('auto');
+  });
+
+  test('returns "auto" when window.RSPRESS_THEME is not set', () => {
+    _globalThis.window = {};
+    expect(getDefaultThemeConfig()).toBe('auto');
+  });
+
+  test('returns "dark" when window.RSPRESS_THEME is "dark"', () => {
+    _globalThis.window = { RSPRESS_THEME: 'dark' };
+    expect(getDefaultThemeConfig()).toBe('dark');
+  });
+
+  test('returns "light" when window.RSPRESS_THEME is "light"', () => {
+    _globalThis.window = { RSPRESS_THEME: 'light' };
+    expect(getDefaultThemeConfig()).toBe('light');
+  });
+
+  test('returns "auto" when window.RSPRESS_THEME is an unsupported value', () => {
+    _globalThis.window = { RSPRESS_THEME: 'wrong' };
+    expect(getDefaultThemeConfig()).toBe('auto');
   });
 });

--- a/packages/core/src/theme/logic/useThemeState.ts
+++ b/packages/core/src/theme/logic/useThemeState.ts
@@ -10,6 +10,12 @@ import { useStorageValue } from './useStorageValue';
 const APPEARANCE_KEY = 'rspress-theme-appearance';
 const MEDIA_QUERY = '(prefers-color-scheme: dark)';
 
+declare global {
+  interface Window {
+    RSPRESS_THEME?: string;
+  }
+}
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -39,6 +45,14 @@ export const getResolvedTheme = (
   prefersDark: boolean,
 ): ThemeValue => (config === 'auto' ? getSystemTheme(prefersDark) : config);
 
+export const getDefaultThemeConfig = () => {
+  if (typeof window === 'undefined') return 'auto';
+  const defaultTheme = window.RSPRESS_THEME;
+  return defaultTheme === 'dark' || defaultTheme === 'light'
+    ? defaultTheme
+    : 'auto';
+};
+
 const applyThemeToDOM = (theme: ThemeValue) => {
   if (!document?.documentElement) return;
   const root = document.documentElement;
@@ -57,7 +71,7 @@ export function useThemeState() {
   const prefersDark = useMediaQuery(MEDIA_QUERY);
   const [storedConfig, setStoredConfig] = useStorageValue<ThemeConfigValue>(
     APPEARANCE_KEY,
-    'auto',
+    getDefaultThemeConfig(),
   );
 
   const theme = disableDarkMode


### PR DESCRIPTION
## Summary

Docs at https://rspress.rs/api/config/config-theme#darkmode have an example of how to set the default theme to be dark via `window.RSPRESS_THEME = 'dark';`, but this doesn't seem to take effect in Rspress 2.

When searching Rspress's repo, it seems that these docs are the only reference to `RSPRESS_THEME`, while it can be seen used in Rspress 1 at https://github.com/web-infra-dev/rspress/blob/v1.47.2/packages/theme-default/src/logic/useAppearance.ts.

I confirmed locally that `pnpm rstest run packages/core` and `pnpm lint` both pass, and I linked a local build where I was able to confirm expected behavior. 

## Related Issue

[Issue #3469](https://github.com/web-infra-dev/rspress/issues/3469) (opened by myself)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
  - Not required since this is specifically updating source code to match existing docs
  
## Idea outside of the change

Instead of requiring the script injection in the head, it could be nice to have a first-class theme config setting that could simply be `defaultTheme: ThemeConfigValue`.