### PR TITLE
feat(mdx/container): Support [!IMPORTANT] callout for feature parity with GitHub-flavored markdown

### DIFF
--- a/e2e/fixtures/github-alert-mdxjs/doc/index.mdx
+++ b/e2e/fixtures/github-alert-mdxjs/doc/index.mdx
@@ -14,6 +14,9 @@ import { Steps } from '@rspress/core/theme';
 > [!CAUTION]
 > This is a 'caution' style block.
 
+> [!IMPORTANT]
+> This is an 'important' style block.
+
 > [!DANGER]
 > This is a 'danger' style block.
 

--- a/e2e/fixtures/github-alert-mdxjs/index.test.ts
+++ b/e2e/fixtures/github-alert-mdxjs/index.test.ts
@@ -24,7 +24,7 @@ test.describe('github alert syntax in mdx-js', async () => {
     });
 
     const topLevelCallouts = page.locator('.rspress-doc > .rp-callout');
-    await expect(topLevelCallouts).toHaveCount(8);
+    await expect(topLevelCallouts).toHaveCount(9);
 
     const listCallouts = page.locator(
       '.rspress-doc > ol li > .rp-callout, .rspress-doc > ul li > .rp-callout',
@@ -34,7 +34,7 @@ test.describe('github alert syntax in mdx-js', async () => {
     const stepsCallouts = page.locator('.rp-steps .rp-callout');
     await expect(stepsCallouts).toHaveCount(2);
 
-    const multiLineCallout = topLevelCallouts.nth(7);
+    const multiLineCallout = topLevelCallouts.nth(8);
     const multiLineText = await multiLineCallout.innerText();
     expect(multiLineText).toContain('Multi-line line 1');
     expect(multiLineText).toContain('Multi-line line 2');
@@ -59,6 +59,7 @@ test.describe('github alert syntax in mdx-js', async () => {
       'note',
       'warning',
       'caution',
+      'important',
       'danger',
       'info',
       'details',

--- a/packages/core/src/node/mdx/remarkPlugins/__snapshots__/containerSyntax.test.ts.snap
+++ b/packages/core/src/node/mdx/remarkPlugins/__snapshots__/containerSyntax.test.ts.snap
@@ -874,6 +874,43 @@ MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle
 "
 `;
 
+exports[`remark-container > github alerts ~ important 1`] = `
+"import {jsx as _jsx} from "react/jsx-runtime";
+import {useMDXComponents as _provideComponents} from "@mdx-js/react";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
+function _createMdxContent(props) {
+  const _components = {
+    p: "p",
+    ..._provideComponents(),
+    ...props.components
+  };
+  return _jsx($$$callout$$$, {
+    type: "important",
+    title: "IMPORTANT",
+    children: _jsx(_components.p, {
+      children: "Key information users need to know to achieve their goal."
+    })
+  });
+}
+export default function MDXContent(props = {}) {
+  const {wrapper: MDXLayout} = {
+    ..._provideComponents(),
+    ...props.components
+  };
+  return MDXLayout ? _jsx(MDXLayout, {
+    ...props,
+    children: _jsx(_createMdxContent, {
+      ...props
+    })
+  }) : _createMdxContent(props);
+}
+
+
+MDXContent.__RSPRESS_PAGE_META = {};
+MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle":"","frontmatter":{}};
+"
+`;
+
 exports[`remark-container > github alerts ~ marker followed by content on same paragraph then more blocks 1`] = `
 "import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
 import {useMDXComponents as _provideComponents} from "@mdx-js/react";
@@ -1094,6 +1131,43 @@ function _createMdxContent(props) {
       }), " instead of ", _jsx(_components.code, {
         children: "demo"
       })]
+    })
+  });
+}
+export default function MDXContent(props = {}) {
+  const {wrapper: MDXLayout} = {
+    ..._provideComponents(),
+    ...props.components
+  };
+  return MDXLayout ? _jsx(MDXLayout, {
+    ...props,
+    children: _jsx(_createMdxContent, {
+      ...props
+    })
+  }) : _createMdxContent(props);
+}
+
+
+MDXContent.__RSPRESS_PAGE_META = {};
+MDXContent.__RSPRESS_PAGE_META["index.mdx"] = {"toc":[],"title":"","headingTitle":"","frontmatter":{}};
+"
+`;
+
+exports[`remark-container > important container via ::: syntax 1`] = `
+"import {jsx as _jsx} from "react/jsx-runtime";
+import {useMDXComponents as _provideComponents} from "@mdx-js/react";
+import {Callout as $$$callout$$$} from "@rspress/core/theme";
+function _createMdxContent(props) {
+  const _components = {
+    p: "p",
+    ..._provideComponents(),
+    ...props.components
+  };
+  return _jsx($$$callout$$$, {
+    type: "important",
+    title: "Important",
+    children: _jsx(_components.p, {
+      children: "\\nThis is an important block."
     })
   });
 }

--- a/packages/core/src/node/mdx/remarkPlugins/containerSyntax.test.ts
+++ b/packages/core/src/node/mdx/remarkPlugins/containerSyntax.test.ts
@@ -202,6 +202,22 @@ This is a details block.
     expect(result).toMatchSnapshot();
   });
 
+  test('github alerts ~ important', async () => {
+    const result = await process(`> [!IMPORTANT]
+> Key information users need to know to achieve their goal.
+`);
+
+    expect(result).toMatchSnapshot();
+  });
+
+  test('important container via ::: syntax', async () => {
+    const result = await process(`:::important
+This is an important block.
+:::`);
+
+    expect(result).toMatchSnapshot();
+  });
+
   test('github alerts ~ multi-line plain content', async () => {
     const result = await process(`> [!NOTE]
 > Line 1
@@ -372,7 +388,7 @@ Line 2 with [link](http://example.com).
   // :::
   // `),
   //     ).rejects.toThrow(
-  //       '[remarkContainerSyntax] Unknown container directive type "Tip". Supported types: tip, note, warning, caution, danger, info, details',
+  //       '[remarkContainerSyntax] Unknown container directive type "Tip". Supported types: tip, note, important, warning, caution, danger, info, details',
   //     );
   //   });
 

--- a/packages/core/src/node/mdx/remarkPlugins/containerSyntax.ts
+++ b/packages/core/src/node/mdx/remarkPlugins/containerSyntax.ts
@@ -29,6 +29,7 @@ import { getNamedImportAstNode } from '../../utils';
 export const DIRECTIVE_TYPES = [
   'tip',
   'note',
+  'important',
   'warning',
   'caution',
   'danger',

--- a/packages/core/src/theme/components/Callout/index.scss
+++ b/packages/core/src/theme/components/Callout/index.scss
@@ -18,6 +18,11 @@
   --rp-container-info-bg: rgba(0, 149, 255, 0.06);
   --rp-container-info-code-bg: rgba(0, 149, 255, 0.1);
 
+  --rp-container-important-border: rgba(137, 87, 229, 0.3);
+  --rp-container-important-text: #8250df;
+  --rp-container-important-bg: rgba(137, 87, 229, 0.08);
+  --rp-container-important-code-bg: rgba(137, 87, 229, 0.1);
+
   --rp-container-warning-border: rgba(255, 197, 23, 0.4);
   --rp-container-warning-text: #887233;
   --rp-container-warning-bg: rgba(255, 197, 23, 0.1);
@@ -51,6 +56,10 @@
 
   --rp-container-info-text: #66c2ff;
   --rp-container-info-bg: rgba(0, 149, 255, 0.1);
+
+  --rp-container-important-text: #b083f0;
+  --rp-container-important-border: rgba(137, 87, 229, 0.35);
+  --rp-container-important-bg: rgba(137, 87, 229, 0.12);
 
   --rp-container-warning-text: rgb(251, 180, 81);
   --rp-container-warning-border: rgba(255, 197, 23, 0.25);
@@ -173,6 +182,29 @@
 
   a {
     color: var(--rp-container-info-text);
+  }
+}
+
+// important
+.rp-callout--important {
+  border-color: var(--rp-container-important-border);
+  background-color: var(--rp-container-important-bg);
+
+  .rp-callout__title {
+    color: var(--rp-container-important-text);
+    &::before {
+      background-color: var(--rp-container-important-text);
+    }
+  }
+
+  // inline code
+  :not(pre) > code {
+    color: var(--rp-container-important-text);
+    background-color: var(--rp-container-important-code-bg);
+  }
+
+  a {
+    color: var(--rp-container-important-text);
   }
 }
 

--- a/packages/core/src/theme/components/Callout/index.tsx
+++ b/packages/core/src/theme/components/Callout/index.tsx
@@ -2,7 +2,15 @@ import type { ReactNode } from 'react';
 import './index.scss';
 
 export interface CalloutProps {
-  type: 'tip' | 'note' | 'warning' | 'caution' | 'danger' | 'info' | 'details';
+  type:
+    | 'tip'
+    | 'note'
+    | 'important'
+    | 'warning'
+    | 'caution'
+    | 'danger'
+    | 'info'
+    | 'details';
   title?: string;
   children: ReactNode;
 }

--- a/website/docs/en/fragments/container-syntax.mdx
+++ b/website/docs/en/fragments/container-syntax.mdx
@@ -12,6 +12,10 @@ This is a `note` callout
 This is a `tip` callout
 :::
 
+:::important
+This is an `important` callout
+:::
+
 :::info
 This is an `info` callout
 :::
@@ -47,6 +51,10 @@ This is a `note` callout
 
 :::tip
 This is a `tip` callout
+:::
+
+:::important
+This is an `important` callout
 :::
 
 :::info

--- a/website/docs/en/guide/use-mdx/container.mdx
+++ b/website/docs/en/guide/use-mdx/container.mdx
@@ -48,6 +48,9 @@ import { Tabs, Tab } from '@rspress/core/theme';
 > [!TIP]
 > This is a `block` of type `tip`
 
+> [!IMPORTANT]
+> This is a `block` of type `important`
+
 > [!INFO]
 > This is a `block` of type `info`
 
@@ -70,6 +73,9 @@ import { Tabs, Tab } from '@rspress/core/theme';
 
 > [!TIP]
 > This is a `block` of type `tip`
+
+> [!IMPORTANT]
+> This is a `block` of type `important`
 
 > [!INFO]
 > This is a `block` of type `info`

--- a/website/docs/en/ui/components/callout.mdx
+++ b/website/docs/en/ui/components/callout.mdx
@@ -66,7 +66,15 @@ interface CalloutProps {
   /**
    * The type of callout, which determines its color and icon.
    */
-  type: 'tip' | 'note' | 'warning' | 'caution' | 'danger' | 'info' | 'details';
+  type:
+    | 'tip'
+    | 'note'
+    | 'important'
+    | 'warning'
+    | 'caution'
+    | 'danger'
+    | 'info'
+    | 'details';
   /**
    * Custom title for the callout. If not provided, the capitalized type will be used.
    */

--- a/website/docs/zh/fragments/container-syntax.mdx
+++ b/website/docs/zh/fragments/container-syntax.mdx
@@ -12,6 +12,10 @@ import { Tabs, Tab } from '@rspress/core/theme';
 这是一个 `tip` 类型的 callout
 :::
 
+:::important
+这是一个 `important` 类型的 callout
+:::
+
 :::info
 这是一个 `info` 类型的 callout
 :::
@@ -47,6 +51,10 @@ import { Tabs, Tab } from '@rspress/core/theme';
 
 :::tip
 这是一个 `tip` 类型的 callout
+:::
+
+:::important
+这是一个 `important` 类型的 callout
 :::
 
 :::info

--- a/website/docs/zh/guide/use-mdx/container.mdx
+++ b/website/docs/zh/guide/use-mdx/container.mdx
@@ -48,6 +48,9 @@ import { Tabs, Tab } from '@rspress/core/theme';
 > [!TIP]
 > 这是一个 `tip` 类型的 `block`
 
+> [!IMPORTANT]
+> 这是一个 `important` 类型的 `block`
+
 > [!INFO]
 > 这是一个 `info` 类型的 `block`
 
@@ -70,6 +73,9 @@ import { Tabs, Tab } from '@rspress/core/theme';
 
 > [!TIP]
 > 这是一个 `tip` 类型的 `block`
+
+> [!IMPORTANT]
+> 这是一个 `important` 类型的 `block`
 
 > [!INFO]
 > 这是一个 `info` 类型的 `block`

--- a/website/docs/zh/ui/components/callout.mdx
+++ b/website/docs/zh/ui/components/callout.mdx
@@ -66,7 +66,15 @@ interface CalloutProps {
   /**
    * callout 的类型，决定其颜色和图标。
    */
-  type: 'tip' | 'note' | 'warning' | 'caution' | 'danger' | 'info' | 'details';
+  type:
+    | 'tip'
+    | 'note'
+    | 'important'
+    | 'warning'
+    | 'caution'
+    | 'danger'
+    | 'info'
+    | 'details';
   /**
    * callout 的自定义标题。如果未提供，将使用首字母大写的类型名。
    */


### PR DESCRIPTION
## Summary

This is a proposal to support GitHub's `[!IMPORTANT]` callout type. By doing this we have full compatibility between the native rspress callouts and those supported in [GitHub-flavored markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts).

Since this kind of callout does not exist yet in rspress I have added it as a new type and gave it GitHub-inspired styling, but if you'd like to map it to something existing or have some specific visual style for I'm open for any suggestions, the main issue I'm trying to address here is markdown files that are rendered both in github _and_ rspress.

Let me know if you have any suggestions/questions!

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
