### PR TITLE
fix(theme/HomeFeature): fix shine not rotating with card causing gap

### DIFF
--- a/packages/core/src/theme/components/HomeFeature/index.scss
+++ b/packages/core/src/theme/components/HomeFeature/index.scss
@@ -68,6 +68,7 @@
     // fill: var(--rp-home-feature-bg-fill);
     backdrop-filter: blur(10px);
     transition: all 0.3s;
+    overflow: hidden;
 
     &--clickable {
       cursor: pointer;

--- a/packages/core/src/theme/components/HomeFeature/index.tsx
+++ b/packages/core/src/theme/components/HomeFeature/index.tsx
@@ -63,9 +63,9 @@ function HomeFeatureItem({ feature }: { feature: Feature }): JSX.Element {
             className="rp-home-feature__detail"
             {...renderHtmlOrText(details)}
           />
+          {shineDom}
         </article>
       </div>
-      {shineDom}
     </div>
   );
 }


### PR DESCRIPTION
…between border and shine

## Summary
<img width="1862" height="1136" alt="image" src="https://github.com/user-attachments/assets/4706c7d2-4f09-43a2-86d1-a38a29f524f1" />


## Related Issue

close #3510 

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
