### PR TITLE
feat(plugin-preview): support custom fixed iframe entries

### DIFF
--- a/.changeset/tidy-pandas-preview.md
+++ b/.changeset/tidy-pandas-preview.md
@@ -1,0 +1,5 @@
+---
+'@rspress/plugin-preview': minor
+---
+
+Support framework-independent custom entries for `iframe-fixed` previews, add route and demo metadata including external source paths to `customEntry`, and allow fixed preview sources to be hidden from document content with `preview-only`.

--- a/e2e/fixtures/plugin-preview-custom-entry/doc/guide/_component-fixed.vue
+++ b/e2e/fixtures/plugin-preview-custom-entry/doc/guide/_component-fixed.vue
@@ -1,0 +1,13 @@
+<template>
+  <div class="fixed-example">{{ message }}</div>
+</template>
+
+<script setup>
+import { message } from './_message';
+</script>
+
+<style scoped>
+.fixed-example {
+  color: blue;
+}
+</style>

--- a/e2e/fixtures/plugin-preview-custom-entry/doc/guide/_message.ts
+++ b/e2e/fixtures/plugin-preview-custom-entry/doc/guide/_message.ts
@@ -1,0 +1,1 @@
+export const message = 'Hello World VUE FIXED';

--- a/e2e/fixtures/plugin-preview-custom-entry/doc/guide/vue.mdx
+++ b/e2e/fixtures/plugin-preview-custom-entry/doc/guide/vue.mdx
@@ -5,3 +5,13 @@
 ```vue preview="iframe-follow" file="./_component.vue"
 
 ```
+
+## iframe-fixed
+
+```vue preview="iframe-fixed" preview-only file="./_component.vue"
+
+```
+
+```vue preview="iframe-fixed" preview-only file="./_component-fixed.vue"
+
+```

--- a/e2e/fixtures/plugin-preview-custom-entry/index.test.ts
+++ b/e2e/fixtures/plugin-preview-custom-entry/index.test.ts
@@ -49,10 +49,29 @@ test.describe('plugin test', async () => {
       waitUntil: 'networkidle',
     });
     const transformedCodePreview = await page
-      .frameLocator('iframe')
+      .frameLocator('.rp-preview iframe')
       .getByText('VUE')
       .innerText();
 
     expect(transformedCodePreview).toBe('Hello World VUE');
+
+    const fixedIframe = page.locator('.rp-fixed-device__iframe');
+    const fixedIframeBody = fixedIframe.contentFrame().locator('body');
+    await expect(fixedIframeBody).toContainText('Hello World VUE');
+    await expect(fixedIframeBody).toContainText('Hello World VUE FIXED');
+
+    const fixedEntry = fixedIframe.contentFrame().locator('.vue-fixed-entry');
+    await expect(fixedEntry).toHaveAttribute('data-route-path', '/guide/vue');
+    await expect(fixedEntry).toHaveAttribute('data-lang', 'en');
+
+    // The two fixed demos are preview-only and should not render code blocks.
+    await expect(page.locator('.rspress-doc > .rp-preview')).toHaveCount(1);
+
+    const mobileDemoLink = page.locator('.rp-fixed-device__mobile-link');
+    await expect(mobileDemoLink).toHaveAttribute('target', '_blank');
+    await expect(mobileDemoLink).toHaveAttribute(
+      'href',
+      /(?:\/~demo\/|:\d+\/)_guide_vue$/,
+    );
   });
 });

--- a/e2e/fixtures/plugin-preview-custom-entry/rspress.config.ts
+++ b/e2e/fixtures/plugin-preview-custom-entry/rspress.config.ts
@@ -8,7 +8,36 @@ export default defineConfig({
   plugins: [
     pluginPreview({
       iframeOptions: {
-        customEntry: ({ demoPath }) => {
+        customEntry: meta => {
+          const { demoPath } = meta;
+          if (meta.previewMode === 'iframe-fixed') {
+            const imports = meta.demos
+              .map(
+                (demo, index) =>
+                  `import Demo_${index} from ${JSON.stringify(
+                    demo.sourcePath ?? demo.demoPath,
+                  )};`,
+              )
+              .join('\n');
+            const children = meta.demos
+              .map((_demo, index) => `h(Demo_${index})`)
+              .join(', ');
+
+            return `
+import { createApp, h } from 'vue';
+${imports}
+const App = {
+  render() {
+    return h('div', {
+      class: 'vue-fixed-entry',
+      'data-route-path': ${JSON.stringify(meta.route.routePath)},
+      'data-lang': ${JSON.stringify(meta.route.lang)},
+    }, [${children}]);
+  },
+};
+createApp(App).mount('#root');
+`;
+          }
           if (demoPath.endsWith('.vue')) {
             return `
 import { createApp } from 'vue';

--- a/packages/plugin-preview/src/generateEntry.ts
+++ b/packages/plugin-preview/src/generateEntry.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { VIRTUAL_DEMO_DIR } from './constants';
-import type { CustomEntry, DemoInfo } from './types';
+import type { CustomEntry, CustomEntryDemo, DemoInfo } from './types';
 import { toValidVarName } from './utils';
 
 function reactEntry({ demoPath }: CustomEntry) {
@@ -11,6 +11,15 @@ function reactEntry({ demoPath }: CustomEntry) {
     const container = document.getElementById('root');
     createRoot(container).render(<Demo />);
     `;
+}
+
+function toCustomEntryDemo(demo: DemoInfo[string][number]): CustomEntryDemo {
+  return {
+    id: demo.id,
+    demoPath: demo.path,
+    sourcePath: demo.sourcePath,
+    title: demo.title,
+  };
 }
 
 export async function generateEntry(
@@ -39,9 +48,14 @@ export async function generateEntry(
         );
 
         const followPromiseList = followDemos.map(async demo => {
-          const { id, path: demoPath } = demo;
+          const { id, path: demoPath, route } = demo;
           const entry = join(VIRTUAL_DEMO_DIR, `${id}.entry.tsx`);
-          const entryContent = generateEntry({ demoPath });
+          const entryContent = generateEntry({
+            previewMode: 'iframe-follow',
+            demoPath,
+            demos: [toCustomEntryDemo(demo)],
+            route,
+          });
           await writeFile(entry, entryContent);
           sourceEntry[id] = entry;
         });
@@ -65,7 +79,7 @@ export async function generateEntry(
         function App() {
           return (
             <div className="rp-preview-container">
-              <div className="rp-preview-nav">{"${fixedDemos[0].title}"}</div>
+              <div className="rp-preview-nav">{${JSON.stringify(fixedDemos[0].title)}}</div>
               ${fixedDemos
                 .map((_demo, index) => {
                   return `<Demo_${index} />`;
@@ -79,7 +93,12 @@ export async function generateEntry(
 
           const id = `_${toValidVarName(pageName)}`;
           const demoPath = join(VIRTUAL_DEMO_DIR, `${id}.app.tsx`);
-          const entryContent = generateEntry({ demoPath });
+          const entryContent = generateEntry({
+            previewMode: 'iframe-fixed',
+            demoPath,
+            demos: fixedDemos.map(toCustomEntryDemo),
+            route: fixedDemos[0].route,
+          });
           const entry = join(VIRTUAL_DEMO_DIR, `${id}.entry.tsx`);
 
           await Promise.all([

--- a/packages/plugin-preview/src/index.ts
+++ b/packages/plugin-preview/src/index.ts
@@ -252,4 +252,9 @@ export function pluginPreview(options?: Options): RspressPlugin {
   };
 }
 
-export type { Options };
+export type {
+  CustomEntry,
+  CustomEntryDemo,
+  Options,
+  PreviewRouteMeta,
+} from './types';

--- a/packages/plugin-preview/src/parsePreviewInfoFromMeta.ts
+++ b/packages/plugin-preview/src/parsePreviewInfoFromMeta.ts
@@ -4,6 +4,7 @@ import type { Options } from './types';
 interface PreviewInfo {
   isPure: boolean;
   isPreview: boolean;
+  previewOnly: boolean;
   previewMode: Options['defaultPreviewMode'] | null;
 }
 
@@ -14,6 +15,7 @@ interface PreviewInfo {
  * - ```tsx preview="internal"
  * - ```tsx preview="iframe-fixed"
  * - ```tsx preview="iframe-follow"
+ * - ```tsx preview="iframe-fixed" preview-only
  * - ```tsx preview          (use defaultPreviewMode)
  * - ```tsx pure
  *
@@ -31,8 +33,11 @@ export function parsePreviewInfoFromMeta(options: {
   const result: PreviewInfo = {
     isPure: false,
     isPreview: false,
+    previewOnly: false,
     previewMode: null,
   };
+
+  result.previewOnly = /(?:^|\s)preview-only(?:\s|$)/.test(meta ?? '');
 
   // No meta string
   if (!meta) {

--- a/packages/plugin-preview/src/remarkPlugin.ts
+++ b/packages/plugin-preview/src/remarkPlugin.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { join } from 'node:path';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { isDeepStrictEqual } from 'node:util';
 import { normalizePosixPath } from '@rspress/core';
 import type { Code, Root } from 'mdast';
@@ -14,6 +14,17 @@ import { generateId, getLangFileExt } from './utils';
 
 export const globalDemos: DemoInfo = {};
 export const isDirtyRef = { current: false };
+
+function getSourcePath(meta: string | null | undefined, pagePath: string) {
+  const fileMatch = meta?.match(
+    /(?:^|\s)file=(?:"([^"]+)"|'([^']+)'|([^\s]+))/,
+  );
+  const filePath = fileMatch?.[1] || fileMatch?.[2] || fileMatch?.[3];
+  if (!filePath) {
+    return undefined;
+  }
+  return isAbsolute(filePath) ? filePath : resolve(dirname(pagePath), filePath);
+}
 
 /**
  * remark plugin to transform code to demo
@@ -47,9 +58,17 @@ export const remarkWriteCodeFile: Plugin<[RemarkPluginOptions], Root> =
 
       const demoMdxImports: MdxjsEsm[] = [];
       const demosInCurrPage: DemoInfo = { [pageName]: [] };
+      const previewRoute = {
+        pageName: route.pageName,
+        routePath: route.routePath,
+        pureRoutePath: route.pureRoutePath,
+        lang: route.lang,
+        version: route.version,
+      };
       function handleCodeBlockByPreviewMode(
         demoId: string,
         demoPath: string,
+        sourcePath: string | undefined,
         currentNode: Code,
         previewMode: Options['defaultPreviewMode'],
       ) {
@@ -58,7 +77,9 @@ export const remarkWriteCodeFile: Plugin<[RemarkPluginOptions], Root> =
             title,
             id: demoId,
             path: demoPath,
+            sourcePath,
             previewMode,
+            route: previewRoute,
           });
         } else {
           demoMdxImports.push(getASTNodeImport(`Demo${demoId}`, demoPath));
@@ -113,11 +134,13 @@ export const remarkWriteCodeFile: Plugin<[RemarkPluginOptions], Root> =
           return;
         }
         if (node.lang && previewLanguages.includes(node.lang)) {
-          const { isPure, previewMode } = parsePreviewInfoFromMeta({
-            meta: node.meta,
-            defaultPreviewMode,
-            defaultRenderMode,
-          });
+          const { isPure, previewMode, previewOnly } = parsePreviewInfoFromMeta(
+            {
+              meta: node.meta,
+              defaultPreviewMode,
+              defaultRenderMode,
+            },
+          );
 
           if (isPure || !previewMode) {
             return;
@@ -147,9 +170,19 @@ export const remarkWriteCodeFile: Plugin<[RemarkPluginOptions], Root> =
           handleCodeBlockByPreviewMode(
             id,
             virtualModulePath,
+            getSourcePath(node.meta, vfile.path || vfile.history[0]),
             node,
             previewMode,
           );
+
+          if (previewMode === 'iframe-fixed' && previewOnly) {
+            Object.assign(node, {
+              type: 'mdxJsxFlowElement',
+              name: null,
+              attributes: [],
+              children: [],
+            });
+          }
         }
       });
 

--- a/packages/plugin-preview/src/types.ts
+++ b/packages/plugin-preview/src/types.ts
@@ -50,9 +50,38 @@ export type IframeOptions = {
   customEntry?: (meta: CustomEntry) => string;
 };
 
-export interface CustomEntry {
+export type PreviewRouteMeta = Pick<
+  RouteMeta,
+  'pageName' | 'routePath' | 'pureRoutePath' | 'lang' | 'version'
+>;
+
+export interface CustomEntryDemo {
+  id: string;
   demoPath: string;
+  /** Absolute path of an external `file` code block. */
+  sourcePath?: string;
+  title: string;
 }
+
+interface CustomFollowEntry {
+  previewMode: 'iframe-follow';
+  demoPath: string;
+  demos: [CustomEntryDemo];
+  route: PreviewRouteMeta;
+}
+
+interface CustomFixedEntry {
+  previewMode: 'iframe-fixed';
+  /**
+   * The default framework-specific aggregate module. Custom fixed entries
+   * should normally import modules from `demos` instead.
+   */
+  demoPath: string;
+  demos: CustomEntryDemo[];
+  route: PreviewRouteMeta;
+}
+
+export type CustomEntry = CustomFollowEntry | CustomFixedEntry;
 
 export type RemarkPluginOptions = Required<
   Pick<
@@ -73,8 +102,10 @@ export type DemoInfo = Record<
   {
     id: string;
     path: string;
+    sourcePath?: string;
     title: string;
     previewMode: 'iframe-fixed' | 'iframe-follow';
+    route: PreviewRouteMeta;
   }[]
 >;
 

--- a/packages/plugin-preview/static/global-components/FixedDevice.css
+++ b/packages/plugin-preview/static/global-components/FixedDevice.css
@@ -9,6 +9,25 @@
   --rp-device-border: 1px solid #e5e6e8;
 }
 
+.rp-fixed-device__mobile-link {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  z-index: 100;
+  display: inline-flex;
+  align-items: center;
+  min-height: 40px;
+  padding: 0 16px;
+  color: var(--rp-c-text-2);
+  font-size: 14px;
+  font-weight: 500;
+  text-decoration: none;
+  background: var(--rp-c-bg);
+  border: 1px solid var(--rp-c-divider);
+  border-radius: 20px;
+  box-shadow: var(--rp-shadow-2);
+}
+
 /* Block: rp-fixed-device */
 .rp-fixed-device {
   display: none;
@@ -50,6 +69,10 @@
 }
 
 @media (min-width: 960px) {
+  .rp-fixed-device__mobile-link {
+    display: none;
+  }
+
   .rp-fixed-device {
     display: inline;
   }

--- a/packages/plugin-preview/static/global-components/FixedDevice.tsx
+++ b/packages/plugin-preview/static/global-components/FixedDevice.tsx
@@ -1,4 +1,4 @@
-import { useDark, usePage } from '@rspress/core/runtime';
+import { useDark, useLang, usePage } from '@rspress/core/runtime';
 import { useCallback, useEffect, useRef, useState } from 'react';
 // @ts-expect-error
 import { normalizeId } from '../../dist/utils';
@@ -11,6 +11,9 @@ export default () => {
   const pageName = `${normalizeId(page.pagePath)}`;
   const demoId = `_${pageName}`;
   const { haveIframeFixedDemos } = page;
+  const lang = useLang();
+  const demoUrl = getPageUrl(demoId);
+  const demoFullUrl = getPageFullUrl(demoId);
 
   const [iframeKey, setIframeKey] = useState(0);
   const dark = useDark();
@@ -31,9 +34,18 @@ export default () => {
   }, [dark]);
 
   return haveIframeFixedDemos ? (
-    <div className="rp-fixed-device">
-      {/* hide the outline */}
-      <style>{`@media (min-width: 1280px) {
+    <>
+      <a
+        className="rp-fixed-device__mobile-link"
+        href={demoUrl}
+        target="_blank"
+        rel="noreferrer"
+      >
+        {lang === 'zh' || lang.startsWith('zh-') ? '打开 Demo' : 'Open Demo'}
+      </a>
+      <div className="rp-fixed-device">
+        {/* hide the outline */}
+        <style>{`@media (min-width: 1280px) {
       .rp-doc-layout__outline { 
         display: none; 
       }
@@ -44,17 +56,18 @@ export default () => {
       }
     }
     `}</style>
-      <iframe
-        src={getPageUrl(demoId)}
-        className="rp-fixed-device__iframe"
-        key={iframeKey}
-        ref={iframeRef}
-      />
-      <MobileOperation
-        url={getPageFullUrl(demoId)}
-        className="rp-fixed-device__operations"
-        refresh={refresh}
-      />
-    </div>
+        <iframe
+          src={demoUrl}
+          className="rp-fixed-device__iframe"
+          key={iframeKey}
+          ref={iframeRef}
+        />
+        <MobileOperation
+          url={demoFullUrl}
+          className="rp-fixed-device__operations"
+          refresh={refresh}
+        />
+      </div>
+    </>
   ) : null;
 };

--- a/packages/plugin-preview/static/global-components/common/PreviewOperations.tsx
+++ b/packages/plugin-preview/static/global-components/common/PreviewOperations.tsx
@@ -32,7 +32,7 @@ export default (props: {
   const { url, className = '', refresh } = props;
   const lang = useLang();
   const triggerRef = useRef(null);
-  const t = lang === 'zh' ? locales.zh : locales.en;
+  const t = lang === 'zh' || lang.startsWith('zh-') ? locales.zh : locales.en;
 
   const toggleQRCode: MouseEventHandler<HTMLButtonElement> = e => {
     if (!showQRCode) {

--- a/packages/plugin-preview/tests/parsePreviewInfoFromMeta.test.ts
+++ b/packages/plugin-preview/tests/parsePreviewInfoFromMeta.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from '@rstest/core';
+import { parsePreviewInfoFromMeta } from '../src/parsePreviewInfoFromMeta';
+
+describe('parsePreviewInfoFromMeta', () => {
+  test('parses preview-only for fixed iframe previews', () => {
+    expect(
+      parsePreviewInfoFromMeta({
+        meta: 'preview="iframe-fixed" preview-only',
+        defaultPreviewMode: 'internal',
+        defaultRenderMode: 'pure',
+      }),
+    ).toEqual({
+      isPure: false,
+      isPreview: true,
+      previewOnly: true,
+      previewMode: 'iframe-fixed',
+    });
+  });
+
+  test('does not match preview-only as a partial token', () => {
+    expect(
+      parsePreviewInfoFromMeta({
+        meta: 'preview="iframe-fixed" data-preview-only="true"',
+        defaultPreviewMode: 'internal',
+        defaultRenderMode: 'pure',
+      }).previewOnly,
+    ).toBe(false);
+  });
+});

--- a/website/docs/en/plugin/official-plugins/preview.mdx
+++ b/website/docs/en/plugin/official-plugins/preview.mdx
@@ -166,6 +166,16 @@ Syntax:
 ```
 ````
 
+Add `preview-only` when the source should be built into the fixed preview but
+should not render as a code block in the document. This is useful for page-level
+demo applications:
+
+````mdx title="example.mdx"
+```tsx file="./_demo.tsx" preview="iframe-fixed" preview-only
+
+```
+````
+
 Rendering result:
 
 ![](https://lf3-static.bytednsdoc.com/obj/eden-cn/uhbfnupenuhf/rspress/demo-preview-mobile-fixed.png)
@@ -292,9 +302,13 @@ export default defineConfig({
 
 Configures a custom entry to support other frameworks like Vue.
 
-:::warning Note
-Only available in `preview="iframe-follow"` mode.
-:::
+`customEntry` is available in both iframe modes. The callback receives
+`previewMode`, route metadata, and a `demos` array. Fixed mode can contain
+multiple demos from the same document.
+
+For external `file` code blocks, each demo also includes an absolute
+`sourcePath`. Prefer it when the source module has relative imports; `demoPath`
+points to the transformed virtual module.
 
 Here is an example for the Vue framework:
 
@@ -307,14 +321,25 @@ export default defineConfig({
   // ...
   plugins: [
     pluginPreview({
-      previewMode: 'iframe',
       previewLanguages: ['vue'],
       iframeOptions: {
-        position: 'follow',
-        customEntry: ({ demoPath }) => {
+        customEntry: meta => {
+          const imports = meta.demos
+            .map(
+              (demo, index) =>
+                `import Demo_${index} from ${JSON.stringify(
+                  demo.sourcePath ?? demo.demoPath,
+                )};`,
+            )
+            .join('\n');
+          const children = meta.demos
+            .map((_demo, index) => `h(Demo_${index})`)
+            .join(', ');
+
           return `
-          import { createApp } from 'vue';
-          import App from ${JSON.stringify(demoPath)};
+          import { createApp, h } from 'vue';
+          ${imports}
+          const App = { render: () => h('div', null, [${children}]) };
           createApp(App).mount('#root');
           `;
         },

--- a/website/docs/zh/plugin/official-plugins/preview.mdx
+++ b/website/docs/zh/plugin/official-plugins/preview.mdx
@@ -166,6 +166,15 @@ iframe 预览模式中的代码有单独的编译环境和运行环境。
 ```
 ````
 
+当源文件需要参与固定预览构建、但不应在文档正文中显示为代码块时，可以添加
+`preview-only`。这适合声明页面级 Demo 应用：
+
+````mdx title="example.mdx"
+```tsx file="./_demo.tsx" preview="iframe-fixed" preview-only
+
+```
+````
+
 渲染结果：
 
 ![](https://lf3-static.bytednsdoc.com/obj/eden-cn/uhbfnupenuhf/rspress/demo-preview-mobile-fixed.png)
@@ -292,9 +301,11 @@ export default defineConfig({
 
 配置自定义入口以支持其他框架（如 Vue）。
 
-:::warning 注意
-仅在 `preview="iframe-follow"` 模式下可用。
-:::
+`customEntry` 在两种 iframe 模式下都可用。回调会收到 `previewMode`、路由元数据和
+`demos` 数组。固定模式可以包含同一文档中的多个 Demo。
+
+对于外部 `file` 代码块，每个 Demo 还包含绝对路径 `sourcePath`。当源模块使用相对导入时
+应优先使用它；`demoPath` 指向经过转换的虚拟模块。
 
 以下是 Vue 框架的配置示例：
 
@@ -307,14 +318,25 @@ export default defineConfig({
   // ...
   plugins: [
     pluginPreview({
-      previewMode: 'iframe',
       previewLanguages: ['vue'],
       iframeOptions: {
-        position: 'follow',
-        customEntry: ({ demoPath }) => {
+        customEntry: meta => {
+          const imports = meta.demos
+            .map(
+              (demo, index) =>
+                `import Demo_${index} from ${JSON.stringify(
+                  demo.sourcePath ?? demo.demoPath,
+                )};`,
+            )
+            .join('\n');
+          const children = meta.demos
+            .map((_demo, index) => `h(Demo_${index})`)
+            .join(', ');
+
           return `
-          import { createApp } from 'vue';
-          import App from ${JSON.stringify(demoPath)};
+          import { createApp, h } from 'vue';
+          ${imports}
+          const App = { render: () => h('div', null, [${children}]) };
           createApp(App).mount('#root');
           `;
         },


### PR DESCRIPTION
## Summary

- support `customEntry` in both `iframe-follow` and `iframe-fixed` modes with discriminated preview, route, and demo metadata
- expose external demo source paths and add `preview-only` for page-level fixed previews that should not render duplicate document content
- add a localized mobile link to the generated pure Demo page while preserving the fixed desktop device
- cover Vue fixed entries, relative imports, existing React behavior, builds, HMR, and documentation

## Related Issue

N/A

## Screenshots

To be added before this draft is marked ready. The new mobile fallback link and its generated Demo URL are covered by the custom-entry E2E fixture.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
