### PR TITLE
feat(core): expose runCLI API

### DIFF
--- a/packages/core/bin/rspress.js
+++ b/packages/core/bin/rspress.js
@@ -12,4 +12,9 @@ if (enableCompileCache) {
   }
 }
 
-import('../dist/cli/index.js');
+async function main() {
+  const { runCLI } = await import('../dist/index.js');
+  runCLI();
+}
+
+main();

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -12,42 +12,172 @@ import { build, dev, serve } from '../node/index';
 
 const META_FILES = ['_meta.json', '_nav.json'];
 
-const cli = cac('rspress').version(version).help();
-
-const landingMessage = `🔥 Rspress v${version}\n`;
-logger.greet(landingMessage);
+export type RunCLIOptions = {
+  /**
+   * The command-line arguments to parse, matching the shape of Node.js `process.argv`
+   * @default process.argv
+   */
+  argv?: string[];
+};
 
 const setNodeEnv = (env: 'development' | 'production') => {
   process.env.NODE_ENV = env;
 };
 
-cli.option(
-  '-c, --config <config>',
-  'Set the configuration file (relative or absolute path)',
-);
+export function runCLI({ argv = process.argv }: RunCLIOptions = {}): void {
+  const cli = cac('rspress').version(version).help();
 
-cli
-  .command('[root]', 'Start the dev server') // default command
-  .alias('dev')
-  .option('--port <port>', 'Set the port number for the server')
-  .option('--host [host]', 'Set the host that the server listens to')
-  .option('--base <base>', 'Set the base path and override config.base')
-  .action(
-    async (
-      root,
-      options?: {
-        port?: number;
-        host?: string;
-        base?: string;
-        config?: string;
+  const landingMessage = `🔥 Rspress v${version}\n`;
+  logger.greet(landingMessage);
+
+  cli.option(
+    '-c, --config <config>',
+    'Set the configuration file (relative or absolute path)',
+  );
+
+  cli
+    .command('[root]', 'Start the dev server') // default command
+    .alias('dev')
+    .option('--port <port>', 'Set the port number for the server')
+    .option('--host [host]', 'Set the host that the server listens to')
+    .option('--base <base>', 'Set the base path and override config.base')
+    .action(
+      async (
+        root,
+        options?: {
+          port?: number;
+          host?: string;
+          base?: string;
+          config?: string;
+        },
+      ) => {
+        setNodeEnv('development');
+        let isRestarting = false;
+        const cwd = process.cwd();
+        let cliWatcher: chokidar.FSWatcher;
+        let devServer: Awaited<ReturnType<typeof dev>>;
+        const startDevServer = async () => {
+          const { port, host } = options || {};
+          const { config, configFilePath } = await loadConfigFile(
+            options?.config,
+          );
+
+          config.root = resolveDocRoot(cwd, root, config.root);
+
+          if (options?.base) {
+            config.base = options.base;
+          }
+
+          const docDirectory = config.root;
+
+          devServer = await dev({
+            appDirectory: cwd,
+            docDirectory,
+            config,
+            configFilePath,
+            extraBuilderConfig: { server: { port, host } },
+          });
+
+          cliWatcher = chokidar.watch([configFilePath, docDirectory], {
+            ignoreInitial: true,
+            ignored: [
+              '**/node_modules/**',
+              '**/.git/**',
+              '**/.DS_Store/**',
+              // ignore public folder in dev, these files are handled by server middleware
+              join(docDirectory, PUBLIC_DIR),
+            ],
+          });
+          cliWatcher.on('all', async (eventName, filepath) => {
+            const basename = path.basename(filepath);
+            if (eventName === 'change' && META_FILES.includes(basename)) {
+              return;
+            }
+
+            if (
+              eventName === 'add' ||
+              eventName === 'unlink' ||
+              (eventName === 'change' && filepath === configFilePath)
+            ) {
+              if (isRestarting) {
+                return;
+              }
+
+              isRestarting = true;
+              console.log(
+                `\n✨ ${eventName} ${picocolors.green(
+                  path.relative(cwd, filepath),
+                )}, dev server will restart...\n`,
+              );
+              await devServer.close();
+              await cliWatcher.close();
+              await startDevServer();
+              isRestarting = false;
+            }
+          });
+        };
+
+        await startDevServer();
+
+        const exitProcess = async () => {
+          try {
+            await devServer.close();
+            await cliWatcher.close();
+          } finally {
+            process.exit(0);
+          }
+        };
+
+        process.on('SIGINT', exitProcess);
+        process.on('SIGTERM', exitProcess);
       },
-    ) => {
-      setNodeEnv('development');
-      let isRestarting = false;
+    );
+
+  cli
+    .command('build [root]', 'Build the documentation site for production')
+    .option('--base <base>', 'Set the base path and override config.base')
+    .action(async (root, options) => {
+      setNodeEnv('production');
       const cwd = process.cwd();
-      let cliWatcher: chokidar.FSWatcher;
-      let devServer: Awaited<ReturnType<typeof dev>>;
-      const startDevServer = async () => {
+      const { config, configFilePath } = await loadConfigFile(options.config);
+
+      config.root = resolveDocRoot(cwd, root, config.root);
+
+      if (options.base) {
+        config.base = options.base;
+      }
+      const docDirectory = config.root;
+
+      try {
+        await build({
+          docDirectory,
+          config,
+          configFilePath,
+        });
+      } catch (err) {
+        logger.error(err);
+        process.exit(1);
+      }
+    });
+
+  cli
+    .command('preview [root]', 'Preview the production build locally')
+    .alias('serve')
+    .option('--port <port>', 'Set the port number for the server')
+    .option('--host [host]', 'Set the host that the server listens to')
+    .option('--base <base>', 'Set the base path and override config.base')
+    .action(
+      async (
+        root,
+        options?: {
+          port?: number;
+          host?: string;
+          base?: string;
+          config?: string;
+        },
+      ) => {
+        setNodeEnv('production');
+        const cwd = process.cwd();
         const { port, host } = options || {};
         const { config, configFilePath } = await loadConfigFile(
           options?.config,
@@ -59,149 +189,31 @@ cli
           config.base = options.base;
         }
 
-        const docDirectory = config.root;
-
-        devServer = await dev({
-          appDirectory: cwd,
-          docDirectory,
+        await serve({
           config,
+          host,
+          port,
           configFilePath,
-          extraBuilderConfig: { server: { port, host } },
         });
-
-        cliWatcher = chokidar.watch([configFilePath, docDirectory], {
-          ignoreInitial: true,
-          ignored: [
-            '**/node_modules/**',
-            '**/.git/**',
-            '**/.DS_Store/**',
-            // ignore public folder in dev, these files are handled by server middleware
-            join(docDirectory, PUBLIC_DIR),
-          ],
-        });
-        cliWatcher.on('all', async (eventName, filepath) => {
-          const basename = path.basename(filepath);
-          if (eventName === 'change' && META_FILES.includes(basename)) {
-            return;
-          }
-
-          if (
-            eventName === 'add' ||
-            eventName === 'unlink' ||
-            (eventName === 'change' && filepath === configFilePath)
-          ) {
-            if (isRestarting) {
-              return;
-            }
-
-            isRestarting = true;
-            console.log(
-              `\n✨ ${eventName} ${picocolors.green(
-                path.relative(cwd, filepath),
-              )}, dev server will restart...\n`,
-            );
-            await devServer.close();
-            await cliWatcher.close();
-            await startDevServer();
-            isRestarting = false;
-          }
-        });
-      };
-
-      await startDevServer();
-
-      const exitProcess = async () => {
-        try {
-          await devServer.close();
-          await cliWatcher.close();
-        } finally {
-          process.exit(0);
-        }
-      };
-
-      process.on('SIGINT', exitProcess);
-      process.on('SIGTERM', exitProcess);
-    },
-  );
-
-cli
-  .command('build [root]', 'Build the documentation site for production')
-  .option('--base <base>', 'Set the base path and override config.base')
-  .action(async (root, options) => {
-    setNodeEnv('production');
-    const cwd = process.cwd();
-    const { config, configFilePath } = await loadConfigFile(options.config);
-
-    config.root = resolveDocRoot(cwd, root, config.root);
-
-    if (options.base) {
-      config.base = options.base;
-    }
-    const docDirectory = config.root;
-
-    try {
-      await build({
-        docDirectory,
-        config,
-        configFilePath,
-      });
-    } catch (err) {
-      logger.error(err);
-      process.exit(1);
-    }
-  });
-
-cli
-  .command('preview [root]', 'Preview the production build locally')
-  .alias('serve')
-  .option('--port <port>', 'Set the port number for the server')
-  .option('--host [host]', 'Set the host that the server listens to')
-  .option('--base <base>', 'Set the base path and override config.base')
-  .action(
-    async (
-      root,
-      options?: {
-        port?: number;
-        host?: string;
-        base?: string;
-        config?: string;
       },
-    ) => {
-      setNodeEnv('production');
-      const cwd = process.cwd();
-      const { port, host } = options || {};
-      const { config, configFilePath } = await loadConfigFile(options?.config);
+    );
 
-      config.root = resolveDocRoot(cwd, root, config.root);
-
-      if (options?.base) {
-        config.base = options.base;
+  cli
+    .command('eject [component]', 'Eject a theme component for customization')
+    .action(async (component?: string) => {
+      if (!component) {
+        await listComponents();
+        return;
       }
 
-      await serve({
-        config,
-        host,
-        port,
-        configFilePath,
-      });
-    },
-  );
+      const cwd = process.cwd();
+      try {
+        await ejectComponent(component, cwd);
+      } catch (error) {
+        logger.error(`Failed to eject component: ${error}`);
+        process.exit(1);
+      }
+    });
 
-cli
-  .command('eject [component]', 'Eject a theme component for customization')
-  .action(async (component?: string) => {
-    if (!component) {
-      await listComponents();
-      return;
-    }
-
-    const cwd = process.cwd();
-    try {
-      await ejectComponent(component, cwd);
-    } catch (error) {
-      logger.error(`Failed to eject component: ${error}`);
-      process.exit(1);
-    }
-  });
-
-cli.parse();
+  cli.parse(argv);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,6 +47,7 @@ export type { UserConfigAsyncFn } from './config/defineConfig';
 // config
 export { defineConfig } from './config/defineConfig';
 // cli
+export { type RunCLIOptions, runCLI } from './cli';
 export {
   build,
   dev,


### PR DESCRIPTION
## Summary

This PR exposes a `runCLI` entry from `@rspress/core` so programmatic consumers can invoke the Rspress CLI with a custom `argv`, matching Rsbuild's API shape. The bin entry now imports `runCLI` from the package root, while importing `@rspress/core` no longer triggers CLI parsing as a side effect.

## Related Issue

None

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).