### PR TITLE
docs: rename multi-version headings

### DIFF
--- a/website/docs/en/guide/basic/multi-version.mdx
+++ b/website/docs/en/guide/basic/multi-version.mdx
@@ -2,7 +2,7 @@
 description: Manage multi-version docs with simple configuration, intuitive directory structure, a version selector in the navbar, and version-specific search.
 ---
 
-# Multi-version docs
+# Multi-version
 
 Rspress's default theme supports multi-version docs. This guide shows how to enable and organize them.
 

--- a/website/docs/en/guide/start/introduction.mdx
+++ b/website/docs/en/guide/start/introduction.mdx
@@ -174,7 +174,7 @@ Rspress includes built-in translations for Chinese, English, Japanese, Korean, a
 
 You can follow the [I18n Tutorial](/guide/basic/i18n) to implement internationalization for your site step by step.
 
-### Multi-version docs
+### Multi-version
 
 Some sites need to maintain docs for multiple product versions. Rspress has built-in multi-version support: enable it with a small config block, then organize versioned directories naturally without extra concepts.
 


### PR DESCRIPTION
## Summary

Rename the English multi-version documentation headings from `Multi-version docs` to `Multi-version`.

## Related Issue

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).