### PR TITLE
fix(core): preserve async config inference

### DIFF
--- a/packages/core/src/config/defineConfig.ts
+++ b/packages/core/src/config/defineConfig.ts
@@ -8,20 +8,6 @@ import type { UserConfig } from '@rspress/shared';
 export type UserConfigAsyncFn = () => Promise<UserConfig>;
 
 /**
- * Define a static Rspress configuration object.
- * @param config - The Rspress configuration object.
- * @returns The same configuration object (enables type checking and IDE autocompletion).
- * @example
- * ```ts
- * import { defineConfig } from '@rspress/core';
- *
- * export default defineConfig({
- *   title: 'My Site',
- * });
- * ```
- */
-export function defineConfig(config: UserConfig): UserConfig;
-/**
  * Define an async Rspress configuration function.
  * Use this overload when you need to perform async operations during configuration,
  * such as fetching remote data, reading files, or dynamically generating config.
@@ -39,7 +25,23 @@ export function defineConfig(config: UserConfig): UserConfig;
  * });
  * ```
  */
-export function defineConfig(config: UserConfigAsyncFn): UserConfigAsyncFn;
+export function defineConfig<const Config extends UserConfig>(
+  config: () => Promise<Config>,
+): UserConfigAsyncFn;
+/**
+ * Define a static Rspress configuration object.
+ * @param config - The Rspress configuration object.
+ * @returns The same configuration object (enables type checking and IDE autocompletion).
+ * @example
+ * ```ts
+ * import { defineConfig } from '@rspress/core';
+ *
+ * export default defineConfig({
+ *   title: 'My Site',
+ * });
+ * ```
+ */
+export function defineConfig(config: UserConfig): UserConfig;
 export function defineConfig(
   config: UserConfig | UserConfigAsyncFn,
 ): UserConfig | UserConfigAsyncFn {


### PR DESCRIPTION
## Summary

Async `defineConfig` callbacks can widen literal configuration values, causing valid configurations such as `themeConfig.hideNavbar: 'always'` to fail overload resolution. This PR adds a const-generic async overload before the object overload while preserving the existing `UserConfigAsyncFn` return type.

## Related Issue

- Related to https://github.com/web-infra-dev/rslib/pull/1787

## Checklist

- [x] Tests updated (or not required). Rspress does not currently have type-tests, so this PR intentionally contains no test changes.
- [x] Documentation updated (or not required).