### PR TITLE
fix(theme/inline-code-link): align link styles `--rp-c-link` and nav gap

### DIFF
--- a/packages/core/src/theme/components/DocContent/doc.scss
+++ b/packages/core/src/theme/components/DocContent/doc.scss
@@ -259,11 +259,11 @@
       color: var(--rp-c-text-code);
     }
     &:where(a > code) {
-      color: var(--rp-c-brand-dark);
+      color: var(--rp-c-link);
       transition: color 0.25s;
     }
     &:where(a:hover > code) {
-      color: var(--rp-c-brand);
+      color: var(--rp-c-link);
     }
     // #endregion
 

--- a/packages/core/src/theme/components/HoverGroup/index.scss
+++ b/packages/core/src/theme/components/HoverGroup/index.scss
@@ -69,7 +69,7 @@
     &__link {
       display: flex;
       align-items: center;
-      gap: 2px;
+      gap: 6px;
       // For click area
       height: 100%;
     }

--- a/packages/core/src/theme/components/HoverGroup/index.scss
+++ b/packages/core/src/theme/components/HoverGroup/index.scss
@@ -69,7 +69,7 @@
     &__link {
       display: flex;
       align-items: center;
-      gap: 6px;
+      gap: 4px;
       // For click area
       height: 100%;
     }

--- a/packages/core/src/theme/components/Nav/NavMenu.scss
+++ b/packages/core/src/theme/components/Nav/NavMenu.scss
@@ -25,7 +25,7 @@
       justify-content: center;
       align-items: center;
       height: 100%;
-      gap: 6px;
+      gap: 4px;
 
       // text
       text-align: center;

--- a/packages/core/src/theme/components/Nav/NavMenu.scss
+++ b/packages/core/src/theme/components/Nav/NavMenu.scss
@@ -25,7 +25,7 @@
       justify-content: center;
       align-items: center;
       height: 100%;
-      gap: 2px;
+      gap: 6px;
 
       // text
       text-align: center;

--- a/packages/core/src/theme/components/NavScreen/NavScreenMenuItem.scss
+++ b/packages/core/src/theme/components/NavScreen/NavScreenMenuItem.scss
@@ -22,6 +22,9 @@
   }
 
   &__left {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
     font-size: 14px;
     font-weight: 500;
     line-height: 22px;

--- a/packages/core/src/theme/components/NavScreen/NavScreenMenuItem.scss
+++ b/packages/core/src/theme/components/NavScreen/NavScreenMenuItem.scss
@@ -24,7 +24,7 @@
   &__left {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
+    gap: 4px;
     font-size: 14px;
     font-weight: 500;
     line-height: 22px;

--- a/website/docs/en/_nav.json
+++ b/website/docs/en/_nav.json
@@ -12,8 +12,7 @@
   {
     "text": "UI",
     "link": "/ui/vars",
-    "activeMatch": "/ui/",
-    "tag": "V2"
+    "activeMatch": "/ui/"
   },
   {
     "text": "API",

--- a/website/docs/en/guide/_meta.json
+++ b/website/docs/en/guide/_meta.json
@@ -12,8 +12,7 @@
   {
     "type": "dir-section-header",
     "label": "Markdown & MDX",
-    "name": "use-mdx",
-    "tag": "updated"
+    "name": "use-mdx"
   },
   {
     "type": "dir-section-header",

--- a/website/docs/en/guide/basic/auto-nav-sidebar.mdx
+++ b/website/docs/en/guide/basic/auto-nav-sidebar.mdx
@@ -1,5 +1,4 @@
 ---
-tag: updated
 description: Automatically generate navbar and sidebar via _nav.json and _meta.json, supporting files, directories, section headers, custom links, and more.
 ---
 

--- a/website/docs/en/plugin/community-plugins/typesense.mdx
+++ b/website/docs/en/plugin/community-plugins/typesense.mdx
@@ -1,7 +1,3 @@
----
-tag: new
----
-
 # rspress-plugin-typesense <SourceCode href="https://github.com/typesense/rspress-plugin-typesense" />
 
 import { SourceCode } from '@rspress/core/theme';

--- a/website/docs/en/plugin/official-plugins/algolia.mdx
+++ b/website/docs/en/plugin/official-plugins/algolia.mdx
@@ -1,7 +1,3 @@
----
-tag: new
----
-
 # @rspress/plugin-algolia <SourceCode href="https://github.com/web-infra-dev/rspress/tree/main/packages/plugin-algolia" />
 
 import { SourceCode } from '@rspress/core/theme';

--- a/website/docs/en/plugin/official-plugins/llms.mdx
+++ b/website/docs/en/plugin/official-plugins/llms.mdx
@@ -1,7 +1,3 @@
----
-tag: new
----
-
 # @rspress/plugin-llms <SourceCode href="https://github.com/web-infra-dev/rspress/tree/main/packages/plugin-llms" />
 
 import { SourceCode } from '@rspress/core/theme';

--- a/website/docs/en/plugin/official-plugins/playground.mdx
+++ b/website/docs/en/plugin/official-plugins/playground.mdx
@@ -1,7 +1,3 @@
----
-tag: updated
----
-
 # @rspress/plugin-playground <SourceCode href="https://github.com/web-infra-dev/rspress/tree/main/packages/plugin-playground" />
 
 import { SourceCode, PackageManagerTabs } from '@rspress/core/theme';

--- a/website/docs/en/plugin/official-plugins/preview.mdx
+++ b/website/docs/en/plugin/official-plugins/preview.mdx
@@ -1,7 +1,3 @@
----
-tag: updated
----
-
 # @rspress/plugin-preview <SourceCode href="https://github.com/web-infra-dev/rspress/tree/main/packages/plugin-preview" />
 
 import { SourceCode, PackageManagerTabs, Tabs, Tab } from '@rspress/core/theme';

--- a/website/docs/en/plugin/official-plugins/sitemap.mdx
+++ b/website/docs/en/plugin/official-plugins/sitemap.mdx
@@ -1,7 +1,3 @@
----
-tag: new
----
-
 # @rspress/plugin-sitemap <SourceCode href="https://github.com/web-infra-dev/rspress/tree/main/packages/plugin-sitemap" />
 
 import { SourceCode } from '@rspress/core/theme';

--- a/website/docs/en/plugin/official-plugins/twoslash.mdx
+++ b/website/docs/en/plugin/official-plugins/twoslash.mdx
@@ -1,7 +1,3 @@
----
-tag: new
----
-
 # @rspress/plugin-twoslash <SourceCode href="https://github.com/web-infra-dev/rspress/tree/main/packages/plugin-twoslash" />
 
 import { SourceCode, PackageManagerTabs, Tabs, Tab } from '@rspress/core/theme';

--- a/website/docs/zh/_nav.json
+++ b/website/docs/zh/_nav.json
@@ -12,8 +12,7 @@
   {
     "text": "UI",
     "link": "/ui/vars",
-    "activeMatch": "/ui/",
-    "tag": "V2"
+    "activeMatch": "/ui/"
   },
   {
     "text": "API",

--- a/website/docs/zh/guide/_meta.json
+++ b/website/docs/zh/guide/_meta.json
@@ -12,8 +12,7 @@
   {
     "type": "dir-section-header",
     "label": "Markdown & MDX",
-    "name": "use-mdx",
-    "tag": "updated"
+    "name": "use-mdx"
   },
   {
     "type": "dir-section-header",

--- a/website/docs/zh/guide/basic/auto-nav-sidebar.mdx
+++ b/website/docs/zh/guide/basic/auto-nav-sidebar.mdx
@@ -1,5 +1,4 @@
 ---
-tag: updated
 description: 通过 _nav.json 和 _meta.json 描述文件自动生成导航栏和侧边栏，支持文件、目录、分组标题、自定义链接等多种配置类型。
 ---
 

--- a/website/docs/zh/plugin/community-plugins/typesense.mdx
+++ b/website/docs/zh/plugin/community-plugins/typesense.mdx
@@ -1,7 +1,3 @@
----
-tag: new
----
-
 # rspress-plugin-typesense <SourceCode href="https://github.com/typesense/rspress-plugin-typesense" />
 
 import { SourceCode } from '@rspress/core/theme';

--- a/website/docs/zh/plugin/official-plugins/algolia.mdx
+++ b/website/docs/zh/plugin/official-plugins/algolia.mdx
@@ -1,7 +1,3 @@
----
-tag: new
----
-
 # @rspress/plugin-algolia <SourceCode href="https://github.com/web-infra-dev/rspress/tree/main/packages/plugin-algolia" />
 
 import { SourceCode } from '@rspress/core/theme';

--- a/website/docs/zh/plugin/official-plugins/llms.mdx
+++ b/website/docs/zh/plugin/official-plugins/llms.mdx
@@ -1,7 +1,3 @@
----
-tag: new
----
-
 # @rspress/plugin-llms <SourceCode href="https://github.com/web-infra-dev/rspress/tree/main/packages/plugin-llms" />
 
 import { SourceCode } from '@rspress/core/theme';

--- a/website/docs/zh/plugin/official-plugins/playground.mdx
+++ b/website/docs/zh/plugin/official-plugins/playground.mdx
@@ -1,7 +1,3 @@
----
-tag: updated
----
-
 # @rspress/plugin-playground <SourceCode href="https://github.com/web-infra-dev/rspress/tree/main/packages/plugin-playground" />
 
 import { SourceCode, PackageManagerTabs } from '@rspress/core/theme';

--- a/website/docs/zh/plugin/official-plugins/preview.mdx
+++ b/website/docs/zh/plugin/official-plugins/preview.mdx
@@ -1,7 +1,3 @@
----
-tag: updated
----
-
 # @rspress/plugin-preview <SourceCode href="https://github.com/web-infra-dev/rspress/tree/main/packages/plugin-preview" />
 
 import { SourceCode, PackageManagerTabs, Tabs, Tab } from '@rspress/core/theme';

--- a/website/docs/zh/plugin/official-plugins/sitemap.mdx
+++ b/website/docs/zh/plugin/official-plugins/sitemap.mdx
@@ -1,7 +1,3 @@
----
-tag: new
----
-
 # @rspress/plugin-sitemap <SourceCode href="https://github.com/web-infra-dev/rspress/tree/main/packages/plugin-sitemap" />
 
 import { SourceCode } from '@rspress/core/theme';

--- a/website/docs/zh/plugin/official-plugins/twoslash.mdx
+++ b/website/docs/zh/plugin/official-plugins/twoslash.mdx
@@ -1,7 +1,3 @@
----
-tag: new
----
-
 # @rspress/plugin-twoslash <SourceCode href="https://github.com/web-infra-dev/rspress/tree/main/packages/plugin-twoslash" />
 
 import { SourceCode, PackageManagerTabs, Tabs, Tab } from '@rspress/core/theme';


### PR DESCRIPTION
## Summary

- Align inline-code links with the document link color token.
- Improve spacing between nav labels and tag badges.
- Remove noisy new/updated badges from Rspress website plugin and guide navigation entries.

## Related Issue

<!--- Provide link of related issues -->

N/A

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

Validation:
- `pnpm exec nx run @rspress/core:build`
- `pnpm build:website`
- `git diff --check`
