### PR TITLE
fix(create-rspress): preserve skill names in prompts

### DIFF
--- a/packages/create-rspress/src/index.ts
+++ b/packages/create-rspress/src/index.ts
@@ -89,23 +89,23 @@ create({
   extraSkills: [
     {
       value: 'rspress-docs-generator',
-      label: 'Rspress docs generator',
+      label: 'rspress-docs-generator',
       source: 'rstackjs/agent-skills',
     },
     {
       value: 'rspress-best-practices',
-      label: 'Rspress best practices',
+      label: 'rspress-best-practices',
       source: 'rstackjs/agent-skills',
     },
     {
       value: 'rspress-custom-theme',
-      label: 'Rspress custom theme',
+      label: 'rspress-custom-theme',
       source: 'rstackjs/agent-skills',
       when: ({ templateName }) => templateName.endsWith('-theme'),
     },
     {
       value: 'rspress-description-generator',
-      label: 'Rspress description generator',
+      label: 'rspress-description-generator',
       source: 'rstackjs/agent-skills',
     },
   ],


### PR DESCRIPTION
## Summary

Preserve the canonical hyphenated Agent Skill names in the optional skill prompt. This fixes all four Rspress skill labels so the displayed names match the skills that are installed.

## Related Issue

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).