### PR TITLE
refactor(theme): internal code change, replace @theme alias with @rspress/core/theme

### DIFF
--- a/e2e/fixtures/code-block-runtime/docs/highlight.mdx
+++ b/e2e/fixtures/code-block-runtime/docs/highlight.mdx
@@ -1,4 +1,4 @@
-import { CodeBlockRuntime } from '@theme';
+import { CodeBlockRuntime } from '@rspress/core/theme';
 import { transformerNotationHighlight } from '@shikijs/transformers';
 
 <CodeBlockRuntime

--- a/e2e/fixtures/code-block-runtime/docs/index.mdx
+++ b/e2e/fixtures/code-block-runtime/docs/index.mdx
@@ -1,4 +1,4 @@
-import { CodeBlockRuntime } from '@theme';
+import { CodeBlockRuntime } from '@rspress/core/theme';
 
 <CodeBlockRuntime
   lang="js"

--- a/e2e/fixtures/github-alert-mdxjs/doc/index.mdx
+++ b/e2e/fixtures/github-alert-mdxjs/doc/index.mdx
@@ -1,4 +1,4 @@
-import { Steps } from '@theme';
+import { Steps } from '@rspress/core/theme';
 
 # Hello world
 

--- a/e2e/fixtures/package-manager-tabs/doc/index.mdx
+++ b/e2e/fixtures/package-manager-tabs/doc/index.mdx
@@ -1,4 +1,4 @@
-import { PackageManagerTabs } from '@theme';
+import { PackageManagerTabs } from '@rspress/core/theme';
 
 # Hello world
 

--- a/e2e/fixtures/ssg-md/doc/components.mdx
+++ b/e2e/fixtures/ssg-md/doc/components.mdx
@@ -14,7 +14,7 @@ MDX is a superset of Markdown, which means you can write Markdown files as usual
 
 In MDX, every `.mdx` file is compiled into a React component, which means it can be imported like any component and can freely render React components. For example:
 
-import { Tabs, Tab } from '@theme';
+import { Tabs, Tab } from '@rspress/core/theme';
 import { Border } from './_Border';
 
 <Tabs>

--- a/e2e/fixtures/ssg-md/doc/index.mdx
+++ b/e2e/fixtures/ssg-md/doc/index.mdx
@@ -1,4 +1,4 @@
-import { Tabs, Tab } from '@theme';
+import { Tabs, Tab } from '@rspress/core/theme';
 
 # Code blocks
 

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -26,7 +26,7 @@ const COMMON_EXTERNALS = [
   'virtual-global-components',
   'virtual-search-hooks',
   'virtual-i18n-text',
-  '@theme',
+  '@rspress/core/theme',
   // To be externalized when bundling d.ts.
   '@types/react',
   '@rspress/core/runtime',

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -26,7 +26,6 @@ const COMMON_EXTERNALS = [
   'virtual-global-components',
   'virtual-search-hooks',
   'virtual-i18n-text',
-  '@rspress/core/theme',
   // To be externalized when bundling d.ts.
   '@types/react',
   '@rspress/core/runtime',

--- a/packages/core/src/node/mdx/rehypePlugins/__snapshots__/headerAnchor.test.ts.snap
+++ b/packages/core/src/node/mdx/rehypePlugins/__snapshots__/headerAnchor.test.ts.snap
@@ -5,7 +5,7 @@ exports[`rehypeHeadAnchor > basic 1`] = `
 /*prettier-ignore-end*/
 import {Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     a: "a",
@@ -121,7 +121,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[{"id":"custom-id","text":"
 exports[`rehypeHeadAnchor > should include nested link text in title id 1`] = `
 "import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     a: "a",
@@ -169,7 +169,7 @@ MDXContent.__RSPRESS_PAGE_META["nested-link.mdx"] = {"toc":[{"id":"this-is-bold-
 exports[`rehypeHeadAnchor > should preserve nested custom id-like text 1`] = `
 "import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     a: "a",
@@ -212,7 +212,7 @@ MDXContent.__RSPRESS_PAGE_META["nested-id-text.mdx"] = {"toc":[{"id":"literal-in
 exports[`rehypeHeadAnchor > should render inline code in title 1`] = `
 "import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     a: "a",
@@ -255,7 +255,7 @@ MDXContent.__RSPRESS_PAGE_META["inline-code.mdx"] = {"toc":[],"title":"Hello Wor
 exports[`rehypeHeadAnchor > should support custom id 1`] = `
 "import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     a: "a",
@@ -298,7 +298,7 @@ MDXContent.__RSPRESS_PAGE_META["inline-code.mdx"] = {"toc":[],"title":"Hello Wor
 exports[`rehypeHeadAnchor > should support mdx component with trim 1`] = `
 "import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     a: "a",

--- a/packages/core/src/node/mdx/remarkPlugins/__snapshots__/containerSyntax.test.ts.snap
+++ b/packages/core/src/node/mdx/remarkPlugins/__snapshots__/containerSyntax.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`remark-container > Has space before ::: 1`] = `
 "import {jsx as _jsx} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     p: "p",
@@ -40,7 +40,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > Has space before type 1`] = `
 "import {jsx as _jsx} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     p: "p",
@@ -77,7 +77,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > No newline 1`] = `
 "import {Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     p: "p",
@@ -118,7 +118,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > Use \\{title="foo"} as title 1`] = `
 "import {jsx as _jsx} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     p: "p",
@@ -155,7 +155,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > Use \\{title='foo'} as title 1`] = `
 "import {jsx as _jsx} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     p: "p",
@@ -192,7 +192,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > Use \\{title=foo} as title 1`] = `
 "import {jsx as _jsx} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     p: "p",
@@ -229,7 +229,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > With a new line after the start position of container 1`] = `
 "import {jsx as _jsx} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     p: "p",
@@ -266,7 +266,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > With block quote in container 1`] = `
 "import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     a: "a",
@@ -315,7 +315,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > With code block in container 1`] = `
 "import {Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     a: "a",
@@ -403,7 +403,7 @@ exports[`remark-container > With link, inlineCode, img, list in container 1`] = 
 "import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
 import image0 from "foo";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     a: "a",
@@ -462,7 +462,7 @@ exports[`remark-container > With link, inlineCode, img, spread list in container
 "import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
 import image0 from "foo";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     a: "a",
@@ -520,7 +520,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > With new line before the end position of container 1`] = `
 "import {jsx as _jsx} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     p: "p",
@@ -557,7 +557,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > With new line in all case 1`] = `
 "import {jsx as _jsx} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     p: "p",
@@ -594,7 +594,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > details 1`] = `
 "import {jsx as _jsx} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     p: "p",
@@ -631,7 +631,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > empty blockquote 1`] = `
 "import {jsx as _jsx} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     blockquote: "blockquote",
@@ -664,7 +664,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > end with a link 1`] = `
 "import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     a: "a",
@@ -709,7 +709,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > end with a new line 1`] = `
 "import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     a: "a",
@@ -754,7 +754,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > end with an inline code 1`] = `
 "import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     code: "code",
@@ -796,7 +796,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > github alerts ~ caution 1`] = `
 "import {Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     code: "code",
@@ -877,7 +877,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > github alerts ~ marker followed by content on same paragraph then more blocks 1`] = `
 "import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     p: "p",
@@ -916,7 +916,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > github alerts ~ multi-line content with inline emphasis 1`] = `
 "import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     em: "em",
@@ -956,7 +956,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > github alerts ~ multi-line plain content 1`] = `
 "import {jsx as _jsx} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     p: "p",
@@ -993,7 +993,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > github alerts ~ note 1`] = `
 "import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     a: "a",
@@ -1037,7 +1037,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > github alerts ~ tip 1`] = `
 "import {jsx as _jsx} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     p: "p",
@@ -1077,7 +1077,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > github alerts ~ warning 1`] = `
 "import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     code: "code",
@@ -1119,7 +1119,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > nested in list - github alerts 1`] = `
 "import {Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     li: "li",
@@ -1177,7 +1177,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > nested in ordered list 1`] = `
 "import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     li: "li",
@@ -1226,7 +1226,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > nested in ordered list inside mdx component 1`] = `
 "import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     li: "li",
@@ -1281,7 +1281,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > nested in unordered list 1`] = `
 "import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     li: "li",
@@ -1330,7 +1330,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > nested in unordered list inside mdx component 1`] = `
 "import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     li: "li",
@@ -1385,7 +1385,7 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 exports[`remark-container > start with a link 1`] = `
 "import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     a: "a",

--- a/packages/core/src/node/mdx/remarkPlugins/__snapshots__/fileCodeBlock.test.ts.snap
+++ b/packages/core/src/node/mdx/remarkPlugins/__snapshots__/fileCodeBlock.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`remarkFileCodeBlock > basic 1`] = `
 "import {Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     code: "code",

--- a/packages/core/src/node/mdx/remarkPlugins/__snapshots__/image.test.ts.snap
+++ b/packages/core/src/node/mdx/remarkPlugins/__snapshots__/image.test.ts.snap
@@ -5,7 +5,7 @@ exports[`mdx > basic 1`] = `
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
 import image0 from "./test3.jpg";
 import image1 from "./test4.png";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     img: "img",

--- a/packages/core/src/node/mdx/remarkPlugins/__snapshots__/link.test.ts.snap
+++ b/packages/core/src/node/mdx/remarkPlugins/__snapshots__/link.test.ts.snap
@@ -4,7 +4,7 @@ exports[`mdx > basic 1`] = `
 "/*jsx link will not be transformed*/
 import {Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 function _createMdxContent(props) {
   const _components = {
     a: "a",

--- a/packages/core/src/node/mdx/remarkPlugins/__snapshots__/toc.test.ts.snap
+++ b/packages/core/src/node/mdx/remarkPlugins/__snapshots__/toc.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`toc > basic link in heading 1`] = `
 "import {Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
-import {Callout as $$$callout$$$} from "@theme";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
 import {Link} from '@rspress/core/theme';
 function _createMdxContent(props) {
   const _components = {

--- a/packages/core/src/node/mdx/remarkPlugins/__snapshots__/toc.test.ts.snap
+++ b/packages/core/src/node/mdx/remarkPlugins/__snapshots__/toc.test.ts.snap
@@ -4,7 +4,7 @@ exports[`toc > basic link in heading 1`] = `
 "import {Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
 import {Callout as $$$callout$$$} from "@theme";
-import {Link} from '@theme';
+import {Link} from '@rspress/core/theme';
 function _createMdxContent(props) {
   const _components = {
     a: "a",

--- a/packages/core/src/node/mdx/remarkPlugins/containerSyntax.ts
+++ b/packages/core/src/node/mdx/remarkPlugins/containerSyntax.ts
@@ -393,11 +393,7 @@ export const remarkContainerSyntax: Plugin<[], Root> = () => {
   return tree => {
     transformer(tree, warnUnknownType);
     tree.children.unshift(
-      getNamedImportAstNode(
-        'Callout',
-        CALLOUT_COMPONENT,
-        '@rspress/core/theme',
-      ),
+      getNamedImportAstNode('Callout', CALLOUT_COMPONENT, '@theme'),
     );
   };
 };

--- a/packages/core/src/node/mdx/remarkPlugins/containerSyntax.ts
+++ b/packages/core/src/node/mdx/remarkPlugins/containerSyntax.ts
@@ -393,7 +393,11 @@ export const remarkContainerSyntax: Plugin<[], Root> = () => {
   return tree => {
     transformer(tree, warnUnknownType);
     tree.children.unshift(
-      getNamedImportAstNode('Callout', CALLOUT_COMPONENT, '@theme'),
+      getNamedImportAstNode(
+        'Callout',
+        CALLOUT_COMPONENT,
+        '@rspress/core/theme',
+      ),
     );
   };
 };

--- a/packages/core/src/node/mdx/remarkPlugins/toc.test.ts
+++ b/packages/core/src/node/mdx/remarkPlugins/toc.test.ts
@@ -22,7 +22,7 @@ describe('toc', async () => {
 
   test('basic link in heading', async () => {
     const result = await process(`
-import { Link } from '@theme';
+import { Link } from '@rspress/core/theme';
 
 # link
 

--- a/packages/core/src/node/ssg-md/remarkSplitMdx.test.ts
+++ b/packages/core/src/node/ssg-md/remarkSplitMdx.test.ts
@@ -610,7 +610,7 @@ This is a <Button>click me</Button> and <Link href="/test">link</Link> example.`
     `);
 
     const input2 = `
-import { Tabs, Tab } from '@theme';
+import { Tabs, Tab } from '@rspress/core/theme';
 
 <Tabs>
 <Tab>
@@ -630,7 +630,7 @@ import Button from './_button.mdx';
     expect(result2).toMatchInlineSnapshot(`
       "/*@jsxRuntime automatic*/
       /*@jsxImportSource react*/
-      import {Tabs, Tab} from '@theme';
+      import {Tabs, Tab} from '@rspress/core/theme';
       import Button from './_button.mdx';
       function _createMdxContent(props) {
         return <Tabs><Tab><Button /></Tab><Tab /></Tabs>;

--- a/packages/core/src/runtime/App.test.tsx
+++ b/packages/core/src/runtime/App.test.tsx
@@ -24,7 +24,7 @@ rs.mock('@rspress/core/runtime', () => ({
   }),
 }));
 
-rs.mock('@theme', () => ({
+rs.mock('@rspress/core/theme', () => ({
   Layout: () => 'Layout content',
   Root: ({ children }: { children: ReactNode }) => children,
 }));

--- a/packages/core/src/runtime/App.tsx
+++ b/packages/core/src/runtime/App.tsx
@@ -1,5 +1,5 @@
 import { PageContext, useLocation } from '@rspress/core/runtime';
-import { Layout, Root } from '@theme';
+import { Layout, Root } from '@rspress/core/theme';
 import React, { useContext, useLayoutEffect } from 'react';
 import globalComponents from 'virtual-global-components';
 import {

--- a/packages/core/src/runtime/ClientApp.tsx
+++ b/packages/core/src/runtime/ClientApp.tsx
@@ -5,7 +5,7 @@ import {
   ThemeContext,
   withBase,
 } from '@rspress/core/runtime';
-import { useThemeState } from '@theme';
+import { useThemeState } from '@rspress/core/theme';
 import { createHead, UnheadProvider } from '@unhead/react/client';
 import { useMemo, useState } from 'react';
 import { App } from './App';

--- a/packages/core/tests/cli/eject.test.ts
+++ b/packages/core/tests/cli/eject.test.ts
@@ -64,7 +64,7 @@ describe('eject command', () => {
 
       // Setup mock file structure
       vol.fromJSON({
-        [`${themePath}/index.tsx`]: `import { Link } from '@theme';\nexport const TestComponent = () => <Link>Test</Link>;`,
+        [`${themePath}/index.tsx`]: `import { Link } from '@rspress/core/theme';\nexport const TestComponent = () => <Link>Test</Link>;`,
         [`${themePath}/styles.scss`]: '.test { color: red; }',
       });
 

--- a/packages/plugin-algolia/rslib.config.ts
+++ b/packages/plugin-algolia/rslib.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
       plugins: [pluginReact()],
       output: {
         externals: [
-          '@theme',
+          '@rspress/core/theme',
           'react',
           'react/jsx-runtime',
           'react/jsx-dev-runtime',

--- a/packages/plugin-algolia/src/runtime/Search.tsx
+++ b/packages/plugin-algolia/src/runtime/Search.tsx
@@ -1,7 +1,6 @@
 import type { DocSearchProps } from '@docsearch/react';
 import { DocSearch } from '@docsearch/react';
 import { removeBase, useLang, useNavigate } from '@rspress/core/runtime';
-// @ts-expect-error @theme is not typed
 import { Link } from '@rspress/core/theme';
 import '@docsearch/css';
 import './Search.css';

--- a/packages/plugin-algolia/src/runtime/Search.tsx
+++ b/packages/plugin-algolia/src/runtime/Search.tsx
@@ -2,7 +2,7 @@ import type { DocSearchProps } from '@docsearch/react';
 import { DocSearch } from '@docsearch/react';
 import { removeBase, useLang, useNavigate } from '@rspress/core/runtime';
 // @ts-expect-error @theme is not typed
-import { Link } from '@theme';
+import { Link } from '@rspress/core/theme';
 import '@docsearch/css';
 import './Search.css';
 import { useEffect } from 'react';

--- a/packages/plugin-api-docgen/static/global-components/API.tsx
+++ b/packages/plugin-api-docgen/static/global-components/API.tsx
@@ -1,5 +1,4 @@
 import { useLang } from '@rspress/core/runtime';
-// @ts-expect-error @theme is overridden by alias in @rspress/core
 import { getCustomMDXComponent } from '@rspress/core/theme';
 import GithubSlugger from 'github-slugger';
 import type { Content, Element, Root } from 'hast';

--- a/packages/plugin-api-docgen/static/global-components/API.tsx
+++ b/packages/plugin-api-docgen/static/global-components/API.tsx
@@ -1,6 +1,6 @@
 import { useLang } from '@rspress/core/runtime';
 // @ts-expect-error @theme is overridden by alias in @rspress/core
-import { getCustomMDXComponent } from '@theme';
+import { getCustomMDXComponent } from '@rspress/core/theme';
 import GithubSlugger from 'github-slugger';
 import type { Content, Element, Root } from 'hast';
 import ReactMarkdown from 'react-markdown';

--- a/packages/plugin-llms/rslib.config.ts
+++ b/packages/plugin-llms/rslib.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
       plugins: [pluginReact()],
       output: {
         externals: [
-          '@theme',
+          '@rspress/core/theme',
           '@rspress/core/theme',
           'react',
           '@types/react',

--- a/packages/plugin-llms/rslib.config.ts
+++ b/packages/plugin-llms/rslib.config.ts
@@ -20,7 +20,6 @@ export default defineConfig({
       output: {
         externals: [
           '@rspress/core/theme',
-          '@rspress/core/theme',
           'react',
           '@types/react',
           'react/jsx-runtime',

--- a/website/docs/en/guide/migration/rspress-1-x.mdx
+++ b/website/docs/en/guide/migration/rspress-1-x.mdx
@@ -2,7 +2,7 @@
 description: Complete migration guide from Rspress 1.x to V2, covering package name changes, import paths, custom themes, Shiki code highlighting, and more.
 ---
 
-import { PackageManagerTabs } from '@theme';
+import { PackageManagerTabs } from '@rspress/core/theme';
 
 # Migrating from Rspress 1.x
 

--- a/website/docs/en/guide/start/ai.mdx
+++ b/website/docs/en/guide/start/ai.mdx
@@ -1,4 +1,4 @@
-import { PackageManagerTabs } from '@theme';
+import { PackageManagerTabs } from '@rspress/core/theme';
 
 # AI
 

--- a/website/docs/zh/guide/migration/rspress-1-x.mdx
+++ b/website/docs/zh/guide/migration/rspress-1-x.mdx
@@ -2,7 +2,7 @@
 description: 从 Rspress 1.x 升级到 V2 的完整迁移指南，包括包名变更、导入路径、自定义主题、Shiki 代码高亮等重要变更。
 ---
 
-import { PackageManagerTabs } from '@theme';
+import { PackageManagerTabs } from '@rspress/core/theme';
 
 # 从 Rspress 1.x 迁移
 
@@ -172,6 +172,20 @@ import { PackageManagerTabs } from '@theme';
   }
 }
 ```
+
+:::tip
+
+如果你遇到 `@theme` 或 `@rspress/core/theme` 缺少导出的错误，很可能是因为在 theme 文件夹中覆盖主题时没有使用 `@rspress/core/theme-original`，导致了循环引用：
+
+```txt
+× ESModulesLinkingError: export 'SvgWrapper' (imported as 'SvgWrapper') was not found in '@theme' (possible exports: HomeLayout, Layout, Search, Tag, getCustomMDXComponent)
+
+× ESModulesLinkingError: export 'Banner' (imported as 'Banner') was not found in '@rspress/core/theme' (possible exports: HomeLayout, Layout, Search, Tag, getCustomMDXComponent)
+```
+
+请确保在 `theme` 文件夹中使用 `@rspress/core/theme-original`，并正确导出所有组件。
+
+:::
 
 ## [重要] Shiki 代码高亮替代 prism
 

--- a/website/docs/zh/guide/start/ai.mdx
+++ b/website/docs/zh/guide/start/ai.mdx
@@ -1,4 +1,4 @@
-import { PackageManagerTabs } from '@theme';
+import { PackageManagerTabs } from '@rspress/core/theme';
 
 # AI
 


### PR DESCRIPTION
## Summary

Standardizes first-party code and docs on the public `@rspress/core/theme` import path instead of the legacy `@theme` alias. `@theme` is an internal build alias, so any example that used it did not match how theme code is actually imported outside the monorepo. This replaces it everywhere that ships or is copied by users:

- Runtime and plugins: `App`, `ClientApp`, `plugin-algolia` Search, `plugin-api-docgen` API.
- Build config: `externals` in the `core`, `plugin-algolia`, and `plugin-llms` rslib configs.
- Unit tests, snapshots, and e2e fixtures.
- Website migration and getting-started docs.

Also adds a migration-guide tip describing the circular-reference error users hit when overriding theme components without importing the originals from `@rspress/core/theme-original`.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
