### PR TITLE
chore(deps): upgrade Rslib to 1.0.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@rstest/core": "^0.11.2",
     "@types/cross-spawn": "^6.0.6",
     "@types/node": "^22.8.1",
-    "@typescript/native-preview": "7.0.0-dev.20260707.2",
+    "@typescript/native": "npm:typescript@7.0.2",
     "bumpp": "^11.1.0",
     "check-dependency-version-consistency": "^5.0.1",
     "cross-env": "^10.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -106,7 +106,7 @@
     "@microsoft/api-extractor": "^7.58.11",
     "@rsbuild/plugin-sass": "~1.5.3",
     "@rsbuild/plugin-svgr": "^2.0.5",
-    "@rslib/core": "0.23.2",
+    "@rslib/core": "1.0.0-beta.1",
     "@rspress/config": "workspace:*",
     "@types/body-scroll-lock": "^3.1.2",
     "@types/hast": "^3.0.5",

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -9,6 +9,7 @@ import { defineConfig } from '@rslib/core';
 import { pluginPublint } from 'rsbuild-plugin-publint';
 
 const require = createRequire(import.meta.url);
+const typescriptPath = fileURLToPath(import.meta.resolve('@typescript/native'));
 const tinypoolDistPath = path.join(
   path.dirname(require.resolve('tinypool/package.json')),
   'dist',
@@ -118,12 +119,7 @@ export default defineConfig({
     {
       bundle: false,
       dts: {
-        tsgo: true,
-      },
-      redirect: {
-        dts: {
-          extension: true,
-        },
+        typescriptPath,
       },
       plugins: [
         pluginReact(),

--- a/packages/create-rspress/package.json
+++ b/packages/create-rspress/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.11",
-    "@rslib/core": "0.23.2",
+    "@rslib/core": "1.0.0-beta.1",
     "@types/node": "^22.8.1",
     "rsbuild-plugin-publint": "^1.0.0",
     "typescript": "^6.0.3"

--- a/packages/plugin-algolia/package.json
+++ b/packages/plugin-algolia/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.11",
     "@rsbuild/plugin-react": "~2.1.0",
-    "@rslib/core": "0.23.2",
+    "@rslib/core": "1.0.0-beta.1",
     "@rspress/config": "workspace:*",
     "@types/node": "^22.8.1",
     "@types/react": "^19.2.17",

--- a/packages/plugin-algolia/rslib.config.ts
+++ b/packages/plugin-algolia/rslib.config.ts
@@ -1,6 +1,9 @@
+import { fileURLToPath } from 'node:url';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rslib/core';
 import { pluginPublint } from 'rsbuild-plugin-publint';
+
+const typescriptPath = fileURLToPath(import.meta.resolve('@typescript/native'));
 
 export default defineConfig({
   plugins: [pluginPublint()],
@@ -12,14 +15,9 @@ export default defineConfig({
         },
       },
       dts: {
-        tsgo: true,
+        typescriptPath,
       },
       syntax: 'es2023',
-      redirect: {
-        dts: {
-          extension: true,
-        },
-      },
     },
     {
       source: {

--- a/packages/plugin-api-docgen/package.json
+++ b/packages/plugin-api-docgen/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.11",
-    "@rslib/core": "0.23.2",
+    "@rslib/core": "1.0.0-beta.1",
     "@types/hast": "^3.0.5",
     "@types/mdast": "^4.0.4",
     "@types/node": "^22.8.1",

--- a/packages/plugin-api-docgen/rslib.config.ts
+++ b/packages/plugin-api-docgen/rslib.config.ts
@@ -1,12 +1,15 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from '@rslib/core';
 import { pluginPublint } from 'rsbuild-plugin-publint';
+
+const typescriptPath = fileURLToPath(import.meta.resolve('@typescript/native'));
 
 export default defineConfig({
   plugins: [pluginPublint()],
   lib: [
     {
       dts: {
-        tsgo: true,
+        typescriptPath,
         bundle: true,
       },
       syntax: 'es2023',

--- a/packages/plugin-client-redirects/package.json
+++ b/packages/plugin-client-redirects/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.11",
-    "@rslib/core": "0.23.2",
+    "@rslib/core": "1.0.0-beta.1",
     "@rspress/config": "workspace:*",
     "@types/node": "^22.8.1",
     "@types/react": "^19.2.17",

--- a/packages/plugin-client-redirects/rslib.config.ts
+++ b/packages/plugin-client-redirects/rslib.config.ts
@@ -1,12 +1,15 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from '@rslib/core';
 import { pluginPublint } from 'rsbuild-plugin-publint';
+
+const typescriptPath = fileURLToPath(import.meta.resolve('@typescript/native'));
 
 export default defineConfig({
   plugins: [pluginPublint()],
   lib: [
     {
       dts: {
-        tsgo: true,
+        typescriptPath,
         bundle: true,
       },
       syntax: 'es2023',

--- a/packages/plugin-llms/package.json
+++ b/packages/plugin-llms/package.json
@@ -43,7 +43,7 @@
     "@microsoft/api-extractor": "^7.58.11",
     "@rsbuild/core": "^2.1.7",
     "@rsbuild/plugin-react": "~2.1.0",
-    "@rslib/core": "0.23.2",
+    "@rslib/core": "1.0.0-beta.1",
     "@rspress/config": "workspace:*",
     "@types/hast": "^3.0.5",
     "@types/mdast": "^4.0.4",

--- a/packages/plugin-llms/rslib.config.ts
+++ b/packages/plugin-llms/rslib.config.ts
@@ -1,13 +1,16 @@
+import { fileURLToPath } from 'node:url';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rslib/core';
 import { pluginPublint } from 'rsbuild-plugin-publint';
+
+const typescriptPath = fileURLToPath(import.meta.resolve('@typescript/native'));
 
 export default defineConfig({
   plugins: [pluginPublint()],
   lib: [
     {
       dts: {
-        tsgo: true,
+        typescriptPath,
         bundle: true,
       },
       source: {
@@ -30,7 +33,7 @@ export default defineConfig({
     },
     {
       dts: {
-        tsgo: true,
+        typescriptPath,
         bundle: true,
       },
       source: {

--- a/packages/plugin-playground/package.json
+++ b/packages/plugin-playground/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@babel/types": "^7.29.7",
     "@rsbuild/plugin-react": "~2.1.0",
-    "@rslib/core": "0.23.2",
+    "@rslib/core": "1.0.0-beta.1",
     "@rspress/plugin-playground": "workspace:*",
     "@types/babel__core": "^7.20.5",
     "@types/babel__standalone": "^7.1.9",

--- a/packages/plugin-playground/rslib.config.ts
+++ b/packages/plugin-playground/rslib.config.ts
@@ -1,6 +1,9 @@
+import { fileURLToPath } from 'node:url';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rslib/core';
 import { pluginPublint } from 'rsbuild-plugin-publint';
+
+const typescriptPath = fileURLToPath(import.meta.resolve('@typescript/native'));
 
 export default defineConfig({
   plugins: [pluginPublint()],
@@ -22,7 +25,7 @@ export default defineConfig({
       },
       syntax: 'es2023',
       dts: {
-        tsgo: true,
+        typescriptPath,
         bundle: true,
       },
     },
@@ -39,7 +42,7 @@ export default defineConfig({
       },
       syntax: 'es2023',
       dts: {
-        tsgo: true,
+        typescriptPath,
         bundle: true,
       },
     },

--- a/packages/plugin-preview/package.json
+++ b/packages/plugin-preview/package.json
@@ -34,7 +34,7 @@
     "qrcode.react": "^4.2.0"
   },
   "devDependencies": {
-    "@rslib/core": "0.23.2",
+    "@rslib/core": "1.0.0-beta.1",
     "@types/mdast": "^4.0.4",
     "@types/node": "^22.8.1",
     "@types/react": "^19.2.17",

--- a/packages/plugin-preview/rslib.config.ts
+++ b/packages/plugin-preview/rslib.config.ts
@@ -1,5 +1,8 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from '@rslib/core';
 import { pluginPublint } from 'rsbuild-plugin-publint';
+
+const typescriptPath = fileURLToPath(import.meta.resolve('@typescript/native'));
 
 export default defineConfig({
   plugins: [pluginPublint()],
@@ -12,7 +15,7 @@ export default defineConfig({
       },
       syntax: 'es2023',
       dts: {
-        tsgo: true,
+        typescriptPath,
         bundle: true,
       },
     },
@@ -24,7 +27,7 @@ export default defineConfig({
       },
       syntax: 'es2023',
       dts: {
-        tsgo: true,
+        typescriptPath,
         bundle: true,
       },
     },

--- a/packages/plugin-rss/package.json
+++ b/packages/plugin-rss/package.json
@@ -33,7 +33,7 @@
     "feed": "^5.2.1"
   },
   "devDependencies": {
-    "@rslib/core": "0.23.2",
+    "@rslib/core": "1.0.0-beta.1",
     "@types/node": "^22.8.1",
     "@types/react": "^19.2.17",
     "react": "^19.2.7",

--- a/packages/plugin-rss/rslib.config.ts
+++ b/packages/plugin-rss/rslib.config.ts
@@ -1,5 +1,8 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from '@rslib/core';
 import { pluginPublint } from 'rsbuild-plugin-publint';
+
+const typescriptPath = fileURLToPath(import.meta.resolve('@typescript/native'));
 
 export default defineConfig({
   plugins: [pluginPublint()],
@@ -8,7 +11,7 @@ export default defineConfig({
       bundle: true,
       syntax: 'es2023',
       dts: {
-        tsgo: true,
+        typescriptPath,
         bundle: true,
       },
     },

--- a/packages/plugin-sitemap/package.json
+++ b/packages/plugin-sitemap/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.11",
-    "@rslib/core": "0.23.2",
+    "@rslib/core": "1.0.0-beta.1",
     "@rspress/config": "workspace:*",
     "rsbuild-plugin-publint": "^1.0.0"
   },

--- a/packages/plugin-sitemap/rslib.config.ts
+++ b/packages/plugin-sitemap/rslib.config.ts
@@ -1,5 +1,8 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from '@rslib/core';
 import { pluginPublint } from 'rsbuild-plugin-publint';
+
+const typescriptPath = fileURLToPath(import.meta.resolve('@typescript/native'));
 
 export default defineConfig({
   plugins: [pluginPublint()],
@@ -8,7 +11,7 @@ export default defineConfig({
       bundle: true,
       syntax: 'es2023',
       dts: {
-        tsgo: true,
+        typescriptPath,
         bundle: true,
       },
     },

--- a/packages/plugin-twoslash/package.json
+++ b/packages/plugin-twoslash/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.11",
-    "@rslib/core": "0.23.2",
+    "@rslib/core": "1.0.0-beta.1",
     "@rspress/config": "workspace:*",
     "@shikijs/types": "^4.2.0",
     "@types/hast": "^3.0.5",

--- a/packages/plugin-twoslash/rslib.config.ts
+++ b/packages/plugin-twoslash/rslib.config.ts
@@ -1,12 +1,15 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from '@rslib/core';
 import { pluginPublint } from 'rsbuild-plugin-publint';
+
+const typescriptPath = fileURLToPath(import.meta.resolve('@typescript/native'));
 
 export default defineConfig({
   plugins: [pluginPublint()],
   lib: [
     {
       dts: {
-        tsgo: true,
+        typescriptPath,
         bundle: true,
       },
       syntax: 'es2023',

--- a/packages/plugin-typedoc/package.json
+++ b/packages/plugin-typedoc/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.11",
-    "@rslib/core": "0.23.2",
+    "@rslib/core": "1.0.0-beta.1",
     "@rspress/config": "workspace:*",
     "@types/node": "^22.8.1",
     "@types/react": "^19.2.17",

--- a/packages/plugin-typedoc/rslib.config.ts
+++ b/packages/plugin-typedoc/rslib.config.ts
@@ -1,12 +1,15 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from '@rslib/core';
 import { pluginPublint } from 'rsbuild-plugin-publint';
+
+const typescriptPath = fileURLToPath(import.meta.resolve('@typescript/native'));
 
 export default defineConfig({
   plugins: [pluginPublint()],
   lib: [
     {
       dts: {
-        tsgo: true,
+        typescriptPath,
         bundle: true,
       },
       syntax: 'es2023',

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -55,7 +55,7 @@
     "unified": "^11.0.5"
   },
   "devDependencies": {
-    "@rslib/core": "0.23.2",
+    "@rslib/core": "1.0.0-beta.1",
     "@types/lodash-es": "^4.17.12",
     "@types/node": "^22.8.1",
     "@types/react": "^19.2.17",

--- a/packages/shared/rslib.config.ts
+++ b/packages/shared/rslib.config.ts
@@ -1,11 +1,14 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from '@rslib/core';
 import { pluginPublint } from 'rsbuild-plugin-publint';
+
+const typescriptPath = fileURLToPath(import.meta.resolve('@typescript/native'));
 
 export default defineConfig({
   lib: [
     {
       dts: {
-        tsgo: true,
+        typescriptPath,
         bundle: true,
       },
       syntax: 'es2023',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: link:scripts/config
       '@rstest/adapter-rslib':
         specifier: 0.11.2
-        version: 0.11.2(@rslib/core@0.23.2(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3))(@rstest/core@0.11.2)(typescript@6.0.3)
+        version: 0.11.2(@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(typescript@7.0.2))(@rstest/core@0.11.2)(typescript@6.0.3)
       '@rstest/core':
         specifier: ^0.11.2
         version: 0.11.2
@@ -35,9 +35,9 @@ importers:
       '@types/node':
         specifier: ^22.8.1
         version: 22.19.15
-      '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260707.2
-        version: 7.0.0-dev.20260707.2
+      '@typescript/native':
+        specifier: npm:typescript@7.0.2
+        version: typescript@7.0.2
       bumpp:
         specifier: ^11.1.0
         version: 11.1.0
@@ -1150,8 +1150,8 @@ importers:
         specifier: ^2.0.5
         version: 2.0.5(@rsbuild/core@2.1.7)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(typescript@6.0.3)
       '@rslib/core':
-        specifier: 0.23.2
-        version: 0.23.2(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
+        specifier: 1.0.0-beta.1
+        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(typescript@6.0.3)
       '@rspress/config':
         specifier: workspace:*
         version: link:../../scripts/config
@@ -1244,8 +1244,8 @@ importers:
         specifier: ^7.58.11
         version: 7.58.11(@types/node@22.19.15)
       '@rslib/core':
-        specifier: 0.23.2
-        version: 0.23.2(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
+        specifier: 1.0.0-beta.1
+        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(typescript@6.0.3)
       '@types/node':
         specifier: ^22.8.1
         version: 22.19.15
@@ -1275,8 +1275,8 @@ importers:
         specifier: ~2.1.0
         version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.5(@swc/helpers@0.5.23))
       '@rslib/core':
-        specifier: 0.23.2
-        version: 0.23.2(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
+        specifier: 1.0.0-beta.1
+        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(typescript@6.0.3)
       '@rspress/config':
         specifier: workspace:*
         version: link:../../scripts/config
@@ -1333,8 +1333,8 @@ importers:
         specifier: ^7.58.11
         version: 7.58.11(@types/node@22.19.15)
       '@rslib/core':
-        specifier: 0.23.2
-        version: 0.23.2(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
+        specifier: 1.0.0-beta.1
+        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(typescript@6.0.3)
       '@types/hast':
         specifier: ^3.0.5
         version: 3.0.5
@@ -1379,8 +1379,8 @@ importers:
         specifier: ^7.58.11
         version: 7.58.11(@types/node@22.19.15)
       '@rslib/core':
-        specifier: 0.23.2
-        version: 0.23.2(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
+        specifier: 1.0.0-beta.1
+        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(typescript@6.0.3)
       '@rspress/config':
         specifier: workspace:*
         version: link:../../scripts/config
@@ -1434,8 +1434,8 @@ importers:
         specifier: ~2.1.0
         version: 2.1.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5(@swc/helpers@0.5.23))
       '@rslib/core':
-        specifier: 0.23.2
-        version: 0.23.2(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
+        specifier: 1.0.0-beta.1
+        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(typescript@6.0.3)
       '@rspress/config':
         specifier: workspace:*
         version: link:../../scripts/config
@@ -1495,8 +1495,8 @@ importers:
         specifier: ~2.1.0
         version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.5(@swc/helpers@0.5.23))
       '@rslib/core':
-        specifier: 0.23.2
-        version: 0.23.2(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
+        specifier: 1.0.0-beta.1
+        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(typescript@6.0.3)
       '@rspress/plugin-playground':
         specifier: workspace:*
         version: 'link:'
@@ -1559,8 +1559,8 @@ importers:
         version: 4.2.0(react@19.2.7)
     devDependencies:
       '@rslib/core':
-        specifier: 0.23.2
-        version: 0.23.2(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
+        specifier: 1.0.0-beta.1
+        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(typescript@6.0.3)
       '@types/mdast':
         specifier: ^4.0.4
         version: 4.0.4
@@ -1608,8 +1608,8 @@ importers:
         version: 5.2.1
     devDependencies:
       '@rslib/core':
-        specifier: 0.23.2
-        version: 0.23.2(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
+        specifier: 1.0.0-beta.1
+        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(typescript@6.0.3)
       '@types/node':
         specifier: ^22.8.1
         version: 22.19.15
@@ -1636,8 +1636,8 @@ importers:
         specifier: ^7.58.11
         version: 7.58.11(@types/node@25.6.0)
       '@rslib/core':
-        specifier: 0.23.2
-        version: 0.23.2(@microsoft/api-extractor@7.58.11(@types/node@25.6.0))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
+        specifier: 1.0.0-beta.1
+        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@25.6.0))(typescript@7.0.2)
       '@rspress/config':
         specifier: workspace:*
         version: link:../../scripts/config
@@ -1676,8 +1676,8 @@ importers:
         specifier: ^7.58.11
         version: 7.58.11(@types/node@25.6.0)
       '@rslib/core':
-        specifier: 0.23.2
-        version: 0.23.2(@microsoft/api-extractor@7.58.11(@types/node@25.6.0))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
+        specifier: 1.0.0-beta.1
+        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@25.6.0))(typescript@6.0.3)
       '@rspress/config':
         specifier: workspace:*
         version: link:../../scripts/config
@@ -1719,8 +1719,8 @@ importers:
         specifier: ^7.58.11
         version: 7.58.11(@types/node@22.19.15)
       '@rslib/core':
-        specifier: 0.23.2
-        version: 0.23.2(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
+        specifier: 1.0.0-beta.1
+        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(typescript@6.0.3)
       '@rspress/config':
         specifier: workspace:*
         version: link:../../scripts/config
@@ -1756,8 +1756,8 @@ importers:
         version: 11.0.5
     devDependencies:
       '@rslib/core':
-        specifier: 0.23.2
-        version: 0.23.2(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
+        specifier: 1.0.0-beta.1
+        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(typescript@6.0.3)
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
@@ -3227,13 +3227,13 @@ packages:
   '@rsdoctor/utils@1.6.0':
     resolution: {integrity: sha512-Qlap7yXB20fw4TShHBvz4jzMy9NzWdbQyhtieDBQHED4k7VeU+GI0I9EoXtOPgc44Nj5Gf4guq52gBkh8kGWJA==}
 
-  '@rslib/core@0.23.2':
-    resolution: {integrity: sha512-KxSp+/y0BJ1O4oKwxX4ydBY7/ZVeJCUpWAmQniCIct8mTxIQFPGO/ibKbKq2IxZYqRuRpM8g+Dtyq0VbEQf9HQ==}
+  '@rslib/core@1.0.0-beta.1':
+    resolution: {integrity: sha512-HHPZ+wTUKT/3bEhw2y0JB0O62wMuljkSHVZelLbSGhBflCaUt+D3LohBcIxYW6bhzPbUp4gkJXo1pdTpxiuNLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@microsoft/api-extractor': ^7
-      typescript: ^5 || ^6 || ^7.0.1-0
+      typescript: ^5 || ^6 || ^7
     peerDependenciesMeta:
       '@microsoft/api-extractor':
         optional: true
@@ -3987,52 +3987,125 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2':
-    resolution: {integrity: sha512-wny2pgKjGbiZtnOIHVa3tXC1UfDqxNEFzyPGmiqybedG8hipG2Nfp0l5UxbaKCjkLacUpH/W5bP2hBOMVhCOzg==}
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260707.2':
-    resolution: {integrity: sha512-Afc7M5zOwo+GpfcYwz5Z8HMB2tPVsui7nNIqEuuFB73MPdVqNn/Wmpe4tP4MRri0AtJnJknoHBaTJ/VDAp/Jhw==}
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260707.2':
-    resolution: {integrity: sha512-iITBa2WjjTI5N9t5l7Z4KoOSI+2zBlhbvFzsD/f8qX8QoKjz/Y4DPyBDgezYi8nkqjjksbgSOJ3/ykzhwrB9cg==}
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260707.2':
-    resolution: {integrity: sha512-hJm/UOqZTr9FHmR7uNm8VGX4oKtfWk0Jem0zPeJFNC8ckGUfSBueyiEYMZB+XmRc1aG4x1E46y3CplP4CLHvGQ==}
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260707.2':
-    resolution: {integrity: sha512-du0dzi6y97Po5vDNdPJTyyijHCpaS22JLRnKZEJXBDaO9gCIymOv/5QQokFRuOlQm0bWl3i9PF4OVdGP6uAOQA==}
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260707.2':
-    resolution: {integrity: sha512-SsAwfhyHJ1akgBc+99z4+hwdbHsdWaKB8EwCNIMA6JfSLMeUjffrYvxu+vfMyxVtOVOz7RrRXRoiDiu4a2sCtg==}
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2':
-    resolution: {integrity: sha512-DL4u27stv0fo71sVhOzHSwE+YMZsbBijVI+kg5dLDLilSH79WFTJ8RSQ46vJrCMt+Gjlv/JOZP1PuLJDfioYeQ==}
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
-
-  '@typescript/native-preview@7.0.0-dev.20260707.2':
-    resolution: {integrity: sha512-oUGp+Rep/hqMhPunyinsALUwSlzHINSxitifPiSaeqoKOKD2OlR9NE3TaPqwsl4NlGslsOSUXI1JotWQzpYCPg==}
-    engines: {node: '>=16.20.0'}
-    hasBin: true
 
   '@typescript/vfs@1.6.4':
     resolution: {integrity: sha512-PJFXFS4ZJKiJ9Qiuix6Dz/OwEIqHD7Dme1UwZhTK11vR+5dqW2ACbdndWQexBzCx+CPuMe5WBYQWCsFyGlQLlQ==}
@@ -6627,18 +6700,15 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
-  rsbuild-plugin-dts@0.23.2:
-    resolution: {integrity: sha512-Ve8WOSPyTBjxH40O/6fChJtflL7yqcUtt5zbF0eHDM4hIt35jqLocRlSdCxFJdQm0blTjl6+hkmPa/vNI06ArA==}
+  rsbuild-plugin-dts@1.0.0-beta.1:
+    resolution: {integrity: sha512-hAEjOXhfIHR4erqjsqjRvA9Yqzc6Thry06tHheXDJUVwmR3VbN8BSMDC8kBZzyKdypDF0IJ98FmLQRiC194sMA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@microsoft/api-extractor': ^7
-      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
-      '@typescript/native-preview': ^7.0.0-0
-      typescript: ^5 || ^6 || ^7.0.1-0
+      '@rsbuild/core': ^2.0.0
+      typescript: ^5 || ^6 || ^7
     peerDependenciesMeta:
       '@microsoft/api-extractor':
-        optional: true
-      '@typescript/native-preview':
         optional: true
       typescript:
         optional: true
@@ -7296,6 +7366,11 @@ packages:
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   uc.micro@2.1.0:
@@ -9173,28 +9248,48 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rslib/core@0.23.2(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)':
+  '@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/core': 2.1.6
-      rsbuild-plugin-dts: 0.23.2(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@rsbuild/core@2.1.6)(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
+      '@rsbuild/core': 2.1.7
+      rsbuild-plugin-dts: 1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@rsbuild/core@2.1.7)(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.11(@types/node@22.19.15)
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
-      - '@typescript/native-preview'
       - core-js
 
-  '@rslib/core@0.23.2(@microsoft/api-extractor@7.58.11(@types/node@25.6.0))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)':
+  '@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(typescript@7.0.2)':
     dependencies:
-      '@rsbuild/core': 2.1.6
-      rsbuild-plugin-dts: 0.23.2(@microsoft/api-extractor@7.58.11(@types/node@25.6.0))(@rsbuild/core@2.1.6)(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
+      '@rsbuild/core': 2.1.7
+      rsbuild-plugin-dts: 1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@rsbuild/core@2.1.7)(typescript@7.0.2)
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.58.11(@types/node@22.19.15)
+      typescript: 7.0.2
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - core-js
+
+  '@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@25.6.0))(typescript@6.0.3)':
+    dependencies:
+      '@rsbuild/core': 2.1.7
+      rsbuild-plugin-dts: 1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@25.6.0))(@rsbuild/core@2.1.7)(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.11(@types/node@25.6.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
-      - '@typescript/native-preview'
+      - core-js
+
+  '@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@25.6.0))(typescript@7.0.2)':
+    dependencies:
+      '@rsbuild/core': 2.1.7
+      rsbuild-plugin-dts: 1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@25.6.0))(@rsbuild/core@2.1.7)(typescript@7.0.2)
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.58.11(@types/node@25.6.0)
+      typescript: 7.0.2
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - core-js
 
   '@rslint/core@0.6.5(jiti@2.7.0)':
@@ -9426,9 +9521,9 @@ snapshots:
     optionalDependencies:
       '@rspress/core': link:packages/core
 
-  '@rstest/adapter-rslib@0.11.2(@rslib/core@0.23.2(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3))(@rstest/core@0.11.2)(typescript@6.0.3)':
+  '@rstest/adapter-rslib@0.11.2(@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(typescript@7.0.2))(@rstest/core@0.11.2)(typescript@6.0.3)':
     dependencies:
-      '@rslib/core': 0.23.2(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
+      '@rslib/core': 1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(typescript@7.0.2)
       '@rstest/core': 0.11.2
     optionalDependencies:
       typescript: 6.0.3
@@ -9925,36 +10020,65 @@ snapshots:
     dependencies:
       '@types/node': 22.19.15
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2':
+  '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260707.2':
+  '@typescript/typescript-darwin-arm64@7.0.2':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260707.2':
+  '@typescript/typescript-darwin-x64@7.0.2':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260707.2':
+  '@typescript/typescript-freebsd-arm64@7.0.2':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260707.2':
+  '@typescript/typescript-freebsd-x64@7.0.2':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260707.2':
+  '@typescript/typescript-linux-arm64@7.0.2':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2':
+  '@typescript/typescript-linux-arm@7.0.2':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260707.2':
-    optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260707.2
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260707.2
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260707.2
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260707.2
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260707.2
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260707.2
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260707.2
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
 
   '@typescript/vfs@1.6.4(typescript@6.0.3)':
     dependencies:
@@ -13349,23 +13473,37 @@ snapshots:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
 
-  rsbuild-plugin-dts@0.23.2(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@rsbuild/core@2.1.6)(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3):
+  rsbuild-plugin-dts@1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@rsbuild/core@2.1.7)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.1.6
+      '@rsbuild/core': 2.1.7
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.11(@types/node@22.19.15)
-      '@typescript/native-preview': 7.0.0-dev.20260707.2
       typescript: 6.0.3
 
-  rsbuild-plugin-dts@0.23.2(@microsoft/api-extractor@7.58.11(@types/node@25.6.0))(@rsbuild/core@2.1.6)(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3):
+  rsbuild-plugin-dts@1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@22.19.15))(@rsbuild/core@2.1.7)(typescript@7.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.1.6
+      '@rsbuild/core': 2.1.7
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.58.11(@types/node@22.19.15)
+      typescript: 7.0.2
+
+  rsbuild-plugin-dts@1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@25.6.0))(@rsbuild/core@2.1.7)(typescript@6.0.3):
+    dependencies:
+      '@ast-grep/napi': 0.37.0
+      '@rsbuild/core': 2.1.7
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.11(@types/node@25.6.0)
-      '@typescript/native-preview': 7.0.0-dev.20260707.2
       typescript: 6.0.3
+
+  rsbuild-plugin-dts@1.0.0-beta.1(@microsoft/api-extractor@7.58.11(@types/node@25.6.0))(@rsbuild/core@2.1.7)(typescript@7.0.2):
+    dependencies:
+      '@ast-grep/napi': 0.37.0
+      '@rsbuild/core': 2.1.7
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.58.11(@types/node@25.6.0)
+      typescript: 7.0.2
 
   rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.6):
     optionalDependencies:
@@ -13992,6 +14130,29 @@ snapshots:
   typescript@5.9.3: {}
 
   typescript@6.0.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   uc.micro@2.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,6 +22,7 @@ minimumReleaseAgeExclude:
   - '@rspack/*'
   - '@rsbuild/*'
   - '@rslib/*'
+  - rsbuild-plugin-dts
   - '@rspress/*'
   - '@rstest/*'
   - '@rsdoctor/*'


### PR DESCRIPTION
## Summary

This PR upgrades all Rslib build dependencies to v1.0.0-beta.1 and exempts its exact `rsbuild-plugin-dts` beta dependency from the minimum release age.
DTS builds now resolve TypeScript 7 through an npm alias and `dts.typescriptPath`, replacing the removed `@typescript/native-preview` integration.
The explicit declaration-extension redirects are removed because beta.1 enables them by default.
Artifact comparison against the pre-upgrade build found all 269 declaration files and every non-core JavaScript file byte-for-byte identical; core JavaScript differences are limited to generated chunk names and internal module IDs.

## Related Issue

- https://github.com/web-infra-dev/rslib/releases/tag/v1.0.0-beta.1
- https://github.com/web-infra-dev/rslib/pull/1784

## Validation

- Built all 13 packages and the production website.
- Passed 323 unit tests and 218 end-to-end tests.
- Passed lint, type checking, formatting, spelling, and heading-case checks.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).