### PR TITLE
fix(theme): hide overview outline in mobile menu

### DIFF
--- a/packages/core/src/theme/components/SidebarMenu/index.tsx
+++ b/packages/core/src/theme/components/SidebarMenu/index.tsx
@@ -22,6 +22,7 @@ export const SidebarMenu = forwardRef(
       onIsOutlineOpenChange,
       beforeOutline,
       afterOutline,
+      showOutline: showOutlineProp,
     }: {
       isSidebarOpen: boolean;
       onIsSidebarOpenChange: (isOpen: boolean) => void;
@@ -29,6 +30,7 @@ export const SidebarMenu = forwardRef(
       onIsOutlineOpenChange: (isOpen: boolean) => void;
       beforeOutline?: ReactNode;
       afterOutline?: ReactNode;
+      showOutline?: boolean;
     },
     forwardedRef,
   ) => {
@@ -46,10 +48,11 @@ export const SidebarMenu = forwardRef(
     const {
       frontmatter: {
         sidebar: sidebarConfig = true,
-        outline: showOutline = true,
+        outline: frontmatterShowOutline = true,
       },
     } = useFrontmatter();
     const showSidebar = sidebarConfig === true;
+    const showOutline = showOutlineProp ?? frontmatterShowOutline;
 
     function openSidebar() {
       onIsSidebarOpenChange(true);

--- a/packages/core/src/theme/components/SidebarMenu/useSidebarMenu.tsx
+++ b/packages/core/src/theme/components/SidebarMenu/useSidebarMenu.tsx
@@ -3,7 +3,11 @@ import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { SidebarMenu } from '.';
 import { useClickOutside } from './useClickOutside';
 
-function useSidebarMenu(beforeOutline?: ReactNode, afterOutline?: ReactNode) {
+function useSidebarMenu(
+  beforeOutline?: ReactNode,
+  afterOutline?: ReactNode,
+  showOutline?: boolean,
+) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isOutlineOpen, setIsOutlineOpen] = useState(false);
 
@@ -41,6 +45,7 @@ function useSidebarMenu(beforeOutline?: ReactNode, afterOutline?: ReactNode) {
         ref={sidebarMenuRef}
         beforeOutline={beforeOutline}
         afterOutline={afterOutline}
+        showOutline={showOutline}
       />
     );
   }, [
@@ -50,6 +55,7 @@ function useSidebarMenu(beforeOutline?: ReactNode, afterOutline?: ReactNode) {
     setIsSidebarOpen,
     beforeOutline,
     afterOutline,
+    showOutline,
   ]);
 
   return {

--- a/packages/core/src/theme/layout/DocLayout/index.test.tsx
+++ b/packages/core/src/theme/layout/DocLayout/index.test.tsx
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it, rs } from '@rstest/core';
 import type { ReactNode } from 'react';
+import { renderToString } from 'react-dom/server';
 import { renderToMarkdownString } from 'react-render-to-markdown';
 import { DocLayout } from './index';
 
 let overview = false;
+const sidebarMenuCalls: unknown[][] = [];
 
 rs.mock('@rspress/core/runtime', () => ({
   useFrontmatter: () => ({
@@ -29,13 +31,16 @@ rs.mock('@rspress/core/theme', () => ({
 }));
 
 rs.mock('../../components/SidebarMenu/useSidebarMenu', () => ({
-  useSidebarMenu: () => ({
-    asideLayoutRef: { current: null },
-    isOutlineOpen: false,
-    isSidebarOpen: false,
-    sidebarLayoutRef: { current: null },
-    sidebarMenu: null,
-  }),
+  useSidebarMenu: (...args: unknown[]) => {
+    sidebarMenuCalls.push(args);
+    return {
+      asideLayoutRef: { current: null },
+      isOutlineOpen: false,
+      isSidebarOpen: false,
+      sidebarLayoutRef: { current: null },
+      sidebarMenu: null,
+    };
+  },
 }));
 
 const originalSsgMd = import.meta.env.SSG_MD;
@@ -51,8 +56,12 @@ const setSsgMd = (value: boolean | undefined) => {
 
 afterEach(() => {
   overview = false;
+  sidebarMenuCalls.length = 0;
   setSsgMd(originalSsgMd);
 });
+
+const getLastShowOutlineArg = () =>
+  sidebarMenuCalls[sidebarMenuCalls.length - 1]?.[2];
 
 describe('DocLayout', () => {
   it('renders only doc content when SSG_MD is enabled', async () => {
@@ -72,5 +81,22 @@ describe('DocLayout', () => {
 
       Overview doc content"
     `);
+  });
+
+  it('shows mobile outline menu on normal doc pages', async () => {
+    setSsgMd(undefined);
+
+    renderToString(<DocLayout />);
+
+    expect(getLastShowOutlineArg()).toBe(true);
+  });
+
+  it('hides mobile outline menu on overview pages', async () => {
+    overview = true;
+    setSsgMd(undefined);
+
+    renderToString(<DocLayout />);
+
+    expect(getLastShowOutlineArg()).toBe(false);
   });
 });

--- a/packages/core/src/theme/layout/DocLayout/index.tsx
+++ b/packages/core/src/theme/layout/DocLayout/index.tsx
@@ -55,7 +55,8 @@ export function DocLayout(props: DocLayoutProps) {
     pageType,
   } = frontmatter;
 
-  const showSidebarMenu = showSidebar || (!isOverviewPage && showOutline);
+  const showPageOutline = !isOverviewPage && showOutline;
+  const showSidebarMenu = showSidebar || showPageOutline;
 
   if (import.meta.env.SSG_MD) {
     return (
@@ -79,7 +80,7 @@ export function DocLayout(props: DocLayoutProps) {
     sidebarMenu,
     asideLayoutRef,
     sidebarLayoutRef,
-  } = useSidebarMenu(beforeOutline, afterOutline);
+  } = useSidebarMenu(beforeOutline, afterOutline, showPageOutline);
 
   const { rspressDocRef } = useWatchToc();
 
@@ -152,7 +153,7 @@ export function DocLayout(props: DocLayoutProps) {
         )}
 
         {/* Right outline */}
-        {isOverviewPage ? null : showOutline ? (
+        {showPageOutline ? (
           <aside
             className={clsx(
               'rp-doc-layout__outline',
@@ -165,7 +166,7 @@ export function DocLayout(props: DocLayoutProps) {
             <Outline />
             {afterOutline}
           </aside>
-        ) : (
+        ) : isOverviewPage ? null : (
           <aside
             className="rp-doc-layout__outline-placeholder"
             style={isDocWide ? { width: '0' } : {}}


### PR DESCRIPTION
## Summary

Fixes overview pages showing the mobile outline entry even though the desktop outline is intentionally hidden for overview layouts. The mobile sidebar menu now receives the same page-outline visibility used by `DocLayout`, so overview pages keep sidebar access without exposing an inconsistent “On this page” control.

## Related Issue

https://github.com/web-infra-dev/rspress/issues/2809

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
