### PR TITLE
chore(ci/rsdoctor): restore Rsdoctor diff comments

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -46,7 +46,7 @@ jobs:
           RSDOCTOR=1 pnpm run build
 
       - name: Report Compressed Size
-        uses: web-infra-dev/rsdoctor-action@96c3d1f7e1d2abf41c1203c3486364c9c4561b60 # main
+        uses: web-infra-dev/rsdoctor-action@bce0934b887cddb56986d16c34a445bcce9a7d65 # main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           file_path: 'website/doc_build/diff-rsdoctor/**/rsdoctor-data.json'


### PR DESCRIPTION
## Summary

The Rsdoctor diff workflow can complete successfully without posting a pull request comment because the pinned action may exit silently while extracting baseline artifacts.

This updates `rsdoctor-action` to the upstream fix that adds explicit ZIP extraction handling and restores diff comment generation.

## Related Issue

- https://github.com/web-infra-dev/rsdoctor-action/issues/56
- https://github.com/web-infra-dev/rsdoctor-action/pull/57

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).