### PR TITLE
fix(create-rspress): add TypeScript dependency to templates

### DIFF
--- a/packages/create-rspress/template-common/package.json
+++ b/packages/create-rspress/template-common/package.json
@@ -16,6 +16,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "react": "^19.2.7",
-    "react-dom": "^19.2.7"
+    "react-dom": "^19.2.7",
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/create-rspress/tests/cli-scaffold.test.ts
+++ b/packages/create-rspress/tests/cli-scaffold.test.ts
@@ -37,6 +37,7 @@ describe('create-rspress CLI scaffold', () => {
       expect(packageJson.scripts.dev).toBe('rspress dev');
       expect(packageJson.scripts.lint).toBe('rslint');
       expect(packageJson.devDependencies['@rslint/core']).toBeTruthy();
+      expect(packageJson.devDependencies.typescript).toBeTruthy();
       expect(existsSync(path.join(projectDir, 'theme/index.tsx'))).toBe(false);
 
       const rslintConfig = readFileSync(


### PR DESCRIPTION
## Summary

The initial create-rspress templates include TypeScript configuration but omit TypeScript itself, so generated projects do not have a local TypeScript toolchain. This PR adds TypeScript to the shared template devDependencies and covers the generated package manifest with a scaffold regression assertion.

## Related Issue

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).