### PR TITLE
chore(ci/test): remove TEST environment branches

### DIFF
--- a/e2e/fixtures/multi-version/rspress.config.ts
+++ b/e2e/fixtures/multi-version/rspress.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from '@rspress/core';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'docs'),
+  route: {
+    localeRedirect: 'never',
+  },
   lang: 'en',
   base: '/base/',
   locales: [

--- a/e2e/fixtures/plugin-api-docgen/locales/rspress.config.ts
+++ b/e2e/fixtures/plugin-api-docgen/locales/rspress.config.ts
@@ -4,6 +4,9 @@ import { pluginApiDocgen } from '@rspress/plugin-api-docgen';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc'),
+  route: {
+    localeRedirect: 'never',
+  },
   lang: 'en',
   plugins: [
     pluginApiDocgen({

--- a/e2e/utils/runCommands.ts
+++ b/e2e/utils/runCommands.ts
@@ -30,7 +30,6 @@ export async function runNpmScript(
     const instance = spawn('npm', commandArgs, {
       cwd: options.appDir,
       env: {
-        TEST: '1',
         ...process.env,
         ...options.env,
       },

--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -244,7 +244,7 @@ async function createInternalBuildConfig(
       favicon: normalizeIcon(config?.icon),
       template: TEMPLATE_PATH,
       tags: [
-        process.env.TEST !== '1' && localeRedirectScript
+        localeRedirectScript
           ? {
               tag: 'script',
               children: localeRedirectScript,
@@ -297,7 +297,6 @@ async function createInternalBuildConfig(
       ],
       include: [PACKAGE_ROOT],
       define: {
-        'process.env.TEST': JSON.stringify(process.env.TEST),
         'import.meta.env.ENABLE_LLMS_UI': JSON.stringify(enableLlmsUI),
         'import.meta.env.ENABLE_LLMS_HINT': JSON.stringify(enableLlmsHint),
       },


### PR DESCRIPTION
## Summary

- remove the `TEST` environment gate from locale redirect script injection
- stop exposing `process.env.TEST` to client builds and E2E subprocesses
- rely on `route.localeRedirect` for explicit redirect opt-out behavior
- disable locale redirects in E2E fixtures that assert fixed non-default-language routes

## Checklist

- [x] Tests updated.
- [x] Documentation updated (not required).
