### PR TITLE
docs: add keywords metadata example

### DIFF
--- a/website/docs/en/guide/advanced/custom-head.mdx
+++ b/website/docs/en/guide/advanced/custom-head.mdx
@@ -61,6 +61,17 @@ head:
 ---
 ```
 
+You can use the same option to add keywords metadata:
+
+```md title="example.mdx"
+---
+head:
+  - - meta
+    - name: keywords
+      content: Rspress, React, static site generator
+---
+```
+
 ## Head component
 
 If you need more complex head customization, you can use the [Head component](/ui/runtime-components/head) provided by Rspress to dynamically set head tags in pages or layout components.

--- a/website/docs/en/guide/advanced/custom-head.mdx
+++ b/website/docs/en/guide/advanced/custom-head.mdx
@@ -61,7 +61,7 @@ head:
 ---
 ```
 
-You can use the same option to add keywords metadata:
+You can use the same `head` frontmatter field to add a `<meta name="keywords">` tag:
 
 ```md title="example.mdx"
 ---

--- a/website/docs/zh/guide/advanced/custom-head.mdx
+++ b/website/docs/zh/guide/advanced/custom-head.mdx
@@ -61,7 +61,7 @@ head:
 ---
 ```
 
-你也可以使用相同的配置添加关键词 metadata：
+你也可以使用相同的配置添加 `<meta name="keywords">` 标签：
 
 ```md title="example.mdx"
 ---

--- a/website/docs/zh/guide/advanced/custom-head.mdx
+++ b/website/docs/zh/guide/advanced/custom-head.mdx
@@ -61,6 +61,17 @@ head:
 ---
 ```
 
+你也可以使用相同的配置添加关键词 metadata：
+
+```md title="example.mdx"
+---
+head:
+  - - meta
+    - name: keywords
+      content: Rspress, React, static site generator
+---
+```
+
 ## Head 组件
 
 如果你需要更复杂的 Head 定制，可以使用 Rspress 提供的 [Head 组件](/ui/runtime-components/head) 在页面或布局组件中动态设置 Head 标签。


### PR DESCRIPTION
## Summary

This PR documents how to add page-level keywords metadata through frontmatter `head`. The example is added to both the English and Chinese custom head guides.

## Related Issue

N/A

## Checklist

- [x] Tests updated (not required).
- [x] Documentation updated.