### PR TITLE
perf(runtime): preload current route chunks with link tag

### DIFF
--- a/e2e/fixtures/ssg-fail-strict/index.test.ts
+++ b/e2e/fixtures/ssg-fail-strict/index.test.ts
@@ -22,6 +22,7 @@ test('csr should be successful', async () => {
     readFile(path.join(appDir, 'doc_build/404.html'), 'utf-8'),
   ]);
 
+  // Verify that each CSR page preloads its current route chunk.
   expect(indexHtml).toMatch(
     /<link rel="preload" href="\/static\/js\/async\/route-[a-f0-9]{12}\..+\.js" as="script">/,
   );

--- a/e2e/fixtures/ssg-fail-strict/index.test.ts
+++ b/e2e/fixtures/ssg-fail-strict/index.test.ts
@@ -1,3 +1,5 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { runBuildCommand } from '../../utils/runCommands';
 
@@ -13,4 +15,18 @@ test('ssg-fail-strict test', async () => {
 test('csr should be successful', async () => {
   const appDir = import.meta.dirname;
   await runBuildCommand(appDir, 'rspress-csr.config.ts');
+
+  const [indexHtml, componentHtml, notFoundHtml] = await Promise.all([
+    readFile(path.join(appDir, 'doc_build/index.html'), 'utf-8'),
+    readFile(path.join(appDir, 'doc_build/Component.html'), 'utf-8'),
+    readFile(path.join(appDir, 'doc_build/404.html'), 'utf-8'),
+  ]);
+
+  expect(indexHtml).toMatch(
+    /<link rel="preload" href="\/static\/js\/async\/rspress-route-index-.+\.js" as="script">/,
+  );
+  expect(componentHtml).toMatch(
+    /<link rel="preload" href="\/static\/js\/async\/rspress-route-Component-.+\.js" as="script">/,
+  );
+  expect(notFoundHtml).not.toContain('<link rel="preload"');
 });

--- a/e2e/fixtures/ssg-fail-strict/index.test.ts
+++ b/e2e/fixtures/ssg-fail-strict/index.test.ts
@@ -23,10 +23,10 @@ test('csr should be successful', async () => {
   ]);
 
   expect(indexHtml).toMatch(
-    /<link rel="preload" href="\/static\/js\/async\/rspress-route-index-.+\.js" as="script">/,
+    /<link rel="preload" href="\/static\/js\/async\/route-[a-f0-9]{12}\..+\.js" as="script">/,
   );
   expect(componentHtml).toMatch(
-    /<link rel="preload" href="\/static\/js\/async\/rspress-route-Component-.+\.js" as="script">/,
+    /<link rel="preload" href="\/static\/js\/async\/route-[a-f0-9]{12}\..+\.js" as="script">/,
   );
   expect(notFoundHtml).not.toContain('<link rel="preload"');
 });

--- a/e2e/fixtures/with-base/index.test.ts
+++ b/e2e/fixtures/with-base/index.test.ts
@@ -1,3 +1,5 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import {
   getPort,
@@ -95,4 +97,24 @@ test.describe('plugin test', async () => {
       'Async updated',
     );
   });
+});
+
+test('Should resolve an auto asset prefix for route preload', async () => {
+  const appDir = import.meta.dirname;
+  await runBuildCommand(appDir, 'rspress-auto-asset-prefix.config.ts');
+
+  const [rootHtml, nestedHtml] = await Promise.all([
+    readFile(path.join(appDir, 'doc_build_auto/index.html'), 'utf-8'),
+    readFile(
+      path.join(appDir, 'doc_build_auto/en/guide/quick-start.html'),
+      'utf-8',
+    ),
+  ]);
+
+  expect(rootHtml).toMatch(
+    /<link rel="preload" href="static\/js\/async\/route-[a-f0-9]{12}\..+\.js" as="script">/,
+  );
+  expect(nestedHtml).toMatch(
+    /<link rel="preload" href="\.\.\/\.\.\/static\/js\/async\/route-[a-f0-9]{12}\..+\.js" as="script">/,
+  );
 });

--- a/e2e/fixtures/with-base/index.test.ts
+++ b/e2e/fixtures/with-base/index.test.ts
@@ -30,7 +30,7 @@ test.describe('plugin test', async () => {
       page.locator('link[rel="preload"][as="script"]'),
     ).toHaveAttribute(
       'href',
-      /^\/base\/static\/js\/async\/rspress-route-en_guide_quick-start-.+\.js$/,
+      /^\/base\/static\/js\/async\/route-[a-f0-9]{12}\..+\.js$/,
     );
     // take the sidebar
     const sidebar = page.locator('.rp-doc-layout__sidebar');

--- a/e2e/fixtures/with-base/index.test.ts
+++ b/e2e/fixtures/with-base/index.test.ts
@@ -26,6 +26,12 @@ test.describe('plugin test', async () => {
     await page.goto(`http://localhost:${appPort}/base/en/guide/quick-start`, {
       waitUntil: 'networkidle',
     });
+    await expect(
+      page.locator('link[rel="preload"][as="script"]'),
+    ).toHaveAttribute(
+      'href',
+      /^\/base\/static\/js\/async\/rspress-route-en_guide_quick-start-.+\.js$/,
+    );
     // take the sidebar
     const sidebar = page.locator('.rp-doc-layout__sidebar');
     await expect(sidebar).toHaveCount(1);

--- a/e2e/fixtures/with-base/index.test.ts
+++ b/e2e/fixtures/with-base/index.test.ts
@@ -28,6 +28,7 @@ test.describe('plugin test', async () => {
     await page.goto(`http://localhost:${appPort}/base/en/guide/quick-start`, {
       waitUntil: 'networkidle',
     });
+    // Verify that the current route chunk preload respects the configured base.
     await expect(
       page.locator('link[rel="preload"][as="script"]'),
     ).toHaveAttribute(

--- a/e2e/fixtures/with-base/rspress-auto-asset-prefix.config.ts
+++ b/e2e/fixtures/with-base/rspress-auto-asset-prefix.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@rspress/core';
+import baseConfig from './rspress.config';
+
+export default defineConfig({
+  ...baseConfig,
+  outDir: 'doc_build_auto',
+  ssg: false,
+  builderConfig: {
+    ...baseConfig.builderConfig,
+    output: {
+      ...baseConfig.builderConfig?.output,
+      assetPrefix: 'auto',
+    },
+  },
+});

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -42,6 +42,7 @@ import {
 import { isLlmsHintEnabled, isLlmsUIEnabled } from './llms';
 import type { PluginDriver } from './PluginDriver';
 import type { RouteService } from './route/RouteService';
+import { RouteChunkAssetsPlugin } from './route/routeChunkAssets';
 import { globalStylesVMPlugin } from './runtimeModule/globalStyles';
 import { globalUIComponentsVMPlugin } from './runtimeModule/globalUIComponents';
 import { i18nVMPlugin } from './runtimeModule/i18n';
@@ -115,6 +116,7 @@ async function createInternalBuildConfig(
   const assetPrefix = isProduction()
     ? addTrailingSlash(config?.builderConfig?.output?.assetPrefix ?? base)
     : '/';
+  const routeChunkAssets = new RouteChunkAssetsPlugin(routeService);
 
   const normalizeIcon = (icon: string | URL | undefined) => {
     if (!icon) {
@@ -204,10 +206,12 @@ async function createInternalBuildConfig(
         ? rsbuildPluginSSG({
             routeService,
             config,
+            routeChunkAssets,
           })
         : rsbuildPluginCSR({
             routeService,
             config,
+            routeChunkAssets,
           }),
       enableSSG && config.llms
         ? rsbuildPluginSSGMD({
@@ -460,6 +464,7 @@ async function createInternalBuildConfig(
         },
         tools: {
           rspack: {
+            plugins: [routeChunkAssets],
             node: {
               __dirname: 'mock',
               __filename: 'mock',

--- a/packages/core/src/node/route/RouteService.test.ts
+++ b/packages/core/src/node/route/RouteService.test.ts
@@ -109,36 +109,42 @@ describe('RouteService', async () => {
       "
       import React from 'react';
       import { lazyWithPreload } from "react-lazy-with-preload";
-      const Route0 = lazyWithPreload(() => import('<ROOT>/packages/core/src/node/route/fixtures/basic/a.mdx'))
-      const Route1 = lazyWithPreload(() => import('<ROOT>/packages/core/src/node/route/fixtures/basic/guide/__e.mdx'))
-      const Route2 = lazyWithPreload(() => import('<ROOT>/packages/core/src/node/route/fixtures/basic/guide/b.mdx'))
-      const Route3 = lazyWithPreload(() => import('<ROOT>/packages/core/src/node/route/fixtures/basic/guide/c.tsx'))
-      const Route4 = lazyWithPreload(() => import('<ROOT>/packages/core/src/node/route/fixtures/basic/guide/index.md'))
-      const Route5 = lazyWithPreload(() => import('<ROOT>/packages/core/src/node/route/fixtures/basic/index.mdx'))
+      const loadRoute0 = () => import(/* webpackChunkName: "rspress-route-a-ba710f8e" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/a.mdx')
+      const Route0 = lazyWithPreload(loadRoute0)
+      const loadRoute1 = () => import(/* webpackChunkName: "rspress-route-guide___e-fe0b57ce" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/__e.mdx')
+      const Route1 = lazyWithPreload(loadRoute1)
+      const loadRoute2 = () => import(/* webpackChunkName: "rspress-route-guide_b-8d52f920" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/b.mdx')
+      const Route2 = lazyWithPreload(loadRoute2)
+      const loadRoute3 = () => import(/* webpackChunkName: "rspress-route-guide_c-c8c47885" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/c.tsx')
+      const Route3 = lazyWithPreload(loadRoute3)
+      const loadRoute4 = () => import(/* webpackChunkName: "rspress-route-guide_index-f507d3f4" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/index.md')
+      const Route4 = lazyWithPreload(loadRoute4)
+      const loadRoute5 = () => import(/* webpackChunkName: "rspress-route-index-2308615e" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/index.mdx')
+      const Route5 = lazyWithPreload(loadRoute5)
       export const routes = [
       { path: '/a', element: React.createElement(Route0), filePath: 'a.mdx', preload: async () => {
               await Route0.preload();
-              return import("<ROOT>/packages/core/src/node/route/fixtures/basic/a.mdx");
+              return loadRoute0();
             }, lang: '', version: '' },
       { path: '/guide/__e', element: React.createElement(Route1), filePath: 'guide/__e.mdx', preload: async () => {
               await Route1.preload();
-              return import("<ROOT>/packages/core/src/node/route/fixtures/basic/guide/__e.mdx");
+              return loadRoute1();
             }, lang: '', version: '' },
       { path: '/guide/b', element: React.createElement(Route2), filePath: 'guide/b.mdx', preload: async () => {
               await Route2.preload();
-              return import("<ROOT>/packages/core/src/node/route/fixtures/basic/guide/b.mdx");
+              return loadRoute2();
             }, lang: '', version: '' },
       { path: '/guide/c', element: React.createElement(Route3), filePath: 'guide/c.tsx', preload: async () => {
               await Route3.preload();
-              return import("<ROOT>/packages/core/src/node/route/fixtures/basic/guide/c.tsx");
+              return loadRoute3();
             }, lang: '', version: '' },
       { path: '/guide/', element: React.createElement(Route4), filePath: 'guide/index.md', preload: async () => {
               await Route4.preload();
-              return import("<ROOT>/packages/core/src/node/route/fixtures/basic/guide/index.md");
+              return loadRoute4();
             }, lang: '', version: '' },
       { path: '/', element: React.createElement(Route5), filePath: 'index.mdx', preload: async () => {
               await Route5.preload();
-              return import("<ROOT>/packages/core/src/node/route/fixtures/basic/index.mdx");
+              return loadRoute5();
             }, lang: '', version: '' }
       ];
       "
@@ -244,31 +250,36 @@ describe('RouteService', async () => {
       "
       import React from 'react';
       import { lazyWithPreload } from "react-lazy-with-preload";
-      const Route0 = lazyWithPreload(() => import('<ROOT>/packages/core/src/node/route/fixtures/basic/a.mdx'))
-      const Route1 = lazyWithPreload(() => import('<ROOT>/packages/core/src/node/route/fixtures/basic/guide/__e.mdx'))
-      const Route2 = lazyWithPreload(() => import('<ROOT>/packages/core/src/node/route/fixtures/basic/guide/c.tsx'))
-      const Route3 = lazyWithPreload(() => import('<ROOT>/packages/core/src/node/route/fixtures/basic/guide/index.md'))
-      const Route4 = lazyWithPreload(() => import('<ROOT>/packages/core/src/node/route/fixtures/basic/index.mdx'))
+      const loadRoute0 = () => import(/* webpackChunkName: "rspress-route-a-ba710f8e" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/a.mdx')
+      const Route0 = lazyWithPreload(loadRoute0)
+      const loadRoute1 = () => import(/* webpackChunkName: "rspress-route-guide___e-fe0b57ce" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/__e.mdx')
+      const Route1 = lazyWithPreload(loadRoute1)
+      const loadRoute2 = () => import(/* webpackChunkName: "rspress-route-guide_c-c8c47885" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/c.tsx')
+      const Route2 = lazyWithPreload(loadRoute2)
+      const loadRoute3 = () => import(/* webpackChunkName: "rspress-route-guide_index-f507d3f4" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/index.md')
+      const Route3 = lazyWithPreload(loadRoute3)
+      const loadRoute4 = () => import(/* webpackChunkName: "rspress-route-index-2308615e" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/index.mdx')
+      const Route4 = lazyWithPreload(loadRoute4)
       export const routes = [
       { path: '/a', element: React.createElement(Route0), filePath: 'a.mdx', preload: async () => {
               await Route0.preload();
-              return import("<ROOT>/packages/core/src/node/route/fixtures/basic/a.mdx");
+              return loadRoute0();
             }, lang: '', version: '' },
       { path: '/guide/__e', element: React.createElement(Route1), filePath: 'guide/__e.mdx', preload: async () => {
               await Route1.preload();
-              return import("<ROOT>/packages/core/src/node/route/fixtures/basic/guide/__e.mdx");
+              return loadRoute1();
             }, lang: '', version: '' },
       { path: '/guide/c', element: React.createElement(Route2), filePath: 'guide/c.tsx', preload: async () => {
               await Route2.preload();
-              return import("<ROOT>/packages/core/src/node/route/fixtures/basic/guide/c.tsx");
+              return loadRoute2();
             }, lang: '', version: '' },
       { path: '/guide/', element: React.createElement(Route3), filePath: 'guide/index.md', preload: async () => {
               await Route3.preload();
-              return import("<ROOT>/packages/core/src/node/route/fixtures/basic/guide/index.md");
+              return loadRoute3();
             }, lang: '', version: '' },
       { path: '/', element: React.createElement(Route4), filePath: 'index.mdx', preload: async () => {
               await Route4.preload();
-              return import("<ROOT>/packages/core/src/node/route/fixtures/basic/index.mdx");
+              return loadRoute4();
             }, lang: '', version: '' }
       ];
       "
@@ -349,31 +360,36 @@ describe('RouteService', async () => {
       "
       import React from 'react';
       import { lazyWithPreload } from "react-lazy-with-preload";
-      const Route0 = lazyWithPreload(() => import('<ROOT>/packages/core/src/node/route/fixtures/basic/a.mdx'))
-      const Route1 = lazyWithPreload(() => import('<ROOT>/packages/core/src/node/route/fixtures/basic/guide/__e.mdx'))
-      const Route2 = lazyWithPreload(() => import('<ROOT>/packages/core/src/node/route/fixtures/basic/guide/b.mdx'))
-      const Route3 = lazyWithPreload(() => import('<ROOT>/packages/core/src/node/route/fixtures/basic/guide/index.md'))
-      const Route4 = lazyWithPreload(() => import('<ROOT>/packages/core/src/node/route/fixtures/basic/index.mdx'))
+      const loadRoute0 = () => import(/* webpackChunkName: "rspress-route-a-ba710f8e" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/a.mdx')
+      const Route0 = lazyWithPreload(loadRoute0)
+      const loadRoute1 = () => import(/* webpackChunkName: "rspress-route-guide___e-fe0b57ce" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/__e.mdx')
+      const Route1 = lazyWithPreload(loadRoute1)
+      const loadRoute2 = () => import(/* webpackChunkName: "rspress-route-guide_b-8d52f920" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/b.mdx')
+      const Route2 = lazyWithPreload(loadRoute2)
+      const loadRoute3 = () => import(/* webpackChunkName: "rspress-route-guide_index-f507d3f4" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/index.md')
+      const Route3 = lazyWithPreload(loadRoute3)
+      const loadRoute4 = () => import(/* webpackChunkName: "rspress-route-index-2308615e" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/index.mdx')
+      const Route4 = lazyWithPreload(loadRoute4)
       export const routes = [
       { path: '/a', element: React.createElement(Route0), filePath: 'a.mdx', preload: async () => {
               await Route0.preload();
-              return import("<ROOT>/packages/core/src/node/route/fixtures/basic/a.mdx");
+              return loadRoute0();
             }, lang: '', version: '' },
       { path: '/guide/__e', element: React.createElement(Route1), filePath: 'guide/__e.mdx', preload: async () => {
               await Route1.preload();
-              return import("<ROOT>/packages/core/src/node/route/fixtures/basic/guide/__e.mdx");
+              return loadRoute1();
             }, lang: '', version: '' },
       { path: '/guide/b', element: React.createElement(Route2), filePath: 'guide/b.mdx', preload: async () => {
               await Route2.preload();
-              return import("<ROOT>/packages/core/src/node/route/fixtures/basic/guide/b.mdx");
+              return loadRoute2();
             }, lang: '', version: '' },
       { path: '/guide/', element: React.createElement(Route3), filePath: 'guide/index.md', preload: async () => {
               await Route3.preload();
-              return import("<ROOT>/packages/core/src/node/route/fixtures/basic/guide/index.md");
+              return loadRoute3();
             }, lang: '', version: '' },
       { path: '/', element: React.createElement(Route4), filePath: 'index.mdx', preload: async () => {
               await Route4.preload();
-              return import("<ROOT>/packages/core/src/node/route/fixtures/basic/index.mdx");
+              return loadRoute4();
             }, lang: '', version: '' }
       ];
       "

--- a/packages/core/src/node/route/RouteService.test.ts
+++ b/packages/core/src/node/route/RouteService.test.ts
@@ -109,17 +109,17 @@ describe('RouteService', async () => {
       "
       import React from 'react';
       import { lazyWithPreload } from "react-lazy-with-preload";
-      const loadRoute0 = () => import(/* webpackChunkName: "rspress-route-a-ba710f8e" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/a.mdx')
+      const loadRoute0 = () => import(/* webpackChunkName: "route-ba710f8e4eb0" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/a.mdx')
       const Route0 = lazyWithPreload(loadRoute0)
-      const loadRoute1 = () => import(/* webpackChunkName: "rspress-route-guide___e-fe0b57ce" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/__e.mdx')
+      const loadRoute1 = () => import(/* webpackChunkName: "route-fe0b57ce1b4b" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/__e.mdx')
       const Route1 = lazyWithPreload(loadRoute1)
-      const loadRoute2 = () => import(/* webpackChunkName: "rspress-route-guide_b-8d52f920" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/b.mdx')
+      const loadRoute2 = () => import(/* webpackChunkName: "route-8d52f920922f" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/b.mdx')
       const Route2 = lazyWithPreload(loadRoute2)
-      const loadRoute3 = () => import(/* webpackChunkName: "rspress-route-guide_c-c8c47885" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/c.tsx')
+      const loadRoute3 = () => import(/* webpackChunkName: "route-c8c47885cd1b" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/c.tsx')
       const Route3 = lazyWithPreload(loadRoute3)
-      const loadRoute4 = () => import(/* webpackChunkName: "rspress-route-guide_index-f507d3f4" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/index.md')
+      const loadRoute4 = () => import(/* webpackChunkName: "route-f507d3f43b22" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/index.md')
       const Route4 = lazyWithPreload(loadRoute4)
-      const loadRoute5 = () => import(/* webpackChunkName: "rspress-route-index-2308615e" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/index.mdx')
+      const loadRoute5 = () => import(/* webpackChunkName: "route-2308615ee227" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/index.mdx')
       const Route5 = lazyWithPreload(loadRoute5)
       export const routes = [
       { path: '/a', element: React.createElement(Route0), filePath: 'a.mdx', preload: async () => {
@@ -250,15 +250,15 @@ describe('RouteService', async () => {
       "
       import React from 'react';
       import { lazyWithPreload } from "react-lazy-with-preload";
-      const loadRoute0 = () => import(/* webpackChunkName: "rspress-route-a-ba710f8e" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/a.mdx')
+      const loadRoute0 = () => import(/* webpackChunkName: "route-ba710f8e4eb0" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/a.mdx')
       const Route0 = lazyWithPreload(loadRoute0)
-      const loadRoute1 = () => import(/* webpackChunkName: "rspress-route-guide___e-fe0b57ce" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/__e.mdx')
+      const loadRoute1 = () => import(/* webpackChunkName: "route-fe0b57ce1b4b" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/__e.mdx')
       const Route1 = lazyWithPreload(loadRoute1)
-      const loadRoute2 = () => import(/* webpackChunkName: "rspress-route-guide_c-c8c47885" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/c.tsx')
+      const loadRoute2 = () => import(/* webpackChunkName: "route-c8c47885cd1b" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/c.tsx')
       const Route2 = lazyWithPreload(loadRoute2)
-      const loadRoute3 = () => import(/* webpackChunkName: "rspress-route-guide_index-f507d3f4" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/index.md')
+      const loadRoute3 = () => import(/* webpackChunkName: "route-f507d3f43b22" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/index.md')
       const Route3 = lazyWithPreload(loadRoute3)
-      const loadRoute4 = () => import(/* webpackChunkName: "rspress-route-index-2308615e" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/index.mdx')
+      const loadRoute4 = () => import(/* webpackChunkName: "route-2308615ee227" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/index.mdx')
       const Route4 = lazyWithPreload(loadRoute4)
       export const routes = [
       { path: '/a', element: React.createElement(Route0), filePath: 'a.mdx', preload: async () => {
@@ -360,15 +360,15 @@ describe('RouteService', async () => {
       "
       import React from 'react';
       import { lazyWithPreload } from "react-lazy-with-preload";
-      const loadRoute0 = () => import(/* webpackChunkName: "rspress-route-a-ba710f8e" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/a.mdx')
+      const loadRoute0 = () => import(/* webpackChunkName: "route-ba710f8e4eb0" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/a.mdx')
       const Route0 = lazyWithPreload(loadRoute0)
-      const loadRoute1 = () => import(/* webpackChunkName: "rspress-route-guide___e-fe0b57ce" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/__e.mdx')
+      const loadRoute1 = () => import(/* webpackChunkName: "route-fe0b57ce1b4b" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/__e.mdx')
       const Route1 = lazyWithPreload(loadRoute1)
-      const loadRoute2 = () => import(/* webpackChunkName: "rspress-route-guide_b-8d52f920" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/b.mdx')
+      const loadRoute2 = () => import(/* webpackChunkName: "route-8d52f920922f" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/b.mdx')
       const Route2 = lazyWithPreload(loadRoute2)
-      const loadRoute3 = () => import(/* webpackChunkName: "rspress-route-guide_index-f507d3f4" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/index.md')
+      const loadRoute3 = () => import(/* webpackChunkName: "route-f507d3f43b22" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/guide/index.md')
       const Route3 = lazyWithPreload(loadRoute3)
-      const loadRoute4 = () => import(/* webpackChunkName: "rspress-route-index-2308615e" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/index.mdx')
+      const loadRoute4 = () => import(/* webpackChunkName: "route-2308615ee227" */ '<ROOT>/packages/core/src/node/route/fixtures/basic/index.mdx')
       const Route4 = lazyWithPreload(loadRoute4)
       export const routes = [
       { path: '/a', element: React.createElement(Route0), filePath: 'a.mdx', preload: async () => {

--- a/packages/core/src/node/route/RouteService.ts
+++ b/packages/core/src/node/route/RouteService.ts
@@ -24,6 +24,7 @@ import {
   absolutePathToRoutePath,
   RoutePage,
 } from './RoutePage';
+import { getRouteChunkName } from './routeChunkAssets';
 
 interface InitOptions {
   scanDir: string;
@@ -298,7 +299,9 @@ import React from 'react';
 import { lazyWithPreload } from "react-lazy-with-preload";
 ${routeMeta
   .map((route, index) => {
-    return `const Route${index} = lazyWithPreload(() => import('${route.absolutePath}'))`;
+    const chunkName = getRouteChunkName(route);
+    return `const loadRoute${index} = () => import(/* webpackChunkName: "${chunkName}" */ '${route.absolutePath}')
+const Route${index} = lazyWithPreload(loadRoute${index})`;
   })
   .join('\n')}
 export const routes = [
@@ -306,7 +309,7 @@ ${routeMeta
   .map((route, index) => {
     const preload = `async () => {
         await Route${index}.preload();
-        return import("${route.absolutePath}");
+        return loadRoute${index}();
       }`;
     const component = `Route${index}`;
     /**

--- a/packages/core/src/node/route/routeChunkAssets.ts
+++ b/packages/core/src/node/route/routeChunkAssets.ts
@@ -5,6 +5,7 @@ import type { RouteService } from './RouteService';
 
 const PLUGIN_NAME = 'RspressRouteChunkAssetsPlugin';
 const JAVASCRIPT_ASSET_REGEXP = /\.[cm]?js$/;
+const ROUTE_CHUNK_HASH_LENGTH = 12;
 
 export interface RouteChunkAssetsManifest {
   assetPrefix: string;
@@ -12,13 +13,7 @@ export interface RouteChunkAssetsManifest {
 }
 
 export function getRouteChunkName(route: RouteMeta): string {
-  const pageName =
-    route.pageName
-      .replace(/[^a-zA-Z0-9_-]+/g, '-')
-      .replace(/^-+|-+$/g, '')
-      .slice(0, 48) || 'page';
-
-  return `rspress-route-${pageName}-${createHash(route.relativePath)}`;
+  return `route-${createHash(route.relativePath, ROUTE_CHUNK_HASH_LENGTH)}`;
 }
 
 export class RouteChunkAssetsPlugin implements Rspack.RspackPluginInstance {

--- a/packages/core/src/node/route/routeChunkAssets.ts
+++ b/packages/core/src/node/route/routeChunkAssets.ts
@@ -1,0 +1,84 @@
+import type { Rspack } from '@rsbuild/core';
+import type { RouteMeta } from '@rspress/shared';
+import { createHash } from '../utils/createHash';
+import type { RouteService } from './RouteService';
+
+const PLUGIN_NAME = 'RspressRouteChunkAssetsPlugin';
+const JAVASCRIPT_ASSET_REGEXP = /\.[cm]?js$/;
+
+export interface RouteChunkAssetsManifest {
+  assetPrefix: string;
+  assets: Record<string, string[]>;
+}
+
+export function getRouteChunkName(route: RouteMeta): string {
+  const pageName =
+    route.pageName
+      .replace(/[^a-zA-Z0-9_-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 48) || 'page';
+
+  return `rspress-route-${pageName}-${createHash(route.relativePath)}`;
+}
+
+export class RouteChunkAssetsPlugin implements Rspack.RspackPluginInstance {
+  #assetPrefix = '/';
+
+  #chunks = new Map<string, Set<Rspack.Chunk>>();
+
+  constructor(private readonly routeService: RouteService) {}
+
+  apply(compiler: Rspack.Compiler): void {
+    compiler.hooks.thisCompilation.tap(PLUGIN_NAME, compilation => {
+      this.#assetPrefix =
+        typeof compilation.outputOptions.publicPath === 'string'
+          ? compilation.outputOptions.publicPath
+          : '/';
+      this.#chunks.clear();
+
+      const routePathsByChunkName = new Map<string, string[]>();
+      for (const route of this.routeService.getRoutes()) {
+        const chunkName = getRouteChunkName(route);
+        const routePaths = routePathsByChunkName.get(chunkName) ?? [];
+        routePaths.push(route.routePath);
+        routePathsByChunkName.set(chunkName, routePaths);
+      }
+
+      compilation.hooks.chunkAsset.tap(PLUGIN_NAME, chunk => {
+        if (!chunk.name) {
+          return;
+        }
+
+        const routePaths = routePathsByChunkName.get(chunk.name);
+        if (!routePaths) {
+          return;
+        }
+
+        for (const routePath of routePaths) {
+          const chunks = this.#chunks.get(routePath) ?? new Set<Rspack.Chunk>();
+          chunks.add(chunk);
+          this.#chunks.set(routePath, chunks);
+        }
+      });
+    });
+  }
+
+  getManifest(): RouteChunkAssetsManifest {
+    return {
+      assetPrefix: this.#assetPrefix,
+      assets: Object.fromEntries(
+        [...this.#chunks].map(([routePath, chunks]) => {
+          const assets = new Set<string>();
+          for (const chunk of chunks) {
+            for (const filename of chunk.files) {
+              if (JAVASCRIPT_ASSET_REGEXP.test(filename)) {
+                assets.add(filename);
+              }
+            }
+          }
+          return [routePath, [...assets]];
+        }),
+      ),
+    };
+  }
+}

--- a/packages/core/src/node/ssg/renderHtmlTemplate.test.ts
+++ b/packages/core/src/node/ssg/renderHtmlTemplate.test.ts
@@ -23,16 +23,16 @@ describe('renderHtmlTemplate', () => {
       {
         assetPrefix: 'https://cdn.example.com/assets/?v=1&',
         assets: {
-          '/guide/': ['static/js/rspress-route-guide.123.js'],
-          '/other': ['static/js/rspress-route-other.456.js'],
+          '/guide/': ['static/js/route-a1b2c3d4e5f6.123.js'],
+          '/other': ['static/js/route-abcdef123456.456.js'],
         },
       },
     );
 
     expect(html).toContain(
-      '<link rel="preload" href="https://cdn.example.com/assets/?v=1&amp;static/js/rspress-route-guide.123.js" as="script">',
+      '<link rel="preload" href="https://cdn.example.com/assets/?v=1&amp;static/js/route-a1b2c3d4e5f6.123.js" as="script">',
     );
-    expect(html).not.toContain('rspress-route-other.456.js');
+    expect(html).not.toContain('route-abcdef123456.456.js');
     expect(html).toContain('<main>Guide</main>');
   });
 

--- a/packages/core/src/node/ssg/renderHtmlTemplate.test.ts
+++ b/packages/core/src/node/ssg/renderHtmlTemplate.test.ts
@@ -51,4 +51,37 @@ describe('renderHtmlTemplate', () => {
 
     expect(html).toBe('<head></head>');
   });
+
+  it('resolves an auto asset prefix relative to the route HTML file', async () => {
+    const manifest = {
+      assetPrefix: 'auto',
+      assets: {
+        '/': ['static/js/route-123456789abc.123.js'],
+        '/guide/': ['static/js/route-a1b2c3d4e5f6.456.js'],
+      },
+    };
+    const [rootHtml, nestedHtml] = await Promise.all([
+      renderHtmlTemplate(
+        `<head>${HEAD_MARKER}</head>`,
+        [],
+        { ...route, routePath: '/' },
+        '',
+        [],
+        manifest,
+      ),
+      renderHtmlTemplate(
+        `<head>${HEAD_MARKER}</head>`,
+        [],
+        route,
+        '',
+        [],
+        manifest,
+      ),
+    ]);
+
+    expect(rootHtml).toContain('href="static/js/route-123456789abc.123.js"');
+    expect(nestedHtml).toContain(
+      'href="../static/js/route-a1b2c3d4e5f6.456.js"',
+    );
+  });
 });

--- a/packages/core/src/node/ssg/renderHtmlTemplate.test.ts
+++ b/packages/core/src/node/ssg/renderHtmlTemplate.test.ts
@@ -1,0 +1,54 @@
+import type { RouteMeta } from '@rspress/shared';
+import { describe, expect, it } from '@rstest/core';
+import { APP_HTML_MARKER, HEAD_MARKER, META_GENERATOR } from '../constants';
+import { renderHtmlTemplate } from './renderHtmlTemplate';
+
+const route: RouteMeta = {
+  routePath: '/guide/',
+  absolutePath: '/root/guide/index.md',
+  relativePath: 'guide/index.md',
+  pageName: 'guide_index',
+  lang: '',
+  version: '',
+};
+
+describe('renderHtmlTemplate', () => {
+  it('injects preload links for the current route chunks', async () => {
+    const html = await renderHtmlTemplate(
+      `<html><head>${META_GENERATOR}${HEAD_MARKER}</head><body>${APP_HTML_MARKER}</body></html>`,
+      [],
+      route,
+      '<main>Guide</main>',
+      [],
+      {
+        assetPrefix: 'https://cdn.example.com/assets/?v=1&',
+        assets: {
+          '/guide/': ['static/js/rspress-route-guide.123.js'],
+          '/other': ['static/js/rspress-route-other.456.js'],
+        },
+      },
+    );
+
+    expect(html).toContain(
+      '<link rel="preload" href="https://cdn.example.com/assets/?v=1&amp;static/js/rspress-route-guide.123.js" as="script">',
+    );
+    expect(html).not.toContain('rspress-route-other.456.js');
+    expect(html).toContain('<main>Guide</main>');
+  });
+
+  it('does not inject a preload link without a matching route asset', async () => {
+    const html = await renderHtmlTemplate(
+      `<head>${HEAD_MARKER}</head>`,
+      [],
+      route,
+      '',
+      [],
+      {
+        assetPrefix: '/',
+        assets: {},
+      },
+    );
+
+    expect(html).toBe('<head></head>');
+  });
+});

--- a/packages/core/src/node/ssg/renderHtmlTemplate.ts
+++ b/packages/core/src/node/ssg/renderHtmlTemplate.ts
@@ -6,6 +6,7 @@ import {
   META_GENERATOR,
   RSPRESS_VERSION,
 } from '../constants';
+import type { RouteChunkAssetsManifest } from '../route/routeChunkAssets';
 import { createError } from '../utils';
 import type { AlternateLink } from './alternateLinks';
 
@@ -36,6 +37,7 @@ export async function renderHtmlTemplate(
   route: RouteMeta,
   appHtml: string = '',
   alternateLinks: AlternateLink[] = [],
+  routeChunkAssets?: RouteChunkAssetsManifest,
 ) {
   const alternateLinkTags = alternateLinks
     .map(
@@ -43,6 +45,7 @@ export async function renderHtmlTemplate(
         `<link ${renderAttrs({ rel: 'alternate', hreflang: hrefLang, href })}>`,
     )
     .join('');
+  const routePreloadLinks = renderRoutePreloadLinks(route, routeChunkAssets);
   const replacedHtmlTemplate = htmlTemplate
     // Don't use `string` as second param
     // To avoid some special characters transformed to the marker, such as `$&`, etc.
@@ -53,9 +56,38 @@ export async function renderHtmlTemplate(
     )
     .replace(
       HEAD_MARKER,
-      [await renderConfigHead(head, route), alternateLinkTags].join(''),
+      [
+        routePreloadLinks,
+        await renderConfigHead(head, route),
+        alternateLinkTags,
+      ].join(''),
     );
   return replacedHtmlTemplate;
+}
+
+function renderRoutePreloadLinks(
+  route: RouteMeta,
+  manifest?: RouteChunkAssetsManifest,
+): string {
+  if (!manifest) return '';
+
+  const assets = manifest.assets[route.routePath];
+  if (!assets) return '';
+
+  return assets
+    .map(asset => {
+      const href = `${manifest.assetPrefix}${asset}`;
+      return `<link rel="preload" href="${escapeHtmlAttribute(href)}" as="script">`;
+    })
+    .join('');
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
 }
 
 function renderAttrs(attrs: Record<string, string>): string {

--- a/packages/core/src/node/ssg/renderHtmlTemplate.ts
+++ b/packages/core/src/node/ssg/renderHtmlTemplate.ts
@@ -1,3 +1,4 @@
+import { posix } from 'node:path';
 import type { RouteMeta, UserConfig } from '@rspress/shared';
 
 import {
@@ -9,6 +10,7 @@ import {
 import type { RouteChunkAssetsManifest } from '../route/routeChunkAssets';
 import { createError } from '../utils';
 import type { AlternateLink } from './alternateLinks';
+import { routePath2HtmlFileName } from './htmlFile';
 
 async function renderConfigHead(
   head: UserConfig['head'],
@@ -76,7 +78,13 @@ function renderRoutePreloadLinks(
 
   return assets
     .map(asset => {
-      const href = `${manifest.assetPrefix}${asset}`;
+      const href =
+        manifest.assetPrefix === 'auto'
+          ? posix.relative(
+              posix.dirname(routePath2HtmlFileName(route.routePath)),
+              asset,
+            )
+          : `${manifest.assetPrefix}${asset}`;
       return `<link rel="preload" href="${escapeHtmlAttribute(href)}" as="script">`;
     })
     .join('');

--- a/packages/core/src/node/ssg/renderPage.ts
+++ b/packages/core/src/node/ssg/renderPage.ts
@@ -9,6 +9,7 @@ import {
 import picocolors from 'picocolors';
 
 import { hintSSGFailed } from '../logger/hint';
+import type { RouteChunkAssetsManifest } from '../route/routeChunkAssets';
 import type { AlternateLink } from './alternateLinks';
 import { renderHtmlTemplate } from './renderHtmlTemplate';
 
@@ -23,6 +24,7 @@ export async function renderPage(
   configHead: UserConfig['head'],
   ssrBundlePath: string,
   alternateLinks: AlternateLink[] = [],
+  routeChunkAssets?: RouteChunkAssetsManifest,
 ) {
   let render: SSRBundleExports['render'];
   try {
@@ -68,6 +70,7 @@ ${absolutePath ? picocolors.gray(`    File: ${absolutePath}\n`) : ''}    ${picoc
     route,
     appHtml,
     alternateLinks,
+    routeChunkAssets,
   );
 
   const html = await transformHtmlTemplate(head, replacedHtmlTemplate);

--- a/packages/core/src/node/ssg/renderPageWorker.ts
+++ b/packages/core/src/node/ssg/renderPageWorker.ts
@@ -3,6 +3,7 @@ import { dirname } from 'node:path';
 import { workerData } from 'node:worker_threads';
 import type { RouteMeta, UserConfig } from '@rspress/shared';
 import pMap from 'p-map';
+import type { RouteChunkAssetsManifest } from '../route/routeChunkAssets';
 import { createError } from '../utils';
 import type { AlternateLinksByRoute } from './alternateLinks';
 import { resolveHtmlFilePath } from './htmlFile';
@@ -14,6 +15,7 @@ interface WorkerDataParams {
   ssrBundlePath: string;
   alternateLinksByRoute: AlternateLinksByRoute;
   distPath?: string;
+  routeChunkAssets?: RouteChunkAssetsManifest;
 }
 
 interface WorkerTask {
@@ -25,8 +27,14 @@ if (!params) {
   throw createError('SSG Worker Thread workerData params missing');
 }
 
-const { htmlTemplate, head, ssrBundlePath, alternateLinksByRoute, distPath } =
-  params;
+const {
+  htmlTemplate,
+  head,
+  ssrBundlePath,
+  alternateLinksByRoute,
+  distPath,
+  routeChunkAssets,
+} = params;
 
 async function writeHtmlFile(routePath: string, html: string) {
   if (!distPath) {
@@ -51,6 +59,7 @@ const exportWorkerGlueFn = async ({
           head,
           ssrBundlePath,
           alternateLinksByRoute[route.routePath] ?? [],
+          routeChunkAssets,
         );
         await writeHtmlFile(route.routePath, html);
       },
@@ -68,6 +77,7 @@ const exportWorkerGlueFn = async ({
         head,
         ssrBundlePath,
         alternateLinksByRoute[route.routePath] ?? [],
+        routeChunkAssets,
       );
       return html;
     },

--- a/packages/core/src/node/ssg/renderPages.ts
+++ b/packages/core/src/node/ssg/renderPages.ts
@@ -6,6 +6,7 @@ import picocolors from 'picocolors';
 
 import { hintSSGFailed } from '../logger/hint';
 import type { RouteService } from '../route/RouteService';
+import type { RouteChunkAssetsManifest } from '../route/routeChunkAssets';
 import {
   createAlternateLinksByRoute,
   type AlternateLinksByRoute,
@@ -27,6 +28,7 @@ export async function renderPages(
   htmlTemplate: string,
   emitAsset: (assetName: string, content: string | Buffer) => void,
   workerOutputDistPath?: string,
+  routeChunkAssets?: RouteChunkAssetsManifest,
 ) {
   const startTime = Date.now();
   const ssg = config.ssg ?? true;
@@ -71,6 +73,7 @@ export async function renderPages(
               htmlTemplate,
               alternateLinksByRoute,
               emitAsset,
+              routeChunkAssets,
             ),
           );
         } else {
@@ -121,6 +124,7 @@ export async function renderPages(
             ssrBundlePath,
             alternateLinksByRoute,
             distPath: workerOutputDistPath,
+            routeChunkAssets,
           },
         },
       });
@@ -154,6 +158,7 @@ export async function renderPages(
             config.head,
             ssrBundlePath,
             alternateLinksByRoute[route.routePath] ?? [],
+            routeChunkAssets,
           );
 
           const fileName = routePath2HtmlFileName(route.routePath);
@@ -183,6 +188,7 @@ async function renderCSRPage(
   htmlTemplate: string,
   alternateLinksByRoute: AlternateLinksByRoute,
   emitAsset: (assetName: string, content: string | Buffer) => void,
+  routeChunkAssets?: RouteChunkAssetsManifest,
 ) {
   const html = await renderHtmlTemplate(
     htmlTemplate,
@@ -190,6 +196,7 @@ async function renderCSRPage(
     route,
     '',
     alternateLinksByRoute[route.routePath] ?? [],
+    routeChunkAssets,
   );
   const fileName = routePath2HtmlFileName(route.routePath);
   emitAsset(fileName, html);
@@ -200,6 +207,7 @@ export async function renderCSRPages(
   config: UserConfig,
   htmlTemplate: string,
   emitAsset: (assetName: string, content: string | Buffer) => void,
+  routeChunkAssets?: RouteChunkAssetsManifest,
 ) {
   const routes = routeService.getRoutes();
   const alternateLinksByRoute = createAlternateLinksByRoute(routes, config);
@@ -216,6 +224,7 @@ export async function renderCSRPages(
         htmlTemplate,
         alternateLinksByRoute,
         emitAsset,
+        routeChunkAssets,
       );
     }),
   );

--- a/packages/core/src/node/ssg/rsbuildPluginCSR.ts
+++ b/packages/core/src/node/ssg/rsbuildPluginCSR.ts
@@ -1,14 +1,17 @@
 import type { RsbuildPlugin } from '@rsbuild/core';
 import type { UserConfig } from '@rspress/shared';
 import type { RouteService } from '../route/RouteService';
+import type { RouteChunkAssetsPlugin } from '../route/routeChunkAssets';
 import { renderCSRPages } from './renderPages';
 
 export const rsbuildPluginCSR = ({
   routeService,
   config,
+  routeChunkAssets,
 }: {
   routeService: RouteService;
   config: UserConfig;
+  routeChunkAssets: RouteChunkAssetsPlugin;
 }): RsbuildPlugin => ({
   name: 'rspress-inner-rsbuild-plugin-csr',
   async setup(api) {
@@ -42,7 +45,13 @@ export const rsbuildPluginCSR = ({
             }
           }
 
-          await renderCSRPages(routeService, config, htmlTemplate, emitAsset);
+          await renderCSRPages(
+            routeService,
+            config,
+            htmlTemplate,
+            emitAsset,
+            routeChunkAssets.getManifest(),
+          );
         },
       );
     });

--- a/packages/core/src/node/ssg/rsbuildPluginSSG.ts
+++ b/packages/core/src/node/ssg/rsbuildPluginSSG.ts
@@ -5,14 +5,17 @@ import { isDebugMode, type UserConfig } from '@rspress/shared';
 import { logger } from '@rspress/shared/logger';
 import { NODE_SSG_BUNDLE_FOLDER, NODE_SSG_BUNDLE_NAME } from '../constants';
 import type { RouteService } from '../route/RouteService';
+import type { RouteChunkAssetsPlugin } from '../route/routeChunkAssets';
 import { renderPages } from './renderPages';
 
 export const rsbuildPluginSSG = ({
   routeService,
   config,
+  routeChunkAssets,
 }: {
   routeService: RouteService;
   config: UserConfig;
+  routeChunkAssets: RouteChunkAssetsPlugin;
 }): RsbuildPlugin => ({
   name: 'rspress-inner-rsbuild-plugin-ssg',
   async setup(api) {
@@ -125,6 +128,7 @@ export const rsbuildPluginSSG = ({
             htmlTemplate,
             emitAsset,
             distPath,
+            routeChunkAssets.getManifest(),
           );
 
           if (!isDebugMode()) {

--- a/packages/core/src/node/utils/createHash.ts
+++ b/packages/core/src/node/utils/createHash.ts
@@ -1,5 +1,5 @@
 import { createHash as createHashFunc } from 'node:crypto';
 
-export function createHash(str: string) {
-  return createHashFunc('sha256').update(str).digest('hex').slice(0, 8);
+export function createHash(str: string, length = 8) {
+  return createHashFunc('sha256').update(str).digest('hex').slice(0, length);
 }

--- a/website/docs/en/guide/advanced/custom-head.mdx
+++ b/website/docs/en/guide/advanced/custom-head.mdx
@@ -4,14 +4,15 @@ Adding head tags (such as meta tags) to web pages is crucial for SEO optimizatio
 
 Currently, Rspress automatically injects the following head tags:
 
-| Tag                                                         | Description                                                                                 |
-| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `<meta name="generator" content="Rspress v${version}">`     | Identifies the site generator and version                                                   |
-| `<meta name="description" content="${description}">`        | Page description, see [How description is determined](#how-description-is-determined) below |
-| `<meta property="og:type" content="website">`               | Open Graph type, fixed as `website`                                                         |
-| `<meta property="og:title" content="${title}">`             | Open Graph title, uses current page title (if available)                                    |
-| `<meta property="og:description" content="${description}">` | Open Graph description, same as above                                                       |
-| `<link rel="alternate" hreflang="${lang}" href="${url}">`   | Alternate language versions of the current page on multilingual sites                       |
+| Tag                                                            | Description                                                                                 |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `<meta name="generator" content="Rspress v${version}">`        | Identifies the site generator and version                                                   |
+| `<meta name="description" content="${description}">`           | Page description, see [How description is determined](#how-description-is-determined) below |
+| `<meta property="og:type" content="website">`                  | Open Graph type, fixed as `website`                                                         |
+| `<meta property="og:title" content="${title}">`                | Open Graph title, uses current page title (if available)                                    |
+| `<meta property="og:description" content="${description}">`    | Open Graph description, same as above                                                       |
+| `<link rel="alternate" hreflang="${lang}" href="${url}">`      | Alternate language versions of the current page on multilingual sites                       |
+| `<link rel="preload" href="${currentRouteChunk}" as="script">` | Performance optimization that preloads the current page's async route chunk                 |
 
 ## How description is determined
 

--- a/website/docs/zh/guide/advanced/custom-head.mdx
+++ b/website/docs/zh/guide/advanced/custom-head.mdx
@@ -4,14 +4,15 @@
 
 目前 Rspress 会自动注入以下 Head 标签：
 
-| 标签                                                        | 描述                                                                 |
-| ----------------------------------------------------------- | -------------------------------------------------------------------- |
-| `<meta name="generator" content="Rspress v${version}">`     | 标识站点生成器及版本号                                               |
-| `<meta name="description" content="${description}">`        | 页面描述，参见下方 [description 的获取方式](#description-的获取方式) |
-| `<meta property="og:type" content="website">`               | Open Graph 类型，固定为 `website`                                    |
-| `<meta property="og:title" content="${title}">`             | Open Graph 标题，使用当前页面标题（如果存在）                        |
-| `<meta property="og:description" content="${description}">` | Open Graph 描述，同上                                                |
-| `<link rel="alternate" hreflang="${lang}" href="${url}">`   | 多语言站点中当前页面的其它语言版本                                   |
+| 标签                                                           | 描述                                                                 |
+| -------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `<meta name="generator" content="Rspress v${version}">`        | 标识站点生成器及版本号                                               |
+| `<meta name="description" content="${description}">`           | 页面描述，参见下方 [description 的获取方式](#description-的获取方式) |
+| `<meta property="og:type" content="website">`                  | Open Graph 类型，固定为 `website`                                    |
+| `<meta property="og:title" content="${title}">`                | Open Graph 标题，使用当前页面标题（如果存在）                        |
+| `<meta property="og:description" content="${description}">`    | Open Graph 描述，同上                                                |
+| `<link rel="alternate" hreflang="${lang}" href="${url}">`      | 多语言站点中当前页面的其它语言版本                                   |
+| `<link rel="preload" href="${currentRouteChunk}" as="script">` | 性能优化：预加载当前页面对应的异步路由 chunk                         |
 
 ## description 的获取方式
 


### PR DESCRIPTION
## Summary

This PR adds the following tag to each generated page so its current async route chunk starts downloading immediately:

```html
<link rel="preload" href="/static/js/async/route-<hash>.<contenthash>.js" as="script">
```

This removes the extra network waterfall where the route code was only requested after the client runtime started hydration. The preload URL respects `base`, CDN asset prefixes, and `assetPrefix: 'auto'`.

## Related Issue

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
