### PR TITLE
fix(plugin-playground): support HMR updates

### DIFF
--- a/e2e/fixtures/plugin-playground/index.test.ts
+++ b/e2e/fixtures/plugin-playground/index.test.ts
@@ -1,19 +1,27 @@
+import fs from 'node:fs/promises';
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 
+const DOC_FILE = new URL('./doc/index.mdx', import.meta.url);
+
 test.describe('plugin test', async () => {
+  test.describe.configure({ mode: 'serial' });
+
   let appPort;
   let app;
+  let originalContent: string;
   test.beforeAll(async () => {
     const appDir = import.meta.dirname;
     appPort = await getPort();
     app = await runDevCommand(appDir, appPort);
+    originalContent = await fs.readFile(DOC_FILE, 'utf-8');
   });
 
   test.afterAll(async () => {
     if (app) {
       await killProcess(app);
     }
+    await fs.writeFile(DOC_FILE, originalContent);
   });
 
   test('Should render the element', async ({ page }) => {
@@ -39,5 +47,23 @@ test.describe('plugin test', async () => {
     await expect(internalDemoCodePreviewDefault).toHaveCount(1);
     await expect(internalDemoCodePreviewVertical).toHaveCount(1);
     await expect(externalDemoCodePreview).toHaveCount(1);
+  });
+
+  test('Should update the rendered code through HMR', async ({ page }) => {
+    await page.goto(`http://localhost:${appPort}/`, {
+      waitUntil: 'networkidle',
+    });
+
+    const updatedContent = originalContent.replace(
+      'Hello World Internal (default)',
+      'Hello World Internal (updated)',
+    );
+    await fs.writeFile(DOC_FILE, updatedContent);
+
+    await expect(
+      page
+        .locator('.rp-playground > .rp-playground-runner > div')
+        .getByText('Hello World Internal (updated)'),
+    ).toHaveCount(1);
   });
 });

--- a/e2e/fixtures/plugin-playground/index.test.ts
+++ b/e2e/fixtures/plugin-playground/index.test.ts
@@ -18,10 +18,13 @@ test.describe('plugin test', async () => {
   });
 
   test.afterAll(async () => {
-    if (app) {
-      await killProcess(app);
+    try {
+      if (app) {
+        await killProcess(app);
+      }
+    } finally {
+      await fs.writeFile(DOC_FILE, originalContent);
     }
-    await fs.writeFile(DOC_FILE, originalContent);
   });
 
   test('Should render the element', async ({ page }) => {

--- a/packages/plugin-playground/static/global-components/Playground.tsx
+++ b/packages/plugin-playground/static/global-components/Playground.tsx
@@ -6,6 +6,7 @@ import {
   type HTMLAttributes,
   type ReactNode,
   useCallback,
+  useEffect,
   useState,
 } from 'react';
 
@@ -67,6 +68,9 @@ export default function Playground(props: PlaygroundProps) {
   const direction = useDirection(props);
 
   const [code, setCode] = useState(codeProp);
+  useEffect(() => {
+    setCode(codeProp);
+  }, [codeProp]);
 
   const handleCodeChange = useCallback((e?: string) => {
     setCode(e || '');


### PR DESCRIPTION
## Summary

This PR keeps plugin-playground previews in sync when fenced code changes through HMR. It updates the local editor and runner state when the generated code prop changes, and adds a serial E2E regression that safely edits and restores the shared MDX fixture.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).