### PR TITLE
fix(plugin-playground): include source path in mdx parse errors

### DIFF
--- a/packages/plugin-playground/src/cli/index.ts
+++ b/packages/plugin-playground/src/cli/index.ts
@@ -157,8 +157,12 @@ export function pluginPlayground(
               }
             });
           } catch (e) {
-            console.error(e);
-            throw e;
+            const message = `[Playground]: Failed to parse ${filepath}.`;
+            if (e instanceof Error) {
+              e.message = `${message}\n${e.message}`;
+              throw e;
+            }
+            throw new Error(`${message}\n${String(e)}`);
           }
         }),
       );

--- a/packages/plugin-playground/tests/error.test.ts
+++ b/packages/plugin-playground/tests/error.test.ts
@@ -1,0 +1,38 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, test } from '@rstest/core';
+import { pluginPlayground } from '../src/cli';
+
+describe('plugin-playground errors', () => {
+  test('should include source file path when mdx parsing fails', async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), 'rspress-playground-'));
+    const filepath = path.join(tempDir, 'index.mdx');
+
+    await writeFile(filepath, '## Test {#base}', 'utf-8');
+
+    try {
+      const plugin = pluginPlayground();
+      if (!plugin.routeGenerated) {
+        throw new Error('Expected playground plugin to expose routeGenerated');
+      }
+
+      await expect(
+        plugin.routeGenerated([
+          {
+            absolutePath: filepath,
+            routePath: '/',
+            relativePath: 'index.mdx',
+            pageName: 'index',
+            lang: '',
+            version: '',
+          },
+        ]),
+      ).rejects.toThrow(
+        `[Playground]: Failed to parse ${filepath}.\nCould not parse expression with acorn`,
+      );
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

This PR improves `@rspress/plugin-playground` diagnostics when its MDX pre-scan fails. Instead of rethrowing the parser error without context, the plugin now includes the source file path while preserving the original parser message.

## Related Issue

Fixes #2238

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).