### PR TITLE
fix(core): declare public type dependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -69,6 +69,8 @@
     "@rsbuild/plugin-react": "~2.1.0",
     "@rspress/shared": "workspace:*",
     "@shikijs/rehype": "^4.2.0",
+    "@types/mdast": "^4.0.4",
+    "@types/react": "^19.2.17",
     "@types/unist": "^3.0.3",
     "@unhead/react": "^2.1.16",
     "body-scroll-lock": "4.0.0-beta.0",
@@ -100,7 +102,8 @@
     "unified": "^11.0.5",
     "unist-util-remove": "^4.0.0",
     "unist-util-visit": "^5.1.0",
-    "unist-util-visit-children": "^3.0.0"
+    "unist-util-visit-children": "^3.0.0",
+    "vfile": "^6.0.3"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.11",
@@ -110,10 +113,8 @@
     "@rspress/config": "workspace:*",
     "@types/body-scroll-lock": "^3.1.2",
     "@types/hast": "^3.0.5",
-    "@types/mdast": "^4.0.4",
     "@types/node": "^22.8.1",
     "@types/nprogress": "^0.2.3",
-    "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@types/react-reconciler": "^0.33.0",
     "@types/web": "^0.0.353",
@@ -132,8 +133,7 @@
     "tinyglobby": "^0.2.17",
     "tinypool": "^1.1.1",
     "ts-json-schema-generator": "^2.9.0",
-    "typescript": "^6.0.3",
-    "vfile": "^6.0.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -52,17 +52,17 @@
   "dependencies": {
     "@rsbuild/core": "^2.1.7",
     "@shikijs/rehype": "^4.2.0",
+    "@types/react": "^19.2.17",
+    "mdast-util-mdx-jsx": "^3.2.0",
     "unified": "^11.0.5"
   },
   "devDependencies": {
     "@rslib/core": "0.23.2",
     "@types/lodash-es": "^4.17.12",
     "@types/node": "^22.8.1",
-    "@types/react": "^19.2.17",
     "github-slugger": "^2.0.0",
     "gray-matter": "4.0.3",
     "lodash-es": "^4.18.1",
-    "mdast-util-mdx-jsx": "^3.2.0",
     "medium-zoom": "1.1.0",
     "rimraf": "^6.1.3",
     "rsbuild-plugin-publint": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1043,6 +1043,12 @@ importers:
       '@shikijs/rehype':
         specifier: ^4.2.0
         version: 4.2.0
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
@@ -1139,6 +1145,9 @@ importers:
       unist-util-visit-children:
         specifier: ^3.0.0
         version: 3.0.0
+      vfile:
+        specifier: ^6.0.3
+        version: 6.0.3
     devDependencies:
       '@microsoft/api-extractor':
         specifier: ^7.58.11
@@ -1161,18 +1170,12 @@ importers:
       '@types/hast':
         specifier: ^3.0.5
         version: 3.0.5
-      '@types/mdast':
-        specifier: ^4.0.4
-        version: 4.0.4
       '@types/node':
         specifier: ^22.8.1
         version: 22.19.15
       '@types/nprogress':
         specifier: ^0.2.3
         version: 0.2.3
-      '@types/react':
-        specifier: ^19.2.17
-        version: 19.2.17
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
@@ -1228,9 +1231,6 @@ importers:
         specifier: ^2.9.0
         version: 2.9.0
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
-      vfile:
         specifier: ^6.0.3
         version: 6.0.3
 
@@ -1751,6 +1751,12 @@ importers:
       '@shikijs/rehype':
         specifier: ^4.2.0
         version: 4.2.0
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      mdast-util-mdx-jsx:
+        specifier: ^3.2.0
+        version: 3.2.0
       unified:
         specifier: ^11.0.5
         version: 11.0.5
@@ -1764,9 +1770,6 @@ importers:
       '@types/node':
         specifier: ^22.8.1
         version: 22.19.15
-      '@types/react':
-        specifier: ^19.2.17
-        version: 19.2.17
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
@@ -1776,9 +1779,6 @@ importers:
       lodash-es:
         specifier: ^4.18.1
         version: 4.18.1
-      mdast-util-mdx-jsx:
-        specifier: ^3.2.0
-        version: 3.2.0
       medium-zoom:
         specifier: 1.1.0
         version: 1.1.0

--- a/website/theme/env.d.ts
+++ b/website/theme/env.d.ts
@@ -1,2 +1,3 @@
 declare module '*.module.scss';
+declare module '*.scss';
 declare module '*.css';

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -10,13 +10,7 @@
     },
     "module": "ESNext"
   },
-  "include": [
-    "./rspress.config.ts",
-    "docs/**/*",
-    "src/**/*",
-    "theme/**/*",
-    "search.tsx"
-  ],
+  "include": ["./rspress.config.ts", "docs/**/*", "src/**/*", "theme/**/*"],
   "mdx": {
     "checkMdx": true
   }


### PR DESCRIPTION
## Summary

The public declarations published by `@rspress/core` and `@rspress/shared` reference packages that were only available during development, causing module resolution errors under strict pnpm layouts with `skipLibCheck: false`.

This PR moves those declaration dependencies to `dependencies` so they are available to consumers. It also aligns the website TypeScript inputs by declaring global SCSS modules and removing the stale `search.tsx` include.

## Related Issue

Fixes https://github.com/web-infra-dev/rspress/issues/3539

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
