### PR TITLE
feat(theme/Llms): add injectLlmsHint option to guide LLMs to Markdown

### DIFF
--- a/e2e/fixtures/plugin-llms/index.test.ts
+++ b/e2e/fixtures/plugin-llms/index.test.ts
@@ -76,9 +76,7 @@ test.describe('plugin-llms', async () => {
       path.resolve(appDir, 'doc_build', 'index.html'),
       'utf-8',
     );
-    expect(indexHtml).toContain(
-      '<div style="display:none" hidden="" aria-hidden="true">Are you an LLM? View https://example.com/docs/llms.txt for optimized Markdown documentation, or https://example.com/docs/llms-full.txt for full documentation bundle. This page is also available as Markdown at https://example.com/docs/index.md</div>',
-    );
+    expect(indexHtml).not.toContain('Are you an LLM?');
   });
 
   test('should order llms.txt entries according to _meta.json', async () => {

--- a/e2e/fixtures/plugin-llms/index.test.ts
+++ b/e2e/fixtures/plugin-llms/index.test.ts
@@ -77,7 +77,7 @@ test.describe('plugin-llms', async () => {
       'utf-8',
     );
     expect(indexHtml).toContain(
-      '<div style="display:none" hidden="" aria-hidden="true">Are you an LLM? View https://example.com/docs/llms.txt for optimized Markdown documentation, or https://example.com/docs/llms-full.txt for full documentation bundle</div>',
+      '<div style="display:none" hidden="" aria-hidden="true">Are you an LLM? View https://example.com/docs/llms.txt for optimized Markdown documentation, or https://example.com/docs/llms-full.txt for full documentation bundle. This page is also available as Markdown at https://example.com/docs/index.md</div>',
     );
   });
 

--- a/e2e/fixtures/plugin-llms/index.test.ts
+++ b/e2e/fixtures/plugin-llms/index.test.ts
@@ -71,6 +71,14 @@ test.describe('plugin-llms', async () => {
     expect(llmsFullTxt).toContain(
       'url: https://example.com/docs/api/commands.md',
     );
+
+    const indexHtml = await readFile(
+      path.resolve(appDir, 'doc_build', 'index.html'),
+      'utf-8',
+    );
+    expect(indexHtml).toContain(
+      '<div style="display:none" hidden="" aria-hidden="true">Are you an LLM? View https://example.com/docs/llms.txt for optimized Markdown documentation, or https://example.com/docs/llms-full.txt for full documentation bundle</div>',
+    );
   });
 
   test('should order llms.txt entries according to _meta.json', async () => {

--- a/e2e/fixtures/plugin-llms/index.test.ts
+++ b/e2e/fixtures/plugin-llms/index.test.ts
@@ -71,12 +71,6 @@ test.describe('plugin-llms', async () => {
     expect(llmsFullTxt).toContain(
       'url: https://example.com/docs/api/commands.md',
     );
-
-    const indexHtml = await readFile(
-      path.resolve(appDir, 'doc_build', 'index.html'),
-      'utf-8',
-    );
-    expect(indexHtml).not.toContain('Are you an LLM?');
   });
 
   test('should order llms.txt entries according to _meta.json', async () => {

--- a/e2e/fixtures/ssg-md/index.test.ts
+++ b/e2e/fixtures/ssg-md/index.test.ts
@@ -51,7 +51,7 @@ test('llms should be successful', async () => {
   expect(indexHtml).toContain('hidden=""');
   expect(indexHtml).toContain('aria-hidden="true"');
   expect(indexHtml).toContain(
-    'Are you an LLM? View https://example.com/docs/llms.txt for optimized Markdown documentation, or https://example.com/docs/llms-full.txt for full documentation bundle',
+    'Are you an LLM? View https://example.com/docs/llms.txt for optimized Markdown documentation, or https://example.com/docs/llms-full.txt for full documentation bundle. This page is also available as Markdown at https://example.com/docs/index.md',
   );
 });
 

--- a/e2e/fixtures/ssg-md/index.test.ts
+++ b/e2e/fixtures/ssg-md/index.test.ts
@@ -42,6 +42,17 @@ test('llms should be successful', async () => {
   expect(llmsTxt).toContain(
     '- [tsx-page](https://example.com/docs/tsx-page.md)',
   );
+
+  const indexHtml = await fs.readFile(
+    path.join(docBuildDir, 'index.html'),
+    'utf-8',
+  );
+  expect(indexHtml).toContain('style="display:none"');
+  expect(indexHtml).toContain('hidden=""');
+  expect(indexHtml).toContain('aria-hidden="true"');
+  expect(indexHtml).toContain(
+    'Are you an LLM? View https://example.com/docs/llms.txt for optimized Markdown documentation, or https://example.com/docs/llms-full.txt for full documentation bundle',
+  );
 });
 
 test('custom llms.txt renderer should be successful', async () => {
@@ -70,4 +81,15 @@ test('custom llms.txt renderer should be successful', async () => {
 test('csr should be successful', async () => {
   const appDir = import.meta.dirname;
   await runBuildCommand(appDir, 'rspress-csr.config.ts');
+});
+
+test('llms hidden hint should be configurable', async () => {
+  const appDir = import.meta.dirname;
+  await runBuildCommand(appDir, 'rspress-no-llms-hint.config.ts');
+
+  const indexHtml = await fs.readFile(
+    path.join(appDir, 'doc_build', 'index.html'),
+    'utf-8',
+  );
+  expect(indexHtml).not.toContain('Are you an LLM?');
 });

--- a/e2e/fixtures/ssg-md/rspress-no-llms-hint.config.ts
+++ b/e2e/fixtures/ssg-md/rspress-no-llms-hint.config.ts
@@ -5,7 +5,7 @@ export default {
   themeConfig: {
     ...baseConfig.themeConfig,
     llmsUI: {
-      injectLlmHint: false,
+      injectLlmsHint: false,
     },
   },
 };

--- a/e2e/fixtures/ssg-md/rspress-no-llms-hint.config.ts
+++ b/e2e/fixtures/ssg-md/rspress-no-llms-hint.config.ts
@@ -1,0 +1,11 @@
+import baseConfig from './rspress.config';
+
+export default {
+  ...baseConfig,
+  themeConfig: {
+    ...baseConfig.themeConfig,
+    llmsUI: {
+      injectLlmHint: false,
+    },
+  },
+};

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -30,6 +30,7 @@ const COMMON_EXTERNALS = [
   '@types/react',
   '@rspress/core/runtime',
   '@rspress/core/theme',
+  '@rspress/core/theme-original',
   '@rspress/core/shiki-transformers',
   '@rspress/shared',
   // react

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -39,7 +39,7 @@ const COMMON_EXTERNALS = [
   'react-router-dom',
 ];
 
-// Keep import.meta.env.SSG_MD for the final Rspress app build to replace.
+// Keep internal import.meta.env flags for the final Rspress app build to replace.
 const PRESERVE_IMPORT_META_ENV = {
   'import.meta.env': 'import.meta.env',
 };

--- a/packages/core/src/env.d.ts
+++ b/packages/core/src/env.d.ts
@@ -1,6 +1,8 @@
 /// <reference types='@rslib/core/types' />
 
 interface ImportMetaEnv {
+  readonly ENABLE_LLMS_HINT: boolean;
+  readonly ENABLE_LLMS_UI: boolean;
   readonly SSG_MD: boolean;
 }
 

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -107,6 +107,11 @@ async function createInternalBuildConfig(
   const outDir = config?.outDir ?? OUTPUT_DIR;
 
   const base = config?.base ?? '/';
+  const llmsUI = config.themeConfig?.llmsUI;
+  const enableLlmsUI = Boolean(llmsUI ?? config.llms);
+  const enableLlmsHint =
+    enableLlmsUI &&
+    (typeof llmsUI !== 'object' || llmsUI.injectLlmHint !== false);
 
   // In production, we need to add assetPrefix in asset path
   const assetPrefix = isProduction()
@@ -282,9 +287,8 @@ async function createInternalBuildConfig(
       include: [PACKAGE_ROOT],
       define: {
         'process.env.TEST': JSON.stringify(process.env.TEST),
-        'process.env.ENABLE_LLMS_UI': JSON.stringify(
-          Boolean(config.themeConfig?.llmsUI ?? config.llms),
-        ),
+        'import.meta.env.ENABLE_LLMS_UI': JSON.stringify(enableLlmsUI),
+        'import.meta.env.ENABLE_LLMS_HINT': JSON.stringify(enableLlmsHint),
       },
     },
     performance: {

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -111,7 +111,7 @@ async function createInternalBuildConfig(
   const enableLlmsUI = Boolean(llmsUI ?? config.llms);
   const enableLlmsHint =
     enableLlmsUI &&
-    (typeof llmsUI !== 'object' || llmsUI.injectLlmHint !== false);
+    (typeof llmsUI !== 'object' || llmsUI.injectLlmsHint !== false);
 
   // In production, we need to add assetPrefix in asset path
   const assetPrefix = isProduction()

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -109,7 +109,7 @@ async function createInternalBuildConfig(
 
   const base = config?.base ?? '/';
   const enableLlmsUI = isLlmsUIEnabled(config);
-  const enableLlmsHint = isLlmsHintEnabled(config);
+  const enableLlmsHint = isLlmsHintEnabled(config, enableSSG);
 
   // In production, we need to add assetPrefix in asset path
   const assetPrefix = isProduction()

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -39,6 +39,7 @@ import {
   hintBuilderPluginsBreakingChange,
   hintThemeBreakingChange,
 } from './logger/hint';
+import { isLlmsHintEnabled, isLlmsUIEnabled } from './llms';
 import type { PluginDriver } from './PluginDriver';
 import type { RouteService } from './route/RouteService';
 import { globalStylesVMPlugin } from './runtimeModule/globalStyles';
@@ -107,11 +108,8 @@ async function createInternalBuildConfig(
   const outDir = config?.outDir ?? OUTPUT_DIR;
 
   const base = config?.base ?? '/';
-  const llmsUI = config.themeConfig?.llmsUI;
-  const enableLlmsUI = Boolean(llmsUI ?? config.llms);
-  const enableLlmsHint =
-    enableLlmsUI &&
-    (typeof llmsUI !== 'object' || llmsUI.injectLlmsHint !== false);
+  const enableLlmsUI = isLlmsUIEnabled(config);
+  const enableLlmsHint = isLlmsHintEnabled(config);
 
   // In production, we need to add assetPrefix in asset path
   const assetPrefix = isProduction()

--- a/packages/core/src/node/llms.test.ts
+++ b/packages/core/src/node/llms.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from '@rstest/core';
+import {
+  isLlmsHintEnabled,
+  isLlmsUIEnabled,
+  renderLlmsHiddenHint,
+} from './llms';
+
+describe('LLMS UI build config', () => {
+  it('allows llmsUI false to override llms', () => {
+    const config = {
+      llms: true,
+      themeConfig: {
+        llmsUI: false,
+      },
+    };
+
+    expect(isLlmsUIEnabled(config)).toBe(false);
+    expect(isLlmsHintEnabled(config)).toBe(false);
+  });
+
+  it('allows the hidden hint to be disabled independently', () => {
+    expect(
+      isLlmsHintEnabled({
+        llms: true,
+        themeConfig: {
+          llmsUI: {
+            injectLlmsHint: false,
+          },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('renders the same hidden markup used by React SSR', () => {
+    expect(
+      renderLlmsHiddenHint({
+        base: '/docs/',
+        siteOrigin: 'https://example.com',
+        themeConfig: {
+          llmsUI: true,
+        },
+      }),
+    ).toBe(
+      '<div style="display:none" hidden="" aria-hidden="true">Are you an LLM? View https://example.com/docs/llms.txt for optimized Markdown documentation, or https://example.com/docs/llms-full.txt for full documentation bundle</div>',
+    );
+  });
+});

--- a/packages/core/src/node/llms.test.ts
+++ b/packages/core/src/node/llms.test.ts
@@ -33,15 +33,18 @@ describe('LLMS UI build config', () => {
 
   it('renders the same hidden markup used by React SSR', () => {
     expect(
-      renderLlmsHiddenHint({
-        base: '/docs/',
-        siteOrigin: 'https://example.com',
-        themeConfig: {
-          llmsUI: true,
+      renderLlmsHiddenHint(
+        {
+          base: '/docs/',
+          siteOrigin: 'https://example.com',
+          themeConfig: {
+            llmsUI: true,
+          },
         },
-      }),
+        '/guide/',
+      ),
     ).toBe(
-      '<div style="display:none" hidden="" aria-hidden="true">Are you an LLM? View https://example.com/docs/llms.txt for optimized Markdown documentation, or https://example.com/docs/llms-full.txt for full documentation bundle</div>',
+      '<div style="display:none" hidden="" aria-hidden="true">Are you an LLM? View https://example.com/docs/llms.txt for optimized Markdown documentation, or https://example.com/docs/llms-full.txt for full documentation bundle. This page is also available as Markdown at https://example.com/docs/guide/index.md</div>',
     );
   });
 });

--- a/packages/core/src/node/llms.test.ts
+++ b/packages/core/src/node/llms.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from '@rstest/core';
-import {
-  isLlmsHintEnabled,
-  isLlmsUIEnabled,
-  renderLlmsHiddenHint,
-} from './llms';
+import { isLlmsHintEnabled, isLlmsUIEnabled } from './llms';
 
 describe('LLMS UI build config', () => {
   it('allows llmsUI false to override llms', () => {
@@ -15,36 +11,43 @@ describe('LLMS UI build config', () => {
     };
 
     expect(isLlmsUIEnabled(config)).toBe(false);
-    expect(isLlmsHintEnabled(config)).toBe(false);
+    expect(isLlmsHintEnabled(config, true)).toBe(false);
   });
 
   it('allows the hidden hint to be disabled independently', () => {
     expect(
-      isLlmsHintEnabled({
-        llms: true,
-        themeConfig: {
-          llmsUI: {
-            injectLlmsHint: false,
+      isLlmsHintEnabled(
+        {
+          llms: true,
+          themeConfig: {
+            llmsUI: {
+              injectLlmsHint: false,
+            },
           },
         },
-      }),
+        true,
+      ),
     ).toBe(false);
   });
 
-  it('renders the same hidden markup used by React SSR', () => {
+  it('only enables the hidden hint for SSG builds', () => {
+    const config = {
+      llms: true,
+      themeConfig: {
+        llmsUI: true,
+      },
+    };
+
+    expect(isLlmsHintEnabled(config, true)).toBe(true);
+    expect(isLlmsHintEnabled(config, false)).toBe(false);
     expect(
-      renderLlmsHiddenHint(
+      isLlmsHintEnabled(
         {
-          base: '/docs/',
-          siteOrigin: 'https://example.com',
-          themeConfig: {
-            llmsUI: true,
-          },
+          ...config,
+          ssg: false,
         },
-        '/guide/',
+        true,
       ),
-    ).toBe(
-      '<div style="display:none" hidden="" aria-hidden="true">Are you an LLM? View https://example.com/docs/llms.txt for optimized Markdown documentation, or https://example.com/docs/llms-full.txt for full documentation bundle. This page is also available as Markdown at https://example.com/docs/guide/index.md</div>',
-    );
+    ).toBe(false);
   });
 });

--- a/packages/core/src/node/llms.ts
+++ b/packages/core/src/node/llms.ts
@@ -1,6 +1,7 @@
 import { withBase, withSiteOrigin, type UserConfig } from '@rspress/shared';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
+import { routePathToMdPath } from './ssg-md/llms/llmsTxt';
 
 export function isLlmsUIEnabled(config: UserConfig): boolean {
   return Boolean(config.themeConfig?.llmsUI ?? config.llms);
@@ -14,7 +15,10 @@ export function isLlmsHintEnabled(config: UserConfig): boolean {
   );
 }
 
-export function renderLlmsHiddenHint(config: UserConfig): string {
+export function renderLlmsHiddenHint(
+  config: UserConfig,
+  routePath: string,
+): string {
   if (!isLlmsHintEnabled(config)) {
     return '';
   }
@@ -28,12 +32,13 @@ export function renderLlmsHiddenHint(config: UserConfig): string {
     withBase('/llms-full.txt', base),
     config.siteOrigin,
   );
+  const pageMdUrl = routePathToMdPath(routePath, base, config.siteOrigin);
 
   return renderToStaticMarkup(
     createElement(
       'div',
       { style: { display: 'none' }, hidden: true, 'aria-hidden': 'true' },
-      `Are you an LLM? View ${llmsTxtUrl} for optimized Markdown documentation, or ${llmsFullTxtUrl} for full documentation bundle`,
+      `Are you an LLM? View ${llmsTxtUrl} for optimized Markdown documentation, or ${llmsFullTxtUrl} for full documentation bundle. This page is also available as Markdown at ${pageMdUrl}`,
     ),
   );
 }

--- a/packages/core/src/node/llms.ts
+++ b/packages/core/src/node/llms.ts
@@ -1,0 +1,39 @@
+import { withBase, withSiteOrigin, type UserConfig } from '@rspress/shared';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+export function isLlmsUIEnabled(config: UserConfig): boolean {
+  return Boolean(config.themeConfig?.llmsUI ?? config.llms);
+}
+
+export function isLlmsHintEnabled(config: UserConfig): boolean {
+  const llmsUI = config.themeConfig?.llmsUI;
+  return (
+    isLlmsUIEnabled(config) &&
+    (typeof llmsUI !== 'object' || llmsUI.injectLlmsHint !== false)
+  );
+}
+
+export function renderLlmsHiddenHint(config: UserConfig): string {
+  if (!isLlmsHintEnabled(config)) {
+    return '';
+  }
+
+  const base = config.base ?? '/';
+  const llmsTxtUrl = withSiteOrigin(
+    withBase('/llms.txt', base),
+    config.siteOrigin,
+  );
+  const llmsFullTxtUrl = withSiteOrigin(
+    withBase('/llms-full.txt', base),
+    config.siteOrigin,
+  );
+
+  return renderToStaticMarkup(
+    createElement(
+      'div',
+      { style: { display: 'none' }, hidden: true, 'aria-hidden': 'true' },
+      `Are you an LLM? View ${llmsTxtUrl} for optimized Markdown documentation, or ${llmsFullTxtUrl} for full documentation bundle`,
+    ),
+  );
+}

--- a/packages/core/src/node/llms.ts
+++ b/packages/core/src/node/llms.ts
@@ -1,44 +1,18 @@
-import { withBase, withSiteOrigin, type UserConfig } from '@rspress/shared';
-import { createElement } from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
-import { routePathToMdPath } from './ssg-md/llms/llmsTxt';
+import type { UserConfig } from '@rspress/shared';
 
 export function isLlmsUIEnabled(config: UserConfig): boolean {
   return Boolean(config.themeConfig?.llmsUI ?? config.llms);
 }
 
-export function isLlmsHintEnabled(config: UserConfig): boolean {
+export function isLlmsHintEnabled(
+  config: UserConfig,
+  enableSSG: boolean,
+): boolean {
   const llmsUI = config.themeConfig?.llmsUI;
   return (
+    enableSSG &&
+    config.ssg !== false &&
     isLlmsUIEnabled(config) &&
     (typeof llmsUI !== 'object' || llmsUI.injectLlmsHint !== false)
-  );
-}
-
-export function renderLlmsHiddenHint(
-  config: UserConfig,
-  routePath: string,
-): string {
-  if (!isLlmsHintEnabled(config)) {
-    return '';
-  }
-
-  const base = config.base ?? '/';
-  const llmsTxtUrl = withSiteOrigin(
-    withBase('/llms.txt', base),
-    config.siteOrigin,
-  );
-  const llmsFullTxtUrl = withSiteOrigin(
-    withBase('/llms-full.txt', base),
-    config.siteOrigin,
-  );
-  const pageMdUrl = routePathToMdPath(routePath, base, config.siteOrigin);
-
-  return renderToStaticMarkup(
-    createElement(
-      'div',
-      { style: { display: 'none' }, hidden: true, 'aria-hidden': 'true' },
-      `Are you an LLM? View ${llmsTxtUrl} for optimized Markdown documentation, or ${llmsFullTxtUrl} for full documentation bundle. This page is also available as Markdown at ${pageMdUrl}`,
-    ),
   );
 }

--- a/packages/core/src/node/ssg/renderPages.ts
+++ b/packages/core/src/node/ssg/renderPages.ts
@@ -4,6 +4,7 @@ import { logger } from '@rspress/shared/logger';
 import pMap from 'p-map';
 import picocolors from 'picocolors';
 
+import { renderLlmsHiddenHint } from '../llms';
 import { hintSSGFailed } from '../logger/hint';
 import type { RouteService } from '../route/RouteService';
 import {
@@ -66,7 +67,7 @@ export async function renderPages(
           csrRoutes.push(route);
           promiseList.push(
             renderCSRPage(
-              config.head,
+              config,
               route,
               htmlTemplate,
               alternateLinksByRoute,
@@ -178,7 +179,7 @@ export async function renderPages(
 }
 
 async function renderCSRPage(
-  head: UserConfig['head'],
+  config: UserConfig,
   route: RouteMeta,
   htmlTemplate: string,
   alternateLinksByRoute: AlternateLinksByRoute,
@@ -186,9 +187,9 @@ async function renderCSRPage(
 ) {
   const html = await renderHtmlTemplate(
     htmlTemplate,
-    head,
+    config.head,
     route,
-    '',
+    renderLlmsHiddenHint(config),
     alternateLinksByRoute[route.routePath] ?? [],
   );
   const fileName = routePath2HtmlFileName(route.routePath);
@@ -211,7 +212,7 @@ export async function renderCSRPages(
   await Promise.all(
     routes.map(route => {
       return renderCSRPage(
-        config.head,
+        config,
         route,
         htmlTemplate,
         alternateLinksByRoute,

--- a/packages/core/src/node/ssg/renderPages.ts
+++ b/packages/core/src/node/ssg/renderPages.ts
@@ -4,7 +4,6 @@ import { logger } from '@rspress/shared/logger';
 import pMap from 'p-map';
 import picocolors from 'picocolors';
 
-import { renderLlmsHiddenHint } from '../llms';
 import { hintSSGFailed } from '../logger/hint';
 import type { RouteService } from '../route/RouteService';
 import {
@@ -67,7 +66,7 @@ export async function renderPages(
           csrRoutes.push(route);
           promiseList.push(
             renderCSRPage(
-              config,
+              config.head,
               route,
               htmlTemplate,
               alternateLinksByRoute,
@@ -179,7 +178,7 @@ export async function renderPages(
 }
 
 async function renderCSRPage(
-  config: UserConfig,
+  head: UserConfig['head'],
   route: RouteMeta,
   htmlTemplate: string,
   alternateLinksByRoute: AlternateLinksByRoute,
@@ -187,9 +186,9 @@ async function renderCSRPage(
 ) {
   const html = await renderHtmlTemplate(
     htmlTemplate,
-    config.head,
+    head,
     route,
-    renderLlmsHiddenHint(config, route.routePath),
+    '',
     alternateLinksByRoute[route.routePath] ?? [],
   );
   const fileName = routePath2HtmlFileName(route.routePath);
@@ -212,7 +211,7 @@ export async function renderCSRPages(
   await Promise.all(
     routes.map(route => {
       return renderCSRPage(
-        config,
+        config.head,
         route,
         htmlTemplate,
         alternateLinksByRoute,

--- a/packages/core/src/node/ssg/renderPages.ts
+++ b/packages/core/src/node/ssg/renderPages.ts
@@ -189,7 +189,7 @@ async function renderCSRPage(
     htmlTemplate,
     config.head,
     route,
-    renderLlmsHiddenHint(config),
+    renderLlmsHiddenHint(config, route.routePath),
     alternateLinksByRoute[route.routePath] ?? [],
   );
   const fileName = routePath2HtmlFileName(route.routePath);

--- a/packages/core/src/runtime/App.test.tsx
+++ b/packages/core/src/runtime/App.test.tsx
@@ -31,6 +31,12 @@ rs.mock('@rspress/core/theme', () => ({
   Root: ({ children }: { children: ReactNode }) => children,
 }));
 
+rs.mock('@rspress/core/theme-original', () => ({
+  Layout: () => 'Layout content',
+  LlmsHiddenHint: () => 'LLMS hidden hint',
+  Root: ({ children }: { children: ReactNode }) => children,
+}));
+
 rs.mock('virtual-global-components', () => ({
   default: [() => 'Global component'],
 }));

--- a/packages/core/src/runtime/App.test.tsx
+++ b/packages/core/src/runtime/App.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, rs } from '@rstest/core';
 import { createContext, type ReactNode } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { renderToMarkdownString } from 'react-render-to-markdown';
 import { PageContext } from '@rspress/core/runtime';
 import { App } from './App';
@@ -26,6 +27,7 @@ rs.mock('@rspress/core/runtime', () => ({
 
 rs.mock('@rspress/core/theme', () => ({
   Layout: () => 'Layout content',
+  LlmsHiddenHint: () => 'LLMS hidden hint',
   Root: ({ children }: { children: ReactNode }) => children,
 }));
 
@@ -40,23 +42,45 @@ rs.mock('./initPageData', () => ({
 }));
 
 const originalSsgMd = import.meta.env.SSG_MD;
+const originalEnableLlmsHint = import.meta.env.ENABLE_LLMS_HINT;
 
-const setSsgMd = (value: boolean | undefined) => {
+const setImportMetaEnv = (
+  key: 'ENABLE_LLMS_HINT' | 'SSG_MD',
+  value: boolean | undefined,
+) => {
   if (value === undefined) {
-    delete (import.meta.env as unknown as Record<string, unknown>).SSG_MD;
+    delete (import.meta.env as unknown as Record<string, unknown>)[key];
     return;
   }
 
-  (import.meta.env as unknown as Record<string, unknown>).SSG_MD = value;
+  (import.meta.env as unknown as Record<string, unknown>)[key] = value;
 };
 
 afterEach(() => {
-  setSsgMd(originalSsgMd);
+  setImportMetaEnv('SSG_MD', originalSsgMd);
+  setImportMetaEnv('ENABLE_LLMS_HINT', originalEnableLlmsHint);
 });
 
 describe('App', () => {
+  it('renders a hidden LLM hint when ENABLE_LLMS_HINT is enabled', () => {
+    setImportMetaEnv('ENABLE_LLMS_HINT', true);
+
+    const html = renderToStaticMarkup(<App />);
+
+    expect(html).toContain('LLMS hidden hint');
+    expect(html.indexOf('LLMS hidden hint')).toBeLessThan(
+      html.indexOf('Layout content'),
+    );
+  });
+
+  it('does not render the LLM hint when it is disabled', () => {
+    setImportMetaEnv('ENABLE_LLMS_HINT', undefined);
+
+    expect(renderToStaticMarkup(<App />)).not.toContain('LLMS hidden hint');
+  });
+
   it('omits global UI components when SSG_MD is enabled', async () => {
-    setSsgMd(true);
+    setImportMetaEnv('SSG_MD', true);
 
     expect(
       await renderToMarkdownString(

--- a/packages/core/src/runtime/App.tsx
+++ b/packages/core/src/runtime/App.tsx
@@ -1,5 +1,5 @@
 import { PageContext, useLocation } from '@rspress/core/runtime';
-import { Layout, Root } from '@rspress/core/theme';
+import { Layout, LlmsHiddenHint, Root } from '@rspress/core/theme';
 import React, { useContext, useLayoutEffect } from 'react';
 import globalComponents from 'virtual-global-components';
 import {
@@ -58,6 +58,7 @@ export function App() {
 
   return (
     <Root>
+      {import.meta.env.ENABLE_LLMS_HINT && <LlmsHiddenHint />}
       <Layout />
       {
         // Global UI

--- a/packages/core/src/runtime/App.tsx
+++ b/packages/core/src/runtime/App.tsx
@@ -1,5 +1,6 @@
 import { PageContext, useLocation } from '@rspress/core/runtime';
-import { Layout, LlmsHiddenHint, Root } from '@rspress/core/theme';
+import { Layout, Root } from '@rspress/core/theme';
+import { LlmsHiddenHint } from '@rspress/core/theme-original';
 import React, { useContext, useLayoutEffect } from 'react';
 import globalComponents from 'virtual-global-components';
 import {

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -42,4 +42,5 @@ export {
   removeTrailingSlash,
   routePathToMdPath,
   withBase,
+  withSiteOrigin,
 } from './utils';

--- a/packages/core/src/runtime/utils.test.ts
+++ b/packages/core/src/runtime/utils.test.ts
@@ -1,12 +1,21 @@
 import { describe, expect, it, rs } from '@rstest/core';
-import { routePathToMdPath } from './utils';
+import { routePathToMdPath, withSiteOrigin } from './utils';
 
 rs.mock('virtual-site-data', () => {
   return {
     default: {
       base: '/',
+      siteOrigin: 'https://example.com',
     },
   };
+});
+
+describe('withSiteOrigin', () => {
+  it('should prepend the configured site origin', () => {
+    expect(withSiteOrigin('/docs/llms.txt')).toBe(
+      'https://example.com/docs/llms.txt',
+    );
+  });
 });
 
 describe('routePathToMdPath', () => {

--- a/packages/core/src/runtime/utils.ts
+++ b/packages/core/src/runtime/utils.ts
@@ -7,6 +7,7 @@ import {
   normalizeHref,
   removeBase as rawRemoveBase,
   withBase as rawWithBase,
+  withSiteOrigin as rawWithSiteOrigin,
   removeHash,
   removeTrailingSlash,
 } from '@rspress/shared';
@@ -14,6 +15,10 @@ import siteData from 'virtual-site-data';
 
 function withBase(url = '/'): string {
   return rawWithBase(url, siteData.base);
+}
+
+function withSiteOrigin(url: string): string {
+  return rawWithSiteOrigin(url, siteData.siteOrigin);
 }
 
 function removeBase(url: string): string {
@@ -77,4 +82,5 @@ export {
   removeTrailingSlash,
   routePathToMdPath,
   withBase,
+  withSiteOrigin,
 };

--- a/packages/core/src/theme/components/DocContent/docComponents/title.tsx
+++ b/packages/core/src/theme/components/DocContent/docComponents/title.tsx
@@ -25,7 +25,7 @@ export const H1 = (props: React.ComponentProps<'h1'>) => {
       <h1 className={clsx('rp-toc-include', className)} {...rest}>
         {children} <Tag tag={tag} />
       </h1>
-      {process.env.ENABLE_LLMS_UI && placement === 'title' && (
+      {import.meta.env.ENABLE_LLMS_UI && placement === 'title' && (
         <LlmsContainer>
           <LlmsCopyButton />
           <LlmsViewOptions />

--- a/packages/core/src/theme/components/Llms/LlmsHiddenHint.test.tsx
+++ b/packages/core/src/theme/components/Llms/LlmsHiddenHint.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it, rs } from '@rstest/core';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { LlmsHiddenHint } from './LlmsHiddenHint';
+
+rs.mock('@rspress/core/runtime', () => ({
+  withBase: (path: string) => `/docs${path}`,
+  withSiteOrigin: (path: string) => `https://example.com${path}`,
+}));
+
+describe('LlmsHiddenHint', () => {
+  it('renders hidden links to the LLM documentation files', () => {
+    const html = renderToStaticMarkup(<LlmsHiddenHint />);
+
+    expect(html).toContain('style="display:none"');
+    expect(html).toContain('hidden=""');
+    expect(html).toContain('aria-hidden="true"');
+    expect(html).toContain(
+      'Are you an LLM? View https://example.com/docs/llms.txt for optimized Markdown documentation, or https://example.com/docs/llms-full.txt for full documentation bundle',
+    );
+  });
+});

--- a/packages/core/src/theme/components/Llms/LlmsHiddenHint.test.tsx
+++ b/packages/core/src/theme/components/Llms/LlmsHiddenHint.test.tsx
@@ -3,6 +3,8 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { LlmsHiddenHint } from './LlmsHiddenHint';
 
 rs.mock('@rspress/core/runtime', () => ({
+  routePathToMdPath: (path: string) => `/docs${path}index.md`,
+  usePageData: () => ({ page: { routePath: '/guide/' } }),
   withBase: (path: string) => `/docs${path}`,
   withSiteOrigin: (path: string) => `https://example.com${path}`,
 }));
@@ -15,7 +17,7 @@ describe('LlmsHiddenHint', () => {
     expect(html).toContain('hidden=""');
     expect(html).toContain('aria-hidden="true"');
     expect(html).toContain(
-      'Are you an LLM? View https://example.com/docs/llms.txt for optimized Markdown documentation, or https://example.com/docs/llms-full.txt for full documentation bundle',
+      'Are you an LLM? View https://example.com/docs/llms.txt for optimized Markdown documentation, or https://example.com/docs/llms-full.txt for full documentation bundle. This page is also available as Markdown at https://example.com/docs/guide/index.md',
     );
   });
 });

--- a/packages/core/src/theme/components/Llms/LlmsHiddenHint.tsx
+++ b/packages/core/src/theme/components/Llms/LlmsHiddenHint.tsx
@@ -1,0 +1,12 @@
+import { withBase, withSiteOrigin } from '@rspress/core/runtime';
+
+export function LlmsHiddenHint() {
+  const llmsTxtUrl = withSiteOrigin(withBase('/llms.txt'));
+  const llmsFullTxtUrl = withSiteOrigin(withBase('/llms-full.txt'));
+
+  return (
+    <div style={{ display: 'none' }} hidden aria-hidden="true">
+      {`Are you an LLM? View ${llmsTxtUrl} for optimized Markdown documentation, or ${llmsFullTxtUrl} for full documentation bundle`}
+    </div>
+  );
+}

--- a/packages/core/src/theme/components/Llms/LlmsHiddenHint.tsx
+++ b/packages/core/src/theme/components/Llms/LlmsHiddenHint.tsx
@@ -1,12 +1,15 @@
 import { withBase, withSiteOrigin } from '@rspress/core/runtime';
+import { useMdUrl } from './useMdUrl';
 
 export function LlmsHiddenHint() {
+  const { pathname } = useMdUrl();
   const llmsTxtUrl = withSiteOrigin(withBase('/llms.txt'));
   const llmsFullTxtUrl = withSiteOrigin(withBase('/llms-full.txt'));
+  const pageMdUrl = withSiteOrigin(pathname);
 
   return (
     <div style={{ display: 'none' }} hidden aria-hidden="true">
-      {`Are you an LLM? View ${llmsTxtUrl} for optimized Markdown documentation, or ${llmsFullTxtUrl} for full documentation bundle`}
+      {`Are you an LLM? View ${llmsTxtUrl} for optimized Markdown documentation, or ${llmsFullTxtUrl} for full documentation bundle. This page is also available as Markdown at ${pageMdUrl}`}
     </div>
   );
 }

--- a/packages/core/src/theme/components/Llms/index.tsx
+++ b/packages/core/src/theme/components/Llms/index.tsx
@@ -1,5 +1,6 @@
 export { LlmsContainer, type LlmsContainerProps } from './LlmsContainer';
 export { LlmsCopyButton, type LlmsCopyButtonProps } from './LlmsCopyButton';
+export { LlmsHiddenHint } from './LlmsHiddenHint';
 export {
   LlmsViewOptions,
   type LlmsViewOptionsItem,

--- a/packages/core/src/theme/components/Outline/index.tsx
+++ b/packages/core/src/theme/components/Outline/index.tsx
@@ -33,7 +33,7 @@ export function Outline() {
       <div className="rp-outline__divider" />
       <div className="rp-outline__bottom">
         <EditLink isOutline />
-        {process.env.ENABLE_LLMS_UI && placement === 'outline' && (
+        {import.meta.env.ENABLE_LLMS_UI && placement === 'outline' && (
           <>
             <LlmsCopyRow />
             <LlmsOpenRow />

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -35,6 +35,7 @@ export {
   type LlmsContainerProps,
   LlmsCopyButton,
   type LlmsCopyButtonProps,
+  LlmsHiddenHint,
   LlmsViewOptions,
   type LlmsViewOptionsItem,
   type LlmsViewOptionsProps,

--- a/packages/shared/src/types/theme/index.ts
+++ b/packages/shared/src/types/theme/index.ts
@@ -18,8 +18,8 @@ export type LlmsViewOption = 'markdownLink' | 'chatgpt' | 'claude';
 export type LlmsUI =
   | {
       /**
-       * Whether to inject a hidden hint into HTML pages that points LLMs to
-       * llms.txt and llms-full.txt.
+       * Whether to inject a hidden hint into SSG HTML pages that points LLMs
+       * to llms.txt and llms-full.txt.
        * @default true
        */
       injectLlmsHint?: boolean;

--- a/packages/shared/src/types/theme/index.ts
+++ b/packages/shared/src/types/theme/index.ts
@@ -22,7 +22,7 @@ export type LlmsUI =
        * llms.txt and llms-full.txt.
        * @default true
        */
-      injectLlmHint?: boolean;
+      injectLlmsHint?: boolean;
       /**
        * Options for LlmsViewOptions component dropdown menu.
        * Set to `false` or an empty array to hide the view options UI.

--- a/packages/shared/src/types/theme/index.ts
+++ b/packages/shared/src/types/theme/index.ts
@@ -18,6 +18,12 @@ export type LlmsViewOption = 'markdownLink' | 'chatgpt' | 'claude';
 export type LlmsUI =
   | {
       /**
+       * Whether to inject a hidden hint into HTML pages that points LLMs to
+       * llms.txt and llms-full.txt.
+       * @default true
+       */
+      injectLlmHint?: boolean;
+      /**
        * Options for LlmsViewOptions component dropdown menu.
        * Set to `false` or an empty array to hide the view options UI.
        * @default ['markdownLink', 'chatgpt', 'claude']
@@ -153,8 +159,8 @@ export type ThemeConfig = {
   fallbackHeadingTitle?: boolean;
   /**
    * LLMS UI components configuration.
-   * When llmsUI.enableOnH1 is true, LlmsCopyButton and LlmsViewOptions
-   * will be automatically added below H1 headers.
+   * When enabled, LlmsCopyButton and LlmsViewOptions will be automatically
+   * added below H1 headers or to the outline sidebar.
    */
   llmsUI?: LlmsUI;
 };

--- a/website/docs/en/api/config/config-theme.mdx
+++ b/website/docs/en/api/config/config-theme.mdx
@@ -618,7 +618,7 @@ export default defineConfig({
 - **Type**: `boolean`
 - **Default**: `true`
 
-With [`siteOrigin`](/api/config/config-basic#siteorigin) set to `https://example.com`, this option controls whether to inject the following hidden hint into the generated HTML page for `/guide/`:
+With [`siteOrigin`](/api/config/config-basic#siteorigin) set to `https://example.com`, this option controls whether to inject the following hidden hint into the SSG-generated HTML page for `/guide/`:
 
 {/* prettier-ignore */}
 ```html
@@ -626,6 +626,8 @@ With [`siteOrigin`](/api/config/config-basic#siteorigin) set to `https://example
 ```
 
 The URLs automatically include the configured `siteOrigin` and [`base`](/api/config/config-basic#base). The page-specific Markdown URL is derived from the current route. Without `siteOrigin`, the URLs remain base-aware paths.
+
+The hint is only rendered during SSG. CSR output generated with `ssg: false` does not include it.
 
 Set `injectLlmsHint` to `false` to remove the hidden hint without disabling the visible LLMS UI components:
 

--- a/website/docs/en/api/config/config-theme.mdx
+++ b/website/docs/en/api/config/config-theme.mdx
@@ -620,12 +620,9 @@ export default defineConfig({
 
 With [`siteOrigin`](/api/config/config-basic#siteorigin) set to `https://example.com`, this option controls whether to inject the following hidden hint into generated HTML pages:
 
+<!-- prettier-ignore -->
 ```html
-<div style="display: none" hidden aria-hidden="true">
-  Are you an LLM? View https://example.com/llms.txt for optimized Markdown
-  documentation, or https://example.com/llms-full.txt for full documentation
-  bundle
-</div>
+<div style="display:none" hidden="" aria-hidden="true">Are you an LLM? View https://example.com/llms.txt for optimized Markdown documentation, or https://example.com/llms-full.txt for full documentation bundle</div>
 ```
 
 The URLs automatically include the configured `siteOrigin` and [`base`](/api/config/config-basic#base). Without `siteOrigin`, they remain base-aware paths.

--- a/website/docs/en/api/config/config-theme.mdx
+++ b/website/docs/en/api/config/config-theme.mdx
@@ -580,6 +580,7 @@ title: Document Title
 type LlmsUI =
   | boolean
   | {
+      injectLlmHint?: boolean;
       viewOptions?: false | Array<'markdownLink' | 'chatgpt' | 'claude'>;
       placement?: 'title' | 'outline';
     };
@@ -604,8 +605,41 @@ export default defineConfig({
   llms: true,
   themeConfig: {
     llmsUI: {
+      injectLlmHint: true,
       viewOptions: ['markdownLink', 'chatgpt', 'claude'],
       placement: 'outline',
+    },
+  },
+});
+```
+
+### injectLlmHint
+
+- **Type**: `boolean`
+- **Default**: `true`
+
+With [`siteOrigin`](/api/config/config-basic#siteorigin) set to `https://example.com`, this option controls whether to inject the following hidden hint into generated HTML pages:
+
+```html
+<div style="display: none" hidden aria-hidden="true">
+  Are you an LLM? View https://example.com/llms.txt for optimized Markdown
+  documentation, or https://example.com/llms-full.txt for full documentation
+  bundle
+</div>
+```
+
+The URLs automatically include the configured `siteOrigin` and [`base`](/api/config/config-basic#base). Without `siteOrigin`, they remain base-aware paths.
+
+Set `injectLlmHint` to `false` to remove the hidden hint without disabling the visible LLMS UI components:
+
+```ts title="rspress.config.ts"
+import { defineConfig } from '@rspress/core';
+
+export default defineConfig({
+  llms: true,
+  themeConfig: {
+    llmsUI: {
+      injectLlmHint: false,
     },
   },
 });

--- a/website/docs/en/api/config/config-theme.mdx
+++ b/website/docs/en/api/config/config-theme.mdx
@@ -618,7 +618,7 @@ export default defineConfig({
 - **Type**: `boolean`
 - **Default**: `true`
 
-This option controls whether a hidden hint is injected into generated HTML pages. The following example uses `https://example.com` as [`siteOrigin`](/api/config/config-basic#siteorigin) and shows the content injected for `/guide/`:
+This option controls whether a hidden hint is injected into generated HTML pages. Assuming [`siteOrigin`](/api/config/config-basic#siteorigin) is `https://example.com`, the following content is injected into the `/guide/` page:
 
 {/* prettier-ignore */}
 ```html

--- a/website/docs/en/api/config/config-theme.mdx
+++ b/website/docs/en/api/config/config-theme.mdx
@@ -580,7 +580,7 @@ title: Document Title
 type LlmsUI =
   | boolean
   | {
-      injectLlmHint?: boolean;
+      injectLlmsHint?: boolean;
       viewOptions?: false | Array<'markdownLink' | 'chatgpt' | 'claude'>;
       placement?: 'title' | 'outline';
     };
@@ -605,7 +605,7 @@ export default defineConfig({
   llms: true,
   themeConfig: {
     llmsUI: {
-      injectLlmHint: true,
+      injectLlmsHint: true,
       viewOptions: ['markdownLink', 'chatgpt', 'claude'],
       placement: 'outline',
     },
@@ -613,7 +613,7 @@ export default defineConfig({
 });
 ```
 
-### injectLlmHint
+### injectLlmsHint
 
 - **Type**: `boolean`
 - **Default**: `true`
@@ -630,7 +630,7 @@ With [`siteOrigin`](/api/config/config-basic#siteorigin) set to `https://example
 
 The URLs automatically include the configured `siteOrigin` and [`base`](/api/config/config-basic#base). Without `siteOrigin`, they remain base-aware paths.
 
-Set `injectLlmHint` to `false` to remove the hidden hint without disabling the visible LLMS UI components:
+Set `injectLlmsHint` to `false` to remove the hidden hint without disabling the visible LLMS UI components:
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from '@rspress/core';
@@ -639,7 +639,7 @@ export default defineConfig({
   llms: true,
   themeConfig: {
     llmsUI: {
-      injectLlmHint: false,
+      injectLlmsHint: false,
     },
   },
 });

--- a/website/docs/en/api/config/config-theme.mdx
+++ b/website/docs/en/api/config/config-theme.mdx
@@ -618,7 +618,7 @@ export default defineConfig({
 - **Type**: `boolean`
 - **Default**: `true`
 
-With [`siteOrigin`](/api/config/config-basic#siteorigin) set to `https://example.com`, this option controls whether to inject the following hidden hint into the generated HTML page for `/guide/`:
+This option controls whether a hidden hint is injected into generated HTML pages. The following example uses `https://example.com` as [`siteOrigin`](/api/config/config-basic#siteorigin) and shows the content injected for `/guide/`:
 
 {/* prettier-ignore */}
 ```html

--- a/website/docs/en/api/config/config-theme.mdx
+++ b/website/docs/en/api/config/config-theme.mdx
@@ -618,7 +618,7 @@ export default defineConfig({
 - **Type**: `boolean`
 - **Default**: `true`
 
-With [`siteOrigin`](/api/config/config-basic#siteorigin) set to `https://example.com`, this option controls whether to inject the following hidden hint into the SSG-generated HTML page for `/guide/`:
+With [`siteOrigin`](/api/config/config-basic#siteorigin) set to `https://example.com`, this option controls whether to inject the following hidden hint into the generated HTML page for `/guide/`:
 
 {/* prettier-ignore */}
 ```html
@@ -626,8 +626,6 @@ With [`siteOrigin`](/api/config/config-basic#siteorigin) set to `https://example
 ```
 
 The URLs automatically include the configured `siteOrigin` and [`base`](/api/config/config-basic#base). The page-specific Markdown URL is derived from the current route. Without `siteOrigin`, the URLs remain base-aware paths.
-
-The hint is only rendered during SSG. CSR output generated with `ssg: false` does not include it.
 
 Set `injectLlmsHint` to `false` to remove the hidden hint without disabling the visible LLMS UI components:
 

--- a/website/docs/en/api/config/config-theme.mdx
+++ b/website/docs/en/api/config/config-theme.mdx
@@ -618,14 +618,14 @@ export default defineConfig({
 - **Type**: `boolean`
 - **Default**: `true`
 
-With [`siteOrigin`](/api/config/config-basic#siteorigin) set to `https://example.com`, this option controls whether to inject the following hidden hint into generated HTML pages:
+With [`siteOrigin`](/api/config/config-basic#siteorigin) set to `https://example.com`, this option controls whether to inject the following hidden hint into the generated HTML page for `/guide/`:
 
 {/* prettier-ignore */}
 ```html
-<div style="display:none" hidden="" aria-hidden="true">Are you an LLM? View https://example.com/llms.txt for optimized Markdown documentation, or https://example.com/llms-full.txt for full documentation bundle</div>
+<div style="display:none" hidden="" aria-hidden="true">Are you an LLM? View https://example.com/llms.txt for optimized Markdown documentation, or https://example.com/llms-full.txt for full documentation bundle. This page is also available as Markdown at https://example.com/guide/index.md</div>
 ```
 
-The URLs automatically include the configured `siteOrigin` and [`base`](/api/config/config-basic#base). Without `siteOrigin`, they remain base-aware paths.
+The URLs automatically include the configured `siteOrigin` and [`base`](/api/config/config-basic#base). The page-specific Markdown URL is derived from the current route. Without `siteOrigin`, the URLs remain base-aware paths.
 
 Set `injectLlmsHint` to `false` to remove the hidden hint without disabling the visible LLMS UI components:
 

--- a/website/docs/en/api/config/config-theme.mdx
+++ b/website/docs/en/api/config/config-theme.mdx
@@ -620,7 +620,7 @@ export default defineConfig({
 
 With [`siteOrigin`](/api/config/config-basic#siteorigin) set to `https://example.com`, this option controls whether to inject the following hidden hint into generated HTML pages:
 
-<!-- prettier-ignore -->
+{/* prettier-ignore */}
 ```html
 <div style="display:none" hidden="" aria-hidden="true">Are you an LLM? View https://example.com/llms.txt for optimized Markdown documentation, or https://example.com/llms-full.txt for full documentation bundle</div>
 ```

--- a/website/docs/en/guide/basic/ssg-md.mdx
+++ b/website/docs/en/guide/basic/ssg-md.mdx
@@ -245,6 +245,7 @@ export default defineConfig({
     llmsUI: false,
     // Or customize options:
     // llmsUI: {
+    //   injectLlmHint: false, // Disable the hidden hint for LLMs
     //   viewOptions: ['markdownLink', 'chatgpt', 'claude'],
     //   placement: 'outline', // Display in outline panel instead of below H1
     // },

--- a/website/docs/en/guide/basic/ssg-md.mdx
+++ b/website/docs/en/guide/basic/ssg-md.mdx
@@ -245,7 +245,7 @@ export default defineConfig({
     llmsUI: false,
     // Or customize options:
     // llmsUI: {
-    //   injectLlmHint: false, // Disable the hidden hint for LLMs
+    //   injectLlmsHint: false, // Disable the hidden hint for LLMs
     //   viewOptions: ['markdownLink', 'chatgpt', 'claude'],
     //   placement: 'outline', // Display in outline panel instead of below H1
     // },

--- a/website/docs/en/plugin/official-plugins/llms.mdx
+++ b/website/docs/en/plugin/official-plugins/llms.mdx
@@ -54,7 +54,7 @@ export default defineConfig({
     llmsUI: true,
     // Or with custom options:
     // llmsUI: {
-    //   injectLlmHint: false, // Disable the hidden hint for LLMs
+    //   injectLlmsHint: false, // Disable the hidden hint for LLMs
     //   viewOptions: ['markdownLink', 'chatgpt', 'claude'],
     //   placement: 'outline', // Display in outline panel instead of below H1
     // },

--- a/website/docs/en/plugin/official-plugins/llms.mdx
+++ b/website/docs/en/plugin/official-plugins/llms.mdx
@@ -62,6 +62,8 @@ export default defineConfig({
 });
 ```
 
+The hidden hint points to the default `/llms.txt` and `/llms-full.txt` files. If you customize or disable either plugin output, set `injectLlmsHint` to `false`.
+
 #### Using custom theme
 
 If you need more control, you can use [custom theme](/guide/basic/custom-theme) to add a copy Markdown button.

--- a/website/docs/en/plugin/official-plugins/llms.mdx
+++ b/website/docs/en/plugin/official-plugins/llms.mdx
@@ -62,7 +62,7 @@ export default defineConfig({
 });
 ```
 
-When SSG is enabled, the hidden hint points to the default `/llms.txt` and `/llms-full.txt` files. If you customize or disable either plugin output, set `injectLlmsHint` to `false`. The hint is not rendered in CSR output.
+The hidden hint points to the default `/llms.txt` and `/llms-full.txt` files. If you customize or disable either plugin output, set `injectLlmsHint` to `false`.
 
 #### Using custom theme
 

--- a/website/docs/en/plugin/official-plugins/llms.mdx
+++ b/website/docs/en/plugin/official-plugins/llms.mdx
@@ -54,6 +54,7 @@ export default defineConfig({
     llmsUI: true,
     // Or with custom options:
     // llmsUI: {
+    //   injectLlmHint: false, // Disable the hidden hint for LLMs
     //   viewOptions: ['markdownLink', 'chatgpt', 'claude'],
     //   placement: 'outline', // Display in outline panel instead of below H1
     // },

--- a/website/docs/en/plugin/official-plugins/llms.mdx
+++ b/website/docs/en/plugin/official-plugins/llms.mdx
@@ -62,8 +62,6 @@ export default defineConfig({
 });
 ```
 
-The hidden hint points to the default `/llms.txt` and `/llms-full.txt` files. If you customize or disable either plugin output, set `injectLlmsHint` to `false`.
-
 #### Using custom theme
 
 If you need more control, you can use [custom theme](/guide/basic/custom-theme) to add a copy Markdown button.

--- a/website/docs/en/plugin/official-plugins/llms.mdx
+++ b/website/docs/en/plugin/official-plugins/llms.mdx
@@ -62,7 +62,7 @@ export default defineConfig({
 });
 ```
 
-The hidden hint points to the default `/llms.txt` and `/llms-full.txt` files. If you customize or disable either plugin output, set `injectLlmsHint` to `false`.
+When SSG is enabled, the hidden hint points to the default `/llms.txt` and `/llms-full.txt` files. If you customize or disable either plugin output, set `injectLlmsHint` to `false`. The hint is not rendered in CSR output.
 
 #### Using custom theme
 

--- a/website/docs/zh/api/config/config-theme.mdx
+++ b/website/docs/zh/api/config/config-theme.mdx
@@ -568,7 +568,7 @@ title: 文档标题
 type LlmsUI =
   | boolean
   | {
-      injectLlmHint?: boolean;
+      injectLlmsHint?: boolean;
       viewOptions?: false | Array<'markdownLink' | 'chatgpt' | 'claude'>;
       placement?: 'title' | 'outline';
     };
@@ -593,7 +593,7 @@ export default defineConfig({
   llms: true,
   themeConfig: {
     llmsUI: {
-      injectLlmHint: true,
+      injectLlmsHint: true,
       viewOptions: ['markdownLink', 'chatgpt', 'claude'],
       placement: 'outline',
     },
@@ -601,7 +601,7 @@ export default defineConfig({
 });
 ```
 
-### injectLlmHint
+### injectLlmsHint
 
 - **类型**：`boolean`
 - **默认值**：`true`
@@ -618,7 +618,7 @@ export default defineConfig({
 
 其中的 URL 会自动包含配置的 `siteOrigin` 和 [`base`](/api/config/config-basic#base)。未配置 `siteOrigin` 时，则保留带 `base` 前缀的路径。
 
-将 `injectLlmHint` 设置为 `false`，可以仅移除隐藏提示，而不禁用可见的 LLMS UI 组件：
+将 `injectLlmsHint` 设置为 `false`，可以仅移除隐藏提示，而不禁用可见的 LLMS UI 组件：
 
 ```ts title="rspress.config.ts"
 import { defineConfig } from '@rspress/core';
@@ -627,7 +627,7 @@ export default defineConfig({
   llms: true,
   themeConfig: {
     llmsUI: {
-      injectLlmHint: false,
+      injectLlmsHint: false,
     },
   },
 });

--- a/website/docs/zh/api/config/config-theme.mdx
+++ b/website/docs/zh/api/config/config-theme.mdx
@@ -606,14 +606,14 @@ export default defineConfig({
 - **类型**：`boolean`
 - **默认值**：`true`
 
-当 [`siteOrigin`](/api/config/config-basic#siteorigin) 设置为 `https://example.com` 时，此选项控制是否在生成的 HTML 页面中注入以下隐藏提示：
+当 [`siteOrigin`](/api/config/config-basic#siteorigin) 设置为 `https://example.com` 时，此选项控制是否在为 `/guide/` 生成的 HTML 页面中注入以下隐藏提示：
 
 {/* prettier-ignore */}
 ```html
-<div style="display:none" hidden="" aria-hidden="true">Are you an LLM? View https://example.com/llms.txt for optimized Markdown documentation, or https://example.com/llms-full.txt for full documentation bundle</div>
+<div style="display:none" hidden="" aria-hidden="true">Are you an LLM? View https://example.com/llms.txt for optimized Markdown documentation, or https://example.com/llms-full.txt for full documentation bundle. This page is also available as Markdown at https://example.com/guide/index.md</div>
 ```
 
-其中的 URL 会自动包含配置的 `siteOrigin` 和 [`base`](/api/config/config-basic#base)。未配置 `siteOrigin` 时，则保留带 `base` 前缀的路径。
+其中的 URL 会自动包含配置的 `siteOrigin` 和 [`base`](/api/config/config-basic#base)，当前页面的 Markdown URL 会根据当前路由生成。未配置 `siteOrigin` 时，则保留带 `base` 前缀的路径。
 
 将 `injectLlmsHint` 设置为 `false`，可以仅移除隐藏提示，而不禁用可见的 LLMS UI 组件：
 

--- a/website/docs/zh/api/config/config-theme.mdx
+++ b/website/docs/zh/api/config/config-theme.mdx
@@ -606,7 +606,7 @@ export default defineConfig({
 - **类型**：`boolean`
 - **默认值**：`true`
 
-当 [`siteOrigin`](/api/config/config-basic#siteorigin) 设置为 `https://example.com` 时，此选项控制是否在为 `/guide/` 生成的 HTML 页面中注入以下隐藏提示：
+此选项用于控制是否在生成的 HTML 页面中注入隐藏提示。以下示例将 `https://example.com` 作为 [`siteOrigin`](/api/config/config-basic#siteorigin)，展示 `/guide/` 页面中注入的内容：
 
 {/* prettier-ignore */}
 ```html

--- a/website/docs/zh/api/config/config-theme.mdx
+++ b/website/docs/zh/api/config/config-theme.mdx
@@ -568,6 +568,7 @@ title: 文档标题
 type LlmsUI =
   | boolean
   | {
+      injectLlmHint?: boolean;
       viewOptions?: false | Array<'markdownLink' | 'chatgpt' | 'claude'>;
       placement?: 'title' | 'outline';
     };
@@ -592,8 +593,41 @@ export default defineConfig({
   llms: true,
   themeConfig: {
     llmsUI: {
+      injectLlmHint: true,
       viewOptions: ['markdownLink', 'chatgpt', 'claude'],
       placement: 'outline',
+    },
+  },
+});
+```
+
+### injectLlmHint
+
+- **类型**：`boolean`
+- **默认值**：`true`
+
+当 [`siteOrigin`](/api/config/config-basic#siteorigin) 设置为 `https://example.com` 时，此选项控制是否在生成的 HTML 页面中注入以下隐藏提示：
+
+```html
+<div style="display: none" hidden aria-hidden="true">
+  Are you an LLM? View https://example.com/llms.txt for optimized Markdown
+  documentation, or https://example.com/llms-full.txt for full documentation
+  bundle
+</div>
+```
+
+其中的 URL 会自动包含配置的 `siteOrigin` 和 [`base`](/api/config/config-basic#base)。未配置 `siteOrigin` 时，则保留带 `base` 前缀的路径。
+
+将 `injectLlmHint` 设置为 `false`，可以仅移除隐藏提示，而不禁用可见的 LLMS UI 组件：
+
+```ts title="rspress.config.ts"
+import { defineConfig } from '@rspress/core';
+
+export default defineConfig({
+  llms: true,
+  themeConfig: {
+    llmsUI: {
+      injectLlmHint: false,
     },
   },
 });

--- a/website/docs/zh/api/config/config-theme.mdx
+++ b/website/docs/zh/api/config/config-theme.mdx
@@ -606,7 +606,7 @@ export default defineConfig({
 - **类型**：`boolean`
 - **默认值**：`true`
 
-当 [`siteOrigin`](/api/config/config-basic#siteorigin) 设置为 `https://example.com` 时，此选项控制是否在为 `/guide/` 生成的 HTML 页面中注入以下隐藏提示：
+当 [`siteOrigin`](/api/config/config-basic#siteorigin) 设置为 `https://example.com` 时，此选项控制是否在 SSG 为 `/guide/` 生成的 HTML 页面中注入以下隐藏提示：
 
 {/* prettier-ignore */}
 ```html
@@ -614,6 +614,8 @@ export default defineConfig({
 ```
 
 其中的 URL 会自动包含配置的 `siteOrigin` 和 [`base`](/api/config/config-basic#base)，当前页面的 Markdown URL 会根据当前路由生成。未配置 `siteOrigin` 时，则保留带 `base` 前缀的路径。
+
+此提示仅在 SSG 期间渲染，通过 `ssg: false` 生成的 CSR 产物不会包含它。
 
 将 `injectLlmsHint` 设置为 `false`，可以仅移除隐藏提示，而不禁用可见的 LLMS UI 组件：
 

--- a/website/docs/zh/api/config/config-theme.mdx
+++ b/website/docs/zh/api/config/config-theme.mdx
@@ -608,7 +608,7 @@ export default defineConfig({
 
 当 [`siteOrigin`](/api/config/config-basic#siteorigin) 设置为 `https://example.com` 时，此选项控制是否在生成的 HTML 页面中注入以下隐藏提示：
 
-<!-- prettier-ignore -->
+{/* prettier-ignore */}
 ```html
 <div style="display:none" hidden="" aria-hidden="true">Are you an LLM? View https://example.com/llms.txt for optimized Markdown documentation, or https://example.com/llms-full.txt for full documentation bundle</div>
 ```

--- a/website/docs/zh/api/config/config-theme.mdx
+++ b/website/docs/zh/api/config/config-theme.mdx
@@ -608,12 +608,9 @@ export default defineConfig({
 
 当 [`siteOrigin`](/api/config/config-basic#siteorigin) 设置为 `https://example.com` 时，此选项控制是否在生成的 HTML 页面中注入以下隐藏提示：
 
+<!-- prettier-ignore -->
 ```html
-<div style="display: none" hidden aria-hidden="true">
-  Are you an LLM? View https://example.com/llms.txt for optimized Markdown
-  documentation, or https://example.com/llms-full.txt for full documentation
-  bundle
-</div>
+<div style="display:none" hidden="" aria-hidden="true">Are you an LLM? View https://example.com/llms.txt for optimized Markdown documentation, or https://example.com/llms-full.txt for full documentation bundle</div>
 ```
 
 其中的 URL 会自动包含配置的 `siteOrigin` 和 [`base`](/api/config/config-basic#base)。未配置 `siteOrigin` 时，则保留带 `base` 前缀的路径。

--- a/website/docs/zh/api/config/config-theme.mdx
+++ b/website/docs/zh/api/config/config-theme.mdx
@@ -606,7 +606,7 @@ export default defineConfig({
 - **类型**：`boolean`
 - **默认值**：`true`
 
-当 [`siteOrigin`](/api/config/config-basic#siteorigin) 设置为 `https://example.com` 时，此选项控制是否在 SSG 为 `/guide/` 生成的 HTML 页面中注入以下隐藏提示：
+当 [`siteOrigin`](/api/config/config-basic#siteorigin) 设置为 `https://example.com` 时，此选项控制是否在为 `/guide/` 生成的 HTML 页面中注入以下隐藏提示：
 
 {/* prettier-ignore */}
 ```html
@@ -614,8 +614,6 @@ export default defineConfig({
 ```
 
 其中的 URL 会自动包含配置的 `siteOrigin` 和 [`base`](/api/config/config-basic#base)，当前页面的 Markdown URL 会根据当前路由生成。未配置 `siteOrigin` 时，则保留带 `base` 前缀的路径。
-
-此提示仅在 SSG 期间渲染，通过 `ssg: false` 生成的 CSR 产物不会包含它。
 
 将 `injectLlmsHint` 设置为 `false`，可以仅移除隐藏提示，而不禁用可见的 LLMS UI 组件：
 

--- a/website/docs/zh/api/config/config-theme.mdx
+++ b/website/docs/zh/api/config/config-theme.mdx
@@ -606,7 +606,7 @@ export default defineConfig({
 - **类型**：`boolean`
 - **默认值**：`true`
 
-此选项用于控制是否在生成的 HTML 页面中注入隐藏提示。以下示例将 `https://example.com` 作为 [`siteOrigin`](/api/config/config-basic#siteorigin)，展示 `/guide/` 页面中注入的内容：
+此选项用于控制是否在生成的 HTML 页面中注入隐藏提示。假设 [`siteOrigin`](/api/config/config-basic#siteorigin) 是 `https://example.com`，会在 `/guide/` 页面中注入以下内容：
 
 {/* prettier-ignore */}
 ```html

--- a/website/docs/zh/guide/basic/ssg-md.mdx
+++ b/website/docs/zh/guide/basic/ssg-md.mdx
@@ -245,7 +245,7 @@ export default defineConfig({
     llmsUI: false,
     // 或自定义选项：
     // llmsUI: {
-    //   injectLlmHint: false, // 禁用面向大语言模型的隐藏提示
+    //   injectLlmsHint: false, // 禁用面向大语言模型的隐藏提示
     //   viewOptions: ['markdownLink', 'chatgpt', 'claude'],
     //   placement: 'outline', // 在大纲面板中显示而非 H1 下方
     // },

--- a/website/docs/zh/guide/basic/ssg-md.mdx
+++ b/website/docs/zh/guide/basic/ssg-md.mdx
@@ -245,6 +245,7 @@ export default defineConfig({
     llmsUI: false,
     // 或自定义选项：
     // llmsUI: {
+    //   injectLlmHint: false, // 禁用面向大语言模型的隐藏提示
     //   viewOptions: ['markdownLink', 'chatgpt', 'claude'],
     //   placement: 'outline', // 在大纲面板中显示而非 H1 下方
     // },

--- a/website/docs/zh/plugin/official-plugins/llms.mdx
+++ b/website/docs/zh/plugin/official-plugins/llms.mdx
@@ -54,7 +54,7 @@ export default defineConfig({
     llmsUI: true,
     // 或者使用自定义选项：
     // llmsUI: {
-    //   injectLlmHint: false, // 禁用面向大语言模型的隐藏提示
+    //   injectLlmsHint: false, // 禁用面向大语言模型的隐藏提示
     //   viewOptions: ['markdownLink', 'chatgpt', 'claude'],
     //   placement: 'outline', // 在大纲面板中显示而非 H1 下方
     // },

--- a/website/docs/zh/plugin/official-plugins/llms.mdx
+++ b/website/docs/zh/plugin/official-plugins/llms.mdx
@@ -62,7 +62,7 @@ export default defineConfig({
 });
 ```
 
-隐藏提示会指向默认的 `/llms.txt` 和 `/llms-full.txt` 文件。如果自定义或禁用了任一插件产物，请将 `injectLlmsHint` 设置为 `false`。
+启用 SSG 时，隐藏提示会指向默认的 `/llms.txt` 和 `/llms-full.txt` 文件。如果自定义或禁用了任一插件产物，请将 `injectLlmsHint` 设置为 `false`。CSR 产物不会渲染此提示。
 
 #### 使用自定义主题
 

--- a/website/docs/zh/plugin/official-plugins/llms.mdx
+++ b/website/docs/zh/plugin/official-plugins/llms.mdx
@@ -62,8 +62,6 @@ export default defineConfig({
 });
 ```
 
-隐藏提示会指向默认的 `/llms.txt` 和 `/llms-full.txt` 文件。如果自定义或禁用了任一插件产物，请将 `injectLlmsHint` 设置为 `false`。
-
 #### 使用自定义主题
 
 如果你需要更多控制，可以通过 [自定义主题](/guide/basic/custom-theme) 来添加复制 Markdown 按钮。

--- a/website/docs/zh/plugin/official-plugins/llms.mdx
+++ b/website/docs/zh/plugin/official-plugins/llms.mdx
@@ -62,7 +62,7 @@ export default defineConfig({
 });
 ```
 
-启用 SSG 时，隐藏提示会指向默认的 `/llms.txt` 和 `/llms-full.txt` 文件。如果自定义或禁用了任一插件产物，请将 `injectLlmsHint` 设置为 `false`。CSR 产物不会渲染此提示。
+隐藏提示会指向默认的 `/llms.txt` 和 `/llms-full.txt` 文件。如果自定义或禁用了任一插件产物，请将 `injectLlmsHint` 设置为 `false`。
 
 #### 使用自定义主题
 

--- a/website/docs/zh/plugin/official-plugins/llms.mdx
+++ b/website/docs/zh/plugin/official-plugins/llms.mdx
@@ -54,6 +54,7 @@ export default defineConfig({
     llmsUI: true,
     // 或者使用自定义选项：
     // llmsUI: {
+    //   injectLlmHint: false, // 禁用面向大语言模型的隐藏提示
     //   viewOptions: ['markdownLink', 'chatgpt', 'claude'],
     //   placement: 'outline', // 在大纲面板中显示而非 H1 下方
     // },

--- a/website/docs/zh/plugin/official-plugins/llms.mdx
+++ b/website/docs/zh/plugin/official-plugins/llms.mdx
@@ -62,6 +62,8 @@ export default defineConfig({
 });
 ```
 
+隐藏提示会指向默认的 `/llms.txt` 和 `/llms-full.txt` 文件。如果自定义或禁用了任一插件产物，请将 `injectLlmsHint` 设置为 `false`。
+
 #### 使用自定义主题
 
 如果你需要更多控制，可以通过 [自定义主题](/guide/basic/custom-theme) 来添加复制 Markdown 按钮。


### PR DESCRIPTION
## Summary

Adds `themeConfig.llmsUI.injectLlmsHint` (`boolean`, default: `true`) to control whether Rspress injects a hidden HTML hint that guides LLMs to the site's `llms.txt`, `llms-full.txt`, and the current page's Markdown URL.

Assuming `siteOrigin` is `https://example.com`, the following content is injected into the `/guide/` page:

```html
<div style="display:none" hidden="" aria-hidden="true">Are you an LLM? View https://example.com/llms.txt for optimized Markdown documentation, or https://example.com/llms-full.txt for full documentation bundle. This page is also available as Markdown at https://example.com/guide/index.md</div>
```

https://github.com/okineadev/vitepress-plugin-llms/blob/4b03853b9db5e5745f24b2a6ff82ddee872ba9e1/src/plugin/hooks.ts#L107-L120

## Related Issue

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
