### PR TITLE
fix(theme/Nav): add :hover as onMouseEnter fallback before hydration

### DIFF
--- a/e2e/fixtures/nav-link-items/index.test.ts
+++ b/e2e/fixtures/nav-link-items/index.test.ts
@@ -100,6 +100,20 @@ const createNavSuite = ({ title, configFile, paths }: NavSuiteConfig) => {
       );
     });
 
+    test('items should be visible on hover before hydration', async ({
+      page,
+    }) => {
+      await init(page);
+
+      await itemsAndLinkItem.evaluate(element => {
+        element.replaceWith(element.cloneNode(true));
+      });
+      await itemsAndLinkItem.hover();
+
+      await expect(itemsAndLinkDropdown).toHaveClass(/rp-hover-group--hidden/);
+      await expect(itemsAndLinkDropdown).toBeVisible();
+    });
+
     test('it should render correct number of nav', async ({ page }) => {
       await init(page);
 

--- a/e2e/fixtures/nav-link-items/index.test.ts
+++ b/e2e/fixtures/nav-link-items/index.test.ts
@@ -369,6 +369,15 @@ test.describe('Nav SSG', () => {
       await expect(itemsAndLinkDropdown).toHaveClass(/rp-hover-group--hidden/);
       await itemsAndLinkItem.hover();
       await expect(itemsAndLinkDropdown).toBeVisible();
+
+      await page.setViewportSize({ width: 1024, height: 768 });
+      const hamburger = page.locator('.rp-nav-hamburger__md');
+      const hamburgerDropdown = hamburger.locator('.rp-hover-group');
+
+      await expect(hamburger).toBeVisible();
+      await expect(hamburgerDropdown).toHaveClass(/rp-hover-group--hidden/);
+      await hamburger.hover();
+      await expect(hamburgerDropdown).toBeVisible();
     } finally {
       await context.close();
     }

--- a/e2e/fixtures/nav-link-items/index.test.ts
+++ b/e2e/fixtures/nav-link-items/index.test.ts
@@ -1,6 +1,12 @@
 import type { Locator, Page } from '@playwright/test';
 import { expect, test } from '@playwright/test';
-import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
+import {
+  getPort,
+  killProcess,
+  runBuildCommand,
+  runDevCommand,
+  runPreviewCommand,
+} from '../../utils/runCommands';
 
 interface NavSuiteConfig {
   title: string;
@@ -98,20 +104,6 @@ const createNavSuite = ({ title, configFile, paths }: NavSuiteConfig) => {
       await expect(itemsAndLinkDropdown).not.toHaveClass(
         /rp-hover-group--hidden/,
       );
-    });
-
-    test('items should be visible on hover before hydration', async ({
-      page,
-    }) => {
-      await init(page);
-
-      await itemsAndLinkItem.evaluate(element => {
-        element.replaceWith(element.cloneNode(true));
-      });
-      await itemsAndLinkItem.hover();
-
-      await expect(itemsAndLinkDropdown).toHaveClass(/rp-hover-group--hidden/);
-      await expect(itemsAndLinkDropdown).toBeVisible();
     });
 
     test('it should render correct number of nav', async ({ page }) => {
@@ -338,4 +330,47 @@ createNavSuite({
     level3Item2: '/nested-items/level3-item2',
     level1Item2: '/nested-items/level1-item2',
   },
+});
+
+test.describe('Nav SSG', () => {
+  let appPort: number;
+  let app: Awaited<ReturnType<typeof runPreviewCommand>>;
+
+  test.beforeAll(async () => {
+    const appDir = import.meta.dirname;
+    appPort = await getPort();
+    await runBuildCommand(appDir);
+    app = await runPreviewCommand(appDir, appPort);
+  });
+
+  test.afterAll(async () => {
+    if (app) {
+      await killProcess(app);
+    }
+  });
+
+  test('items should be visible on hover when JavaScript is disabled', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({ javaScriptEnabled: false });
+    const page = await context.newPage();
+
+    try {
+      await page.goto(`http://localhost:${appPort}`, {
+        waitUntil: 'domcontentloaded',
+      });
+
+      const navMenuItems = page
+        .locator('.rp-nav-menu')
+        .locator('.rp-nav-menu__item');
+      const itemsAndLinkItem = navMenuItems.nth(2);
+      const itemsAndLinkDropdown = itemsAndLinkItem.locator('.rp-hover-group');
+
+      await expect(itemsAndLinkDropdown).toHaveClass(/rp-hover-group--hidden/);
+      await itemsAndLinkItem.hover();
+      await expect(itemsAndLinkDropdown).toBeVisible();
+    } finally {
+      await context.close();
+    }
+  });
 });

--- a/packages/core/src/theme/components/HoverGroup/index.scss
+++ b/packages/core/src/theme/components/HoverGroup/index.scss
@@ -46,6 +46,14 @@
       visibility 0s linear 0.3s;
   }
 
+  // Keep navigation dropdowns usable before React hydration.
+  .rp-nav-menu__item:hover > &--hidden {
+    visibility: visible;
+    opacity: 1;
+    pointer-events: auto;
+    transition: opacity 0.3s ease-in-out;
+  }
+
   &__item {
     height: 32px;
     flex: 1;

--- a/packages/core/src/theme/components/HoverGroup/index.scss
+++ b/packages/core/src/theme/components/HoverGroup/index.scss
@@ -47,7 +47,8 @@
   }
 
   // Keep navigation dropdowns usable before React hydration.
-  .rp-nav-menu__item:hover > &--hidden {
+  .rp-nav-menu__item:hover > &--hidden,
+  .rp-nav-hamburger:hover > &--hidden {
     visibility: visible;
     opacity: 1;
     pointer-events: auto;


### PR DESCRIPTION
## Summary

Navigation dropdowns rendered by SSR remain hidden until React hydration because their visibility relies on mouse event handlers. This adds a CSS hover fallback so dropdown links are usable before hydration while preserving the existing React behavior.

## Related Issue

Fixes https://github.com/web-infra-dev/rspress/issues/3512

<img width="1647" height="788" alt="image" src="https://github.com/user-attachments/assets/ec484394-5c2c-4bac-8d33-0c7b10bf5f90" />


1. disable javascript
2. hover the menu

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).