### PR TITLE
fix(mdx/container): Fix rendering of multi-line GitHub-style alerts

### DIFF
--- a/e2e/fixtures/github-alert-mdxjs/doc/index.mdx
+++ b/e2e/fixtures/github-alert-mdxjs/doc/index.mdx
@@ -23,6 +23,11 @@ import { Steps } from '@theme';
 > [!DETAILS]
 > This is a 'details' style block.
 
+> [!NOTE]
+> Multi-line line 1
+> Multi-line line 2
+> Multi-line line 3
+
 > # This is a heading inside a blockquote
 
 > **Bold text**

--- a/e2e/fixtures/github-alert-mdxjs/index.test.ts
+++ b/e2e/fixtures/github-alert-mdxjs/index.test.ts
@@ -24,7 +24,7 @@ test.describe('github alert syntax in mdx-js', async () => {
     });
 
     const topLevelCallouts = page.locator('.rspress-doc > .rp-callout');
-    await expect(topLevelCallouts).toHaveCount(7);
+    await expect(topLevelCallouts).toHaveCount(8);
 
     const listCallouts = page.locator(
       '.rspress-doc > ol li > .rp-callout, .rspress-doc > ul li > .rp-callout',
@@ -33,6 +33,12 @@ test.describe('github alert syntax in mdx-js', async () => {
 
     const stepsCallouts = page.locator('.rp-steps .rp-callout');
     await expect(stepsCallouts).toHaveCount(2);
+
+    const multiLineCallout = topLevelCallouts.nth(7);
+    const multiLineText = await multiLineCallout.innerText();
+    expect(multiLineText).toContain('Multi-line line 1');
+    expect(multiLineText).toContain('Multi-line line 2');
+    expect(multiLineText).toContain('Multi-line line 3');
 
     const allCallouts = [topLevelCallouts, listCallouts, stepsCallouts];
     const containerTypes: string[] = [];
@@ -56,6 +62,7 @@ test.describe('github alert syntax in mdx-js', async () => {
       'danger',
       'info',
       'details',
+      'note',
       'info',
       'warning',
       'info',

--- a/packages/core/src/node/mdx/remarkPlugins/__snapshots__/containerSyntax.test.ts.snap
+++ b/packages/core/src/node/mdx/remarkPlugins/__snapshots__/containerSyntax.test.ts.snap
@@ -874,6 +874,122 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 "
 `;
 
+exports[`remark-container > github alerts ~ marker followed by content on same paragraph then more blocks 1`] = `
+"import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
+import {useMDXComponents as _provideComponents} from "@mdx-js/react";
+import {Callout as $$$callout$$$} from "@theme";
+function _createMdxContent(props) {
+  const _components = {
+    p: "p",
+    ..._provideComponents(),
+    ...props.components
+  };
+  return _jsxs($$$callout$$$, {
+    type: "tip",
+    title: "TIP",
+    children: [_jsx(_components.p, {
+      children: "First paragraph line 1\\nFirst paragraph line 2"
+    }), _jsx(_components.p, {
+      children: "Second paragraph"
+    })]
+  });
+}
+export default function MDXContent(props = {}) {
+  const {wrapper: MDXLayout} = {
+    ..._provideComponents(),
+    ...props.components
+  };
+  return MDXLayout ? _jsx(MDXLayout, {
+    ...props,
+    children: _jsx(_createMdxContent, {
+      ...props
+    })
+  }) : _createMdxContent(props);
+}
+
+
+MDXContent.__RSPRESS_PAGE_META = {};
+MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle":"","frontmatter":{}};
+"
+`;
+
+exports[`remark-container > github alerts ~ multi-line content with inline emphasis 1`] = `
+"import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
+import {useMDXComponents as _provideComponents} from "@mdx-js/react";
+import {Callout as $$$callout$$$} from "@theme";
+function _createMdxContent(props) {
+  const _components = {
+    em: "em",
+    p: "p",
+    ..._provideComponents(),
+    ...props.components
+  };
+  return _jsx($$$callout$$$, {
+    type: "note",
+    title: "NOTE",
+    children: _jsxs(_components.p, {
+      children: ["Line 1\\n", _jsx(_components.em, {
+        children: "Line"
+      }), " 2\\nLine 3"]
+    })
+  });
+}
+export default function MDXContent(props = {}) {
+  const {wrapper: MDXLayout} = {
+    ..._provideComponents(),
+    ...props.components
+  };
+  return MDXLayout ? _jsx(MDXLayout, {
+    ...props,
+    children: _jsx(_createMdxContent, {
+      ...props
+    })
+  }) : _createMdxContent(props);
+}
+
+
+MDXContent.__RSPRESS_PAGE_META = {};
+MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle":"","frontmatter":{}};
+"
+`;
+
+exports[`remark-container > github alerts ~ multi-line plain content 1`] = `
+"import {jsx as _jsx} from "react/jsx-runtime";
+import {useMDXComponents as _provideComponents} from "@mdx-js/react";
+import {Callout as $$$callout$$$} from "@theme";
+function _createMdxContent(props) {
+  const _components = {
+    p: "p",
+    ..._provideComponents(),
+    ...props.components
+  };
+  return _jsx($$$callout$$$, {
+    type: "note",
+    title: "NOTE",
+    children: _jsx(_components.p, {
+      children: "Line 1\\nLine 2\\nLine 3"
+    })
+  });
+}
+export default function MDXContent(props = {}) {
+  const {wrapper: MDXLayout} = {
+    ..._provideComponents(),
+    ...props.components
+  };
+  return MDXLayout ? _jsx(MDXLayout, {
+    ...props,
+    children: _jsx(_createMdxContent, {
+      ...props
+    })
+  }) : _createMdxContent(props);
+}
+
+
+MDXContent.__RSPRESS_PAGE_META = {};
+MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle":"","frontmatter":{}};
+"
+`;
+
 exports[`remark-container > github alerts ~ note 1`] = `
 "import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";

--- a/packages/core/src/node/mdx/remarkPlugins/containerSyntax.test.ts
+++ b/packages/core/src/node/mdx/remarkPlugins/containerSyntax.test.ts
@@ -202,6 +202,37 @@ This is a details block.
     expect(result).toMatchSnapshot();
   });
 
+  test('github alerts ~ multi-line plain content', async () => {
+    const result = await process(`> [!NOTE]
+> Line 1
+> Line 2
+> Line 3
+`);
+
+    expect(result).toMatchSnapshot();
+  });
+
+  test('github alerts ~ multi-line content with inline emphasis', async () => {
+    const result = await process(`> [!NOTE]
+> Line 1
+> *Line* 2
+> Line 3
+`);
+
+    expect(result).toMatchSnapshot();
+  });
+
+  test('github alerts ~ marker followed by content on same paragraph then more blocks', async () => {
+    const result = await process(`> [!TIP]
+> First paragraph line 1
+> First paragraph line 2
+>
+> Second paragraph
+`);
+
+    expect(result).toMatchSnapshot();
+  });
+
   test('nested in ordered list', async () => {
     const result = await process(`
 1. Title1

--- a/packages/core/src/node/mdx/remarkPlugins/containerSyntax.ts
+++ b/packages/core/src/node/mdx/remarkPlugins/containerSyntax.ts
@@ -37,7 +37,8 @@ export const DIRECTIVE_TYPES = [
 ] as const;
 export const REGEX_BEGIN = /^\s*:::\s*(\w+)\s*(.*)?/;
 export const REGEX_END = /\s*:::$/;
-export const REGEX_GH_BEGIN = /^\s*\s*\[!(\w+)\]\s*(.*)?/;
+export const REGEX_GH_BEGIN = /^\s*\[!(\w+)\]/;
+export const REGEX_GH_MARKER = /^\s*\[!\w+\][^\S\n]*\n?/;
 export const TITLE_REGEX_IN_MD = /{\s*title=["']?(.+)}\s*/;
 export const TITLE_REGEX_IN_MDX = /\s*title=["']?(.+)\s*/;
 
@@ -157,7 +158,9 @@ function transformer(
       node.children[0].children?.[0] &&
       'value' in node.children[0].children[0]
     ) {
-      const initiatorTag = node.children[0].children[0].value;
+      const firstParagraph = node.children[0];
+      const firstTextNode = firstParagraph.children[0] as Literal;
+      const initiatorTag = firstTextNode.value;
       const match = initiatorTag.match(REGEX_GH_BEGIN);
 
       if (match) {
@@ -167,18 +170,22 @@ function transformer(
           i++;
           continue;
         }
-        if (
-          node.children.length === 1 &&
-          node.children[0].type === 'paragraph'
-        ) {
-          node.children[0].children[0].value = match[2] ?? '';
-        }
+        // Strip only the `[!TYPE]` marker (and the single line break separating it
+        // from the body) from the first text node, preserving the remaining body
+        // content (soft line breaks and sibling phrasing nodes such as emphasis).
+        firstTextNode.value = initiatorTag.replace(REGEX_GH_MARKER, '');
+        // If removing the marker leaves an empty leading paragraph (the body lives
+        // in subsequent block nodes), drop it; otherwise keep all children.
+        const isFirstParagraphEmpty = firstParagraph.children.every(
+          child => child.type === 'text' && child.value.trim() === '',
+        );
+        const children = (
+          isFirstParagraphEmpty ? node.children.slice(1) : node.children
+        ) as BlockContent[];
         const newChild = createContainer(
           type.toLowerCase(),
           type.toUpperCase(),
-          (node.children.slice(1).length === 0
-            ? node.children.slice(0)
-            : node.children.slice(1)) as BlockContent[],
+          children,
         );
         tree.children.splice(i, 1, newChild as RootContent);
       }


### PR DESCRIPTION
## Summary

We've noticed that when using GitHub-style alerts, multi-line comments get swallowed. For example the following markdown:

```markdown
> [!NOTE]
> Line 1
> Line 2
> Line 3

> [!NOTE]
> Line 1
> *Line* 2
> Line 3
```

renders nicely on GitHub:

> [!NOTE]
> Line 1
> Line 2
> Line 3

> [!NOTE]
> Line 1
> *Line* 2
> Line 3

but in `rspress` it results in:
<img width="849" height="245" alt="image" src="https://github.com/user-attachments/assets/ad23c713-dcb6-45fb-8832-426dd41388d3" />

This PR fixes this by splitting the parsing of GitHub syntax into 2 steps.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
