### PR TITLE
chore(deps): update Rsbuild to v2.1.7

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@mdx-js/mdx": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
-    "@rsbuild/core": "^2.1.6",
+    "@rsbuild/core": "^2.1.7",
     "@rsbuild/plugin-react": "~2.1.0",
     "@rspress/shared": "workspace:*",
     "@shikijs/rehype": "^4.2.0",

--- a/packages/plugin-llms/package.json
+++ b/packages/plugin-llms/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.11",
-    "@rsbuild/core": "^2.1.6",
+    "@rsbuild/core": "^2.1.7",
     "@rsbuild/plugin-react": "~2.1.0",
     "@rslib/core": "0.23.2",
     "@rspress/config": "workspace:*",

--- a/packages/plugin-preview/package.json
+++ b/packages/plugin-preview/package.json
@@ -28,7 +28,7 @@
     "reset": "rimraf ./**/node_modules"
   },
   "dependencies": {
-    "@rsbuild/core": "^2.1.6",
+    "@rsbuild/core": "^2.1.7",
     "@rsbuild/plugin-react": "~2.1.0",
     "picocolors": "^1.1.1",
     "qrcode.react": "^4.2.0"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -50,7 +50,7 @@
     "reset": "rimraf ./**/node_modules"
   },
   "dependencies": {
-    "@rsbuild/core": "^2.1.6",
+    "@rsbuild/core": "^2.1.7",
     "@shikijs/rehype": "^4.2.0",
     "unified": "^11.0.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 1.61.1
       '@rsbuild/plugin-react':
         specifier: ~2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.5(@swc/helpers@0.5.23))
       '@rslint/core':
         specifier: ^0.6.5
         version: 0.6.5(jiti@2.7.0)
@@ -103,7 +103,7 @@ importers:
     devDependencies:
       '@rsdoctor/rspack-plugin':
         specifier: 1.6.0
-        version: 1.6.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.6)(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)
+        version: 1.6.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.6)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
       '@types/node':
         specifier: ^22.8.1
         version: 22.19.15
@@ -619,7 +619,7 @@ importers:
     dependencies:
       '@rsbuild/plugin-vue':
         specifier: ^1.2.9
-        version: 1.2.9(@rsbuild/core@2.1.6)(@rspack/core@2.1.4(@swc/helpers@0.5.23))(vue@3.5.40(typescript@6.0.3))
+        version: 1.2.9(@rsbuild/core@2.1.6)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(vue@3.5.40(typescript@6.0.3))
       '@rspress/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -960,7 +960,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: ^2.0.3
-        version: 2.0.3(@rsbuild/core@2.1.6)(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)
+        version: 2.0.3(@rsbuild/core@2.1.6)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
       '@types/node':
         specifier: ^22.8.1
         version: 22.19.15
@@ -1032,11 +1032,11 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1(@types/react@19.2.17)(react@19.2.7)
       '@rsbuild/core':
-        specifier: ^2.1.6
-        version: 2.1.6
+        specifier: ^2.1.7
+        version: 2.1.7
       '@rsbuild/plugin-react':
         specifier: ~2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5(@swc/helpers@0.5.23))
       '@rspress/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1145,10 +1145,10 @@ importers:
         version: 7.58.11(@types/node@22.19.15)
       '@rsbuild/plugin-sass':
         specifier: ~1.5.3
-        version: 1.5.3(@rsbuild/core@2.1.6)
+        version: 1.5.3(@rsbuild/core@2.1.7)
       '@rsbuild/plugin-svgr':
         specifier: ^2.0.5
-        version: 2.0.5(@rsbuild/core@2.1.6)(@rspack/core@2.1.4(@swc/helpers@0.5.23))(typescript@6.0.3)
+        version: 2.0.5(@rsbuild/core@2.1.7)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(typescript@6.0.3)
       '@rslib/core':
         specifier: 0.23.2
         version: 0.23.2(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
@@ -1214,10 +1214,10 @@ importers:
         version: 4.0.0
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.1.6)
+        version: 1.0.0(@rsbuild/core@2.1.7)
       rsbuild-plugin-virtual-module:
         specifier: 0.4.5
-        version: 0.4.5(@rsbuild/core@2.1.6)
+        version: 0.4.5(@rsbuild/core@2.1.7)
       tinyglobby:
         specifier: ^0.2.17
         version: 0.2.17
@@ -1273,7 +1273,7 @@ importers:
         version: 7.58.11(@types/node@22.19.15)
       '@rsbuild/plugin-react':
         specifier: ~2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.5(@swc/helpers@0.5.23))
       '@rslib/core':
         specifier: 0.23.2
         version: 0.23.2(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
@@ -1428,11 +1428,11 @@ importers:
         specifier: ^7.58.11
         version: 7.58.11(@types/node@22.19.15)
       '@rsbuild/core':
-        specifier: ^2.1.6
-        version: 2.1.6
+        specifier: ^2.1.7
+        version: 2.1.7
       '@rsbuild/plugin-react':
         specifier: ~2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5(@swc/helpers@0.5.23))
       '@rslib/core':
         specifier: 0.23.2
         version: 0.23.2(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
@@ -1456,7 +1456,7 @@ importers:
         version: 19.2.7
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.1.6)
+        version: 1.0.0(@rsbuild/core@2.1.7)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1493,7 +1493,7 @@ importers:
         version: 7.29.7
       '@rsbuild/plugin-react':
         specifier: ~2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.5(@swc/helpers@0.5.23))
       '@rslib/core':
         specifier: 0.23.2
         version: 0.23.2(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
@@ -1543,11 +1543,11 @@ importers:
   packages/plugin-preview:
     dependencies:
       '@rsbuild/core':
-        specifier: ^2.1.6
-        version: 2.1.6
+        specifier: ^2.1.7
+        version: 2.1.7
       '@rsbuild/plugin-react':
         specifier: ~2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5(@swc/helpers@0.5.23))
       '@rspress/core':
         specifier: workspace:^2.0.10
         version: link:../core
@@ -1587,7 +1587,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.1.6)
+        version: 1.0.0(@rsbuild/core@2.1.7)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1746,8 +1746,8 @@ importers:
   packages/shared:
     dependencies:
       '@rsbuild/core':
-        specifier: ^2.1.6
-        version: 2.1.6
+        specifier: ^2.1.7
+        version: 2.1.7
       '@shikijs/rehype':
         specifier: ^4.2.0
         version: 4.2.0
@@ -1787,7 +1787,7 @@ importers:
         version: 6.1.3
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.1.6)
+        version: 1.0.0(@rsbuild/core@2.1.7)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1808,7 +1808,7 @@ importers:
         version: 1.5.3(@rsbuild/core@2.1.6)
       '@rsdoctor/rspack-plugin':
         specifier: 1.6.0
-        version: 1.6.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.6)(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)
+        version: 1.6.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.7)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
       '@rspress/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -3127,6 +3127,16 @@ packages:
       core-js:
         optional: true
 
+  '@rsbuild/core@2.1.7':
+    resolution: {integrity: sha512-Xhs8DkLw2Vk5ydwjNG3GMJe1h03lqlCO4dV9EOG9HSR6vDfh07K48aq3KJ8/ncEL/YuFBaCIJrVc7rMFoR1y7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
   '@rsbuild/plugin-check-syntax@1.6.1':
     resolution: {integrity: sha512-26xtEYN0QjZYoyt0lWnvIztBWjEZJvcfw7MN4f5B4SpNggmnF7F7aNPrgkY3EccXVFx1VGQBhnCkBV//OoS07Q==}
     peerDependencies:
@@ -3288,13 +3298,29 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@2.1.5':
+    resolution: {integrity: sha512-XLAN6YSU36qkciJtV9DY9z57pdHOjKy/f1HyoqpZenRg8p46jnXPziV45lfrTZpG+FF6g/jtTUc4dKbeyoWqPw==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@2.1.4':
     resolution: {integrity: sha512-bz/AsCplLs+3fXULPQU9d4r8H4PdeljgHFyItvVIrA/NKZqzQ8sX0topf/zJVZAOtPH7GNnrKjq0/F0U2DHikQ==}
     cpu: [x64]
     os: [darwin]
 
+  '@rspack/binding-darwin-x64@2.1.5':
+    resolution: {integrity: sha512-KLW7PV86jyCOyqJSqrkZdvYUWYCFX/Q4LsGmVc8tyDA8jBYLMHJDewC/lNf9ot3rU2SoLDZKhDUh7q7dX0FRmg==}
+    cpu: [x64]
+    os: [darwin]
+
   '@rspack/binding-linux-arm64-gnu@2.1.4':
     resolution: {integrity: sha512-x0HQTLU1MusCtNamuXxf3ayEPkvh9uuaq4wVyBqveRkn4FznSOoHUsxTAKMnjGARX+vdLV/y/SwWJRDp2RI4zw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-gnu@2.1.5':
+    resolution: {integrity: sha512-KOooAC8L+Ljx5sY7ZuMeaXCQ310FNWaPWXcYQJpFPApF3qyLeSfuOftUGwxcxeo5U0mS5OY3zxp7/5CaHWKYjg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -3305,8 +3331,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-arm64-musl@2.1.5':
+    resolution: {integrity: sha512-0GFc07gT71+uRbHtejDecBfSL0fs7dQAwCtXYieXboACauL7UvS3Hwr6v8A91aGtAcvLotnCaIa3CWWYwtYlYQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-linux-riscv64-gnu@2.1.4':
     resolution: {integrity: sha512-jYtQKtnDRaVfyasvTGY04Z7m+xDWZYVwAIEOB4hP7czM7FVLOMgHlMlvw/EgF0DNHrBthqbPfBIS2tP50CzpEA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-riscv64-gnu@2.1.5':
+    resolution: {integrity: sha512-isQQDp3fBzPSZpLVFzPqVXIVA4I9b9mKs58TfUgOzDP/1g1582YSV3iFopgFogvEliihXDuuXvM6aAkP+w8Z+Q==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
@@ -3317,8 +3355,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-riscv64-musl@2.1.5':
+    resolution: {integrity: sha512-/SP6VknY4kH60BYplI2FDNAJCo4U4DUszLxhKsgVlgA5ImgHC8Ew2AsKgidk7ceiYV9OcKzYuWYe9tVpysBYVA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-linux-x64-gnu@2.1.4':
     resolution: {integrity: sha512-C53B3e6M4yzlYn4hDxR9cHZV+HqkfFGR0zuhH8QCfdBfN5KyGsmXmujiFU85ANEvBgf9CF8VreBQeJ20lyto/g==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-gnu@2.1.5':
+    resolution: {integrity: sha512-/GJmS+buA4pilT10gs5mfAhAZxSHXpDD8veZ3QpYvNUuoU9gvempAq9TgjbyNN/vc5pf76GdXPXKFMiehudYSA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -3329,12 +3379,27 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-x64-musl@2.1.5':
+    resolution: {integrity: sha512-iwS3t75nZ2TnUjB05KtvpvjpdkOy/nLxbaOnwjbdnNZZXpUaMadLbllGAWayHPGCMsL2yKBEhVEESZpR7tK3SA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-wasm32-wasi@2.1.4':
     resolution: {integrity: sha512-0P1WZEfu7JOPzD/jQfk9U/6gnRFc7RpvYCQaYZVVYZNJ2gU6O0/yLegRGKNK/2L0zjYwiD0ynhOIBVUUERf5Pw==}
     cpu: [wasm32]
 
+  '@rspack/binding-wasm32-wasi@2.1.5':
+    resolution: {integrity: sha512-jOhW69t1H/jcRaSMB5U8jVzWP18j0YQIlo0nT8W+KvNVScJeyOze4FFc+5RIS7VmuT8/jid7hUyydZOfm6UgqA==}
+    cpu: [wasm32]
+
   '@rspack/binding-win32-arm64-msvc@2.1.4':
     resolution: {integrity: sha512-+aStQipk1EakLRPfD+/aQbtmTXfxqSWetcRRDWV3cAsD4ebv1tF8FLKYY1PCaFpQbX1FxzCBGF0KHxkAsi9cxA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@2.1.5':
+    resolution: {integrity: sha512-OLfMXmtFBcrWr9BRGKXJYrWgYR0JSaoAWr3EVFDjKGi/YR5aUwQSGc3AJPBph9g0YsdSqRuUhtQGtCk84DeeEA==}
     cpu: [arm64]
     os: [win32]
 
@@ -3343,16 +3408,41 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@2.1.5':
+    resolution: {integrity: sha512-p4OSmnj21+AY8vpIADveLEBXfXJRXonOTYim2VLVWV4TbXfhYNMLiX3qESHCdNnn6lVJM0q6zxxzEUfTyAKydw==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@2.1.4':
     resolution: {integrity: sha512-Z4je7JBaDpO9vvNMgCxlycycRJq+GQwwuXSXagW2xvvGM10Ij63YVtIehSMG9xaW8PED41oc9nWndoEsiD60pA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rspack/binding-win32-x64-msvc@2.1.5':
+    resolution: {integrity: sha512-YCkLLDGMkHsw5CpcsFtFhzCu+JZEsNrcH9O1GpWMkyxR2ku2Fq1i2wEHYSm26HyW+PJ3+Fv347MPWMFZIz9q2g==}
     cpu: [x64]
     os: [win32]
 
   '@rspack/binding@2.1.4':
     resolution: {integrity: sha512-iye4BaTYtTt0qa39avWwEsUobVxFNhQHr6B8reFeKU7sdaZsC9LUoDR8JAt5gOnbnzFMPdKgrdU/VzkC6rXbIg==}
 
+  '@rspack/binding@2.1.5':
+    resolution: {integrity: sha512-lF3ZLeeyV0AN3BL0m2jAmNZD5pP9IHsQ8gUXN7mo0g4xsW6nf6hsN7o9CnEHECz5uUZb+EoWsuWzAAmnA9Ip8Q==}
+
   '@rspack/core@2.1.4':
     resolution: {integrity: sha512-lpJgtr+JAXuDAMBJfRJ1LHyWVuYJyhZu6L6aj9t4lipUU03qwakHnzn3vwSCr68PsVvVPzR6NbJE1gJienSV0g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@2.1.5':
+    resolution: {integrity: sha512-YHjL7xVXycAWsjJtF39cRZ2u+ddiNFxY+FcNgEBe6Y8OaLeUfMfjba3gK+B1Oj32UcKD6BmXGsPfu9p+OII/Yw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -8830,6 +8920,13 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
+  '@rsbuild/core@2.1.7':
+    dependencies:
+      '@rspack/core': 2.1.5(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
   '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.1.6)':
     dependencies:
       acorn: 8.16.0
@@ -8840,21 +8937,40 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.6
 
-  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4(@swc/helpers@0.5.23))':
+  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.1.7)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      acorn: 8.16.0
+      browserslist-to-es-version: 1.4.1
+      htmlparser2: 10.0.0
+      picocolors: 1.1.1
+      source-map: 0.7.6
+    optionalDependencies:
+      '@rsbuild/core': 2.1.7
+
+  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.1.7)(@rspack/core@2.1.5(@swc/helpers@0.5.23))':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 2.1.7
+    transitivePeerDependencies:
+      - '@rspack/core'
+
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.5(@swc/helpers@0.5.23))':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.5(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
       '@rsbuild/core': 2.1.6
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4(@swc/helpers@0.5.23))':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5(@swc/helpers@0.5.23))':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.4(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.5(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.6
+      '@rsbuild/core': 2.1.7
     transitivePeerDependencies:
       - '@rspack/core'
 
@@ -8868,33 +8984,43 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.6
 
-  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.1.6)(@rspack/core@2.1.4(@swc/helpers@0.5.23))(typescript@6.0.3)':
+  '@rsbuild/plugin-sass@1.5.3(@rsbuild/core@2.1.7)':
     dependencies:
-      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4(@swc/helpers@0.5.23))
+      deepmerge: 4.3.1
+      loader-utils: 2.0.4
+      postcss: 8.5.20
+      reduce-configs: 1.1.2
+      sass-embedded: 1.100.0
+    optionalDependencies:
+      '@rsbuild/core': 2.1.7
+
+  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.1.7)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(typescript@6.0.3)':
+    dependencies:
+      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.1.7)(@rspack/core@2.1.5(@swc/helpers@0.5.23))
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))(typescript@6.0.3)
       deepmerge: 4.3.1
       loader-utils: 3.3.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.6
+      '@rsbuild/core': 2.1.7
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.1.6)(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)':
+  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.1.6)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)':
     dependencies:
-      '@tailwindcss/webpack': 4.3.1(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)
+      '@tailwindcss/webpack': 4.3.1(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
     optionalDependencies:
       '@rsbuild/core': 2.1.6
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-vue@1.2.9(@rsbuild/core@2.1.6)(@rspack/core@2.1.4(@swc/helpers@0.5.23))(vue@3.5.40(typescript@6.0.3))':
+  '@rsbuild/plugin-vue@1.2.9(@rsbuild/core@2.1.6)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(vue@3.5.40(typescript@6.0.3))':
     dependencies:
-      rspack-vue-loader: 17.5.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(vue@3.5.40(typescript@6.0.3))
+      rspack-vue-loader: 17.5.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(vue@3.5.40(typescript@6.0.3))
     optionalDependencies:
       '@rsbuild/core': 2.1.6
     transitivePeerDependencies:
@@ -8904,13 +9030,13 @@ snapshots:
 
   '@rsdoctor/client@1.6.0': {}
 
-  '@rsdoctor/core@1.6.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.6)(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)':
+  '@rsdoctor/core@1.6.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.6)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)':
     dependencies:
       '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.1.6)
-      '@rsdoctor/graph': 1.6.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)
-      '@rsdoctor/sdk': 1.6.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)
-      '@rsdoctor/types': 1.6.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)
-      '@rsdoctor/utils': 1.6.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)
+      '@rsdoctor/graph': 1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
+      '@rsdoctor/sdk': 1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
+      '@rsdoctor/types': 1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
+      '@rsdoctor/utils': 1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
       '@rspack/resolver': 0.2.8(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
       browserslist-load-config: 1.0.3
       es-toolkit: 1.49.0
@@ -8928,10 +9054,34 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/graph@1.6.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)':
+  '@rsdoctor/core@1.6.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.7)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)':
     dependencies:
-      '@rsdoctor/types': 1.6.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)
-      '@rsdoctor/utils': 1.6.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)
+      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.1.7)
+      '@rsdoctor/graph': 1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
+      '@rsdoctor/sdk': 1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
+      '@rsdoctor/types': 1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
+      '@rsdoctor/utils': 1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
+      '@rspack/resolver': 0.2.8(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      browserslist-load-config: 1.0.3
+      es-toolkit: 1.49.0
+      filesize: 11.0.17
+      fs-extra: 11.3.4
+      semver: 7.8.5
+      source-map: 0.7.6
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@rsbuild/core'
+      - '@rspack/core'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - webpack
+
+  '@rsdoctor/graph@1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)':
+    dependencies:
+      '@rsdoctor/types': 1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
+      '@rsdoctor/utils': 1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
       es-toolkit: 1.49.0
       path-browserify: 1.0.1
       source-map: 0.7.6
@@ -8939,15 +9089,15 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.6.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.6)(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)':
+  '@rsdoctor/rspack-plugin@1.6.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.6)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)':
     dependencies:
-      '@rsdoctor/core': 1.6.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.6)(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)
-      '@rsdoctor/graph': 1.6.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)
-      '@rsdoctor/sdk': 1.6.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)
-      '@rsdoctor/types': 1.6.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)
-      '@rsdoctor/utils': 1.6.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)
+      '@rsdoctor/core': 1.6.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.6)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
+      '@rsdoctor/graph': 1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
+      '@rsdoctor/sdk': 1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
+      '@rsdoctor/types': 1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
+      '@rsdoctor/utils': 1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
     optionalDependencies:
-      '@rspack/core': 2.1.4(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.5(@swc/helpers@0.5.23)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -8957,12 +9107,30 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/sdk@1.6.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)':
+  '@rsdoctor/rspack-plugin@1.6.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.7)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)':
+    dependencies:
+      '@rsdoctor/core': 1.6.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.7)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
+      '@rsdoctor/graph': 1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
+      '@rsdoctor/sdk': 1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
+      '@rsdoctor/types': 1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
+      '@rsdoctor/utils': 1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
+    optionalDependencies:
+      '@rspack/core': 2.1.5(@swc/helpers@0.5.23)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@rsbuild/core'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - webpack
+
+  '@rsdoctor/sdk@1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)':
     dependencies:
       '@rsdoctor/client': 1.6.0
-      '@rsdoctor/graph': 1.6.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)
-      '@rsdoctor/types': 1.6.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)
-      '@rsdoctor/utils': 1.6.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)
+      '@rsdoctor/graph': 1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
+      '@rsdoctor/types': 1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
+      '@rsdoctor/utils': 1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
       launch-editor: 2.13.2
       safer-buffer: 2.1.2
       socket.io: 4.8.1
@@ -8974,20 +9142,20 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/types@1.6.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)':
+  '@rsdoctor/types@1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)':
     dependencies:
       '@types/connect': 3.4.38
       '@types/estree': 1.0.5
       '@types/tapable': 2.3.0
       source-map: 0.7.6
     optionalDependencies:
-      '@rspack/core': 2.1.4(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.5(@swc/helpers@0.5.23)
       webpack: 5.107.1
 
-  '@rsdoctor/utils@1.6.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)':
+  '@rsdoctor/utils@1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@rsdoctor/types': 1.6.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)
+      '@rsdoctor/types': 1.6.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)
       '@types/estree': 1.0.5
       acorn: 8.16.0
       acorn-import-attributes: 1.9.5(acorn@8.16.0)
@@ -9070,25 +9238,49 @@ snapshots:
   '@rspack/binding-darwin-arm64@2.1.4':
     optional: true
 
+  '@rspack/binding-darwin-arm64@2.1.5':
+    optional: true
+
   '@rspack/binding-darwin-x64@2.1.4':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.1.5':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@2.1.4':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@2.1.5':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@2.1.4':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.1.5':
     optional: true
 
   '@rspack/binding-linux-riscv64-gnu@2.1.4':
     optional: true
 
+  '@rspack/binding-linux-riscv64-gnu@2.1.5':
+    optional: true
+
   '@rspack/binding-linux-riscv64-musl@2.1.4':
+    optional: true
+
+  '@rspack/binding-linux-riscv64-musl@2.1.5':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@2.1.4':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@2.1.5':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@2.1.4':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.1.5':
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.1.4':
@@ -9098,13 +9290,29 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
+  '@rspack/binding-wasm32-wasi@2.1.5':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@2.1.4':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.1.5':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.1.4':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@2.1.5':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@2.1.4':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.1.5':
     optional: true
 
   '@rspack/binding@2.1.4':
@@ -9122,25 +9330,46 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.1.4
       '@rspack/binding-win32-x64-msvc': 2.1.4
 
+  '@rspack/binding@2.1.5':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.1.5
+      '@rspack/binding-darwin-x64': 2.1.5
+      '@rspack/binding-linux-arm64-gnu': 2.1.5
+      '@rspack/binding-linux-arm64-musl': 2.1.5
+      '@rspack/binding-linux-riscv64-gnu': 2.1.5
+      '@rspack/binding-linux-riscv64-musl': 2.1.5
+      '@rspack/binding-linux-x64-gnu': 2.1.5
+      '@rspack/binding-linux-x64-musl': 2.1.5
+      '@rspack/binding-wasm32-wasi': 2.1.5
+      '@rspack/binding-win32-arm64-msvc': 2.1.5
+      '@rspack/binding-win32-ia32-msvc': 2.1.5
+      '@rspack/binding-win32-x64-msvc': 2.1.5
+
   '@rspack/core@2.1.4(@swc/helpers@0.5.23)':
     dependencies:
       '@rspack/binding': 2.1.4
     optionalDependencies:
       '@swc/helpers': 0.5.23
 
+  '@rspack/core@2.1.5(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': 2.1.5
+    optionalDependencies:
+      '@swc/helpers': 0.5.23
+
   '@rspack/lite-tapable@1.1.0': {}
 
-  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.1.4(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.5(@swc/helpers@0.5.23)
 
-  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.4(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.5(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.1.4(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.5(@swc/helpers@0.5.23)
 
   '@rspack/resolver-binding-darwin-arm64@0.2.8':
     optional: true
@@ -9523,14 +9752,14 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
 
-  '@tailwindcss/webpack@4.3.1(@rspack/core@2.1.4(@swc/helpers@0.5.23))(webpack@5.107.1)':
+  '@tailwindcss/webpack@4.3.1(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.107.1)':
     dependencies:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
     optionalDependencies:
-      '@rspack/core': 2.1.4(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.5(@swc/helpers@0.5.23)
       webpack: 5.107.1
 
   '@ts-morph/common@0.28.1':
@@ -9968,18 +10197,18 @@ snapshots:
     optionalDependencies:
       ajv: 8.20.0
 
-  ajv-formats@2.1.1(ajv@8.18.0):
+  ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
     optional: true
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
 
-  ajv-keywords@5.1.0(ajv@8.18.0):
+  ajv-keywords@5.1.0(ajv@8.20.0):
     dependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
       fast-deep-equal: 3.1.3
     optional: true
 
@@ -13152,9 +13381,19 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.6
 
+  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.1.7):
+    dependencies:
+      publint: 0.3.21
+    optionalDependencies:
+      '@rsbuild/core': 2.1.7
+
   rsbuild-plugin-virtual-module@0.4.5(@rsbuild/core@2.1.6):
     optionalDependencies:
       '@rsbuild/core': 2.1.6
+
+  rsbuild-plugin-virtual-module@0.4.5(@rsbuild/core@2.1.7):
+    optionalDependencies:
+      '@rsbuild/core': 2.1.7
 
   rslog@2.1.2: {}
 
@@ -13162,12 +13401,12 @@ snapshots:
     dependencies:
       fs-extra: 11.3.4
 
-  rspack-vue-loader@17.5.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(vue@3.5.40(typescript@6.0.3)):
+  rspack-vue-loader@17.5.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(vue@3.5.40(typescript@6.0.3)):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
       chalk: 4.1.2
     optionalDependencies:
-      '@rspack/core': 2.1.4(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.5(@swc/helpers@0.5.23)
       vue: 3.5.40(typescript@6.0.3)
 
   rspress-plugin-devkit@1.0.0(@rspress/core@packages+core):
@@ -13331,9 +13570,9 @@ snapshots:
   schema-utils@4.3.3:
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.18.0
-      ajv-formats: 2.1.1(ajv@8.18.0)
-      ajv-keywords: 5.1.0(ajv@8.18.0)
+      ajv: 8.20.0
+      ajv-formats: 2.1.1(ajv@8.20.0)
+      ajv-keywords: 5.1.0(ajv@8.20.0)
     optional: true
 
   scroll-into-view-if-needed@3.1.0:


### PR DESCRIPTION
## Summary

- Update `@rsbuild/core` from 2.1.6 to 2.1.7 across the core, shared, and plugin packages.
- Refresh the lockfile for Rsbuild 2.1.7 and its Rspack 2.1.5 dependency.

## Related Issue

https://github.com/web-infra-dev/rsbuild/releases/tag/v2.1.7

## Screenshots

Not applicable.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
