### PR TITLE
Release v2.0.18

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/core",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "description": "The Rspress Documentation Framework",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {

--- a/packages/create-rspress/package.json
+++ b/packages/create-rspress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rspress",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "description": "Create a new Rspress project",
   "homepage": "https://rspress.rs",
   "repository": {

--- a/packages/plugin-algolia/package.json
+++ b/packages/plugin-algolia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/plugin-algolia",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "description": "A plugin for rspress to search with algolia in docs.",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {

--- a/packages/plugin-api-docgen/package.json
+++ b/packages/plugin-api-docgen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/plugin-api-docgen",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "description": "A plugin for rspress to generate api doc.",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {

--- a/packages/plugin-client-redirects/package.json
+++ b/packages/plugin-client-redirects/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/plugin-client-redirects",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "description": "A plugin for rspress to client redirect in docs.",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {

--- a/packages/plugin-llms/package.json
+++ b/packages/plugin-llms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/plugin-llms",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "description": "A plugin for rspress to generate llms.txt, llms-full.txt, md files to let llm understand your website.",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {

--- a/packages/plugin-playground/package.json
+++ b/packages/plugin-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/plugin-playground",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "description": "A plugin for rspress to preview the code block in markdown/mdx file.",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {

--- a/packages/plugin-preview/package.json
+++ b/packages/plugin-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/plugin-preview",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "description": "A plugin for rspress to preview the code block in markdown/mdx file.",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {

--- a/packages/plugin-rss/package.json
+++ b/packages/plugin-rss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/plugin-rss",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "description": "A plugin for rss generation for rspress",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {

--- a/packages/plugin-sitemap/package.json
+++ b/packages/plugin-sitemap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/plugin-sitemap",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "description": "A plugin for rspress to generate sitemap.xml",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {

--- a/packages/plugin-twoslash/package.json
+++ b/packages/plugin-twoslash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/plugin-twoslash",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "description": "A plugin for rspress to applies twoslash to code blocks.",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {

--- a/packages/plugin-typedoc/package.json
+++ b/packages/plugin-typedoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/plugin-typedoc",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "description": "A plugin for rspress to integrate typedoc",
   "bugs": "https://github.com/web-infra-dev/rspress/issues",
   "repository": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspress/shared",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/web-infra-dev/rspress.git",


### PR DESCRIPTION
## Summary

Prepare the `v2.0.18` patch release by bumping all 13 public Rspress packages from `2.0.17` to `2.0.18`.

## Related Issue

N/A

## Checklist

- [x] Tests updated (not required for version-only changes).
- [x] Documentation updated (not required for version-only changes).
