### PR TITLE
perf(core): resolve lastUpdated with a single git process

### DIFF
--- a/.changeset/rotten-moons-fetch.md
+++ b/.changeset/rotten-moons-fetch.md
@@ -1,0 +1,5 @@
+---
+'@rspress/core': patch
+---
+
+Resolve the `lastUpdated` git metadata of every page with a single `git log` process instead of forking one `git` process per page.

--- a/packages/core/src/node/last-updated/gitLog.test.ts
+++ b/packages/core/src/node/last-updated/gitLog.test.ts
@@ -1,0 +1,90 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import type { PageIndexInfo, RouteMeta } from '@rspress/shared';
+import { afterAll, beforeAll, describe, expect, it } from '@rstest/core';
+import { execa } from 'execa';
+import { pluginLastUpdated } from './index';
+
+/**
+ * The unit tests run against a hand written `git log` output, which cannot
+ * catch a wrong assumption about the format itself. These run the real `git`
+ * over a throwaway repository instead.
+ */
+describe('pluginLastUpdated against a real repository', () => {
+  let repo: string;
+
+  const commit = (message: string, date: string) =>
+    execa(
+      'git',
+      [
+        '-c',
+        'user.name=Alice',
+        '-c',
+        'user.email=alice@test',
+        'commit',
+        '-m',
+        message,
+      ],
+      { cwd: repo, env: { GIT_AUTHOR_DATE: date, GIT_COMMITTER_DATE: date } },
+    );
+
+  const write = async (relativePath: string, content: string) => {
+    const filePath = path.join(repo, relativePath);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, content);
+    await execa('git', ['add', relativePath], { cwd: repo });
+  };
+
+  beforeAll(async () => {
+    repo = await fs.mkdtemp(path.join(os.tmpdir(), 'rspress-last-updated-'));
+    await execa('git', ['init', '-q', '--initial-branch=main'], { cwd: repo });
+
+    await write('docs/index.mdx', 'first');
+    await write('docs/guide/legacy.mdx', 'first');
+    await commit('first', '2020-01-02T03:04:05Z');
+
+    await write('docs/index.mdx', 'second');
+    await commit('second', '2021-06-07T08:09:10Z');
+  });
+
+  afterAll(async () => {
+    await fs.rm(repo, { recursive: true, force: true });
+  });
+
+  it('should read the last commit of every page in one pass', async () => {
+    const pages = [
+      'docs/index.mdx',
+      'docs/guide/legacy.mdx',
+      'docs/new.mdx',
+    ].map(
+      relativePath =>
+        ({
+          _filepath: path.join(repo, relativePath),
+          lang: 'en',
+        }) as PageIndexInfo,
+    );
+    const plugin = pluginLastUpdated(true);
+
+    await plugin.routeGenerated?.(
+      pages.map(page => ({ absolutePath: page._filepath }) as RouteMeta),
+    );
+    await Promise.all(pages.map(page => plugin.extendPageData?.(page, true)));
+
+    const [index, legacy, uncommitted] = pages as (PageIndexInfo & {
+      lastUpdatedTime?: string;
+      lastUpdatedAuthor?: string;
+    })[];
+
+    // The newest commit touching the file wins, not the newest commit overall.
+    expect(index.lastUpdatedTime).toBe(
+      new Date('2021-06-07T08:09:10Z').toLocaleString('en'),
+    );
+    expect(legacy.lastUpdatedTime).toBe(
+      new Date('2020-01-02T03:04:05Z').toLocaleString('en'),
+    );
+    expect(index.lastUpdatedAuthor).toBe('Alice');
+    // A page that was never committed keeps no last updated information.
+    expect(uncommitted.lastUpdatedTime).toBeUndefined();
+  });
+});

--- a/packages/core/src/node/last-updated/gitLog.test.ts
+++ b/packages/core/src/node/last-updated/gitLog.test.ts
@@ -16,20 +16,18 @@ describe('pluginLastUpdated against a real repository', () => {
 
   const git = (args: string[]) => execa('git', args, { cwd: repo });
 
+  const identity = (author: string) => [
+    '-c',
+    `user.name=${author}`,
+    '-c',
+    `user.email=${author.toLowerCase()}@test`,
+  ];
+
   const commit = (message: string, date: string, author = 'Alice') =>
-    execa(
-      'git',
-      [
-        '-c',
-        `user.name=${author}`,
-        '-c',
-        `user.email=${author.toLowerCase()}@test`,
-        'commit',
-        '-m',
-        message,
-      ],
-      { cwd: repo, env: { GIT_AUTHOR_DATE: date, GIT_COMMITTER_DATE: date } },
-    );
+    execa('git', [...identity(author), 'commit', '-m', message], {
+      cwd: repo,
+      env: { GIT_AUTHOR_DATE: date, GIT_COMMITTER_DATE: date },
+    });
 
   const write = async (relativePath: string, content: string) => {
     const filePath = path.join(repo, relativePath);
@@ -58,7 +56,14 @@ describe('pluginLastUpdated against a real repository', () => {
     await git(['checkout', '-q', 'main']);
     await write('docs/index.mdx', 'trunk');
     await commit('trunk', '2022-03-04T05:06:07Z');
-    await git(['merge', 'side']).catch(() => {
+    // `git merge` demands a committer identity before even looking at the
+    // trees — without one it dies with no conflict left behind to resolve.
+    await execa('git', [...identity('Merle'), 'merge', 'side'], {
+      cwd: repo,
+    }).catch((error: { stdout?: string }) => {
+      if (!error.stdout?.includes('CONFLICT')) {
+        throw error;
+      }
       // The conflict on `index.mdx` is expected.
     });
     await write('docs/index.mdx', 'merged');

--- a/packages/core/src/node/last-updated/gitLog.test.ts
+++ b/packages/core/src/node/last-updated/gitLog.test.ts
@@ -14,14 +14,16 @@ import { pluginLastUpdated } from './index';
 describe('pluginLastUpdated against a real repository', () => {
   let repo: string;
 
-  const commit = (message: string, date: string) =>
+  const git = (args: string[]) => execa('git', args, { cwd: repo });
+
+  const commit = (message: string, date: string, author = 'Alice') =>
     execa(
       'git',
       [
         '-c',
-        'user.name=Alice',
+        `user.name=${author}`,
         '-c',
-        'user.email=alice@test',
+        `user.email=${author.toLowerCase()}@test`,
         'commit',
         '-m',
         message,
@@ -33,12 +35,12 @@ describe('pluginLastUpdated against a real repository', () => {
     const filePath = path.join(repo, relativePath);
     await fs.mkdir(path.dirname(filePath), { recursive: true });
     await fs.writeFile(filePath, content);
-    await execa('git', ['add', relativePath], { cwd: repo });
+    await git(['add', relativePath]);
   };
 
   beforeAll(async () => {
     repo = await fs.mkdtemp(path.join(os.tmpdir(), 'rspress-last-updated-'));
-    await execa('git', ['init', '-q', '--initial-branch=main'], { cwd: repo });
+    await git(['init', '-q', '--initial-branch=main']);
 
     await write('docs/index.mdx', 'first');
     await write('docs/guide/legacy.mdx', 'first');
@@ -46,6 +48,21 @@ describe('pluginLastUpdated against a real repository', () => {
 
     await write('docs/index.mdx', 'second');
     await commit('second', '2021-06-07T08:09:10Z');
+
+    // A branch conflicting with main on `index.mdx` and cleanly adding
+    // `clean.mdx`, so the merge commit resolves the conflict by hand.
+    await git(['checkout', '-qb', 'side']);
+    await write('docs/index.mdx', 'side');
+    await write('docs/clean.mdx', 'clean');
+    await commit('side', '2022-01-02T03:04:05Z', 'Bob');
+    await git(['checkout', '-q', 'main']);
+    await write('docs/index.mdx', 'trunk');
+    await commit('trunk', '2022-03-04T05:06:07Z');
+    await git(['merge', 'side']).catch(() => {
+      // The conflict on `index.mdx` is expected.
+    });
+    await write('docs/index.mdx', 'merged');
+    await commit('merge side', '2023-05-06T07:08:09Z', 'Merle');
   });
 
   afterAll(async () => {
@@ -56,6 +73,7 @@ describe('pluginLastUpdated against a real repository', () => {
     const pages = [
       'docs/index.mdx',
       'docs/guide/legacy.mdx',
+      'docs/clean.mdx',
       'docs/new.mdx',
     ].map(
       relativePath =>
@@ -71,19 +89,27 @@ describe('pluginLastUpdated against a real repository', () => {
     );
     await Promise.all(pages.map(page => plugin.extendPageData?.(page, true)));
 
-    const [index, legacy, uncommitted] = pages as (PageIndexInfo & {
+    const [index, legacy, clean, uncommitted] = pages as (PageIndexInfo & {
       lastUpdatedTime?: string;
       lastUpdatedAuthor?: string;
     })[];
 
-    // The newest commit touching the file wins, not the newest commit overall.
+    // The conflict resolution touched `index.mdx`, so the merge commit is its
+    // last update, exactly as `git log -1 -- <file>` reports it.
     expect(index.lastUpdatedTime).toBe(
-      new Date('2021-06-07T08:09:10Z').toLocaleString('en'),
+      new Date('2023-05-06T07:08:09Z').toLocaleString('en'),
     );
+    expect(index.lastUpdatedAuthor).toBe('Merle');
+    // A file merged without conflict keeps its own branch commit.
+    expect(clean.lastUpdatedTime).toBe(
+      new Date('2022-01-02T03:04:05Z').toLocaleString('en'),
+    );
+    expect(clean.lastUpdatedAuthor).toBe('Bob');
+    // The newest commit touching the file wins, not the newest commit overall.
     expect(legacy.lastUpdatedTime).toBe(
       new Date('2020-01-02T03:04:05Z').toLocaleString('en'),
     );
-    expect(index.lastUpdatedAuthor).toBe('Alice');
+    expect(legacy.lastUpdatedAuthor).toBe('Alice');
     // A page that was never committed keeps no last updated information.
     expect(uncommitted.lastUpdatedTime).toBeUndefined();
   });

--- a/packages/core/src/node/last-updated/index.test.ts
+++ b/packages/core/src/node/last-updated/index.test.ts
@@ -6,7 +6,8 @@ import { pluginLastUpdated } from './index';
 
 rs.mock('execa', () => {
   // A commit as printed by `--pretty=format:%x00%at%x00%an%x00%ae --name-only`,
-  // commits being separated by an empty line.
+  // commits being separated by an empty line and paths being relative to the
+  // repository root.
   const commit = (at: number, name: string, email: string, files: string[]) => [
     `\u0000${at}\u0000${name}\u0000${email}`,
     ...files,
@@ -14,13 +15,20 @@ rs.mock('execa', () => {
   ];
   const stdout = [
     ...commit(100, 'Alice', 'alice@example.com', [
-      'index.mdx',
-      'guide/nested.mdx',
+      'docs/index.mdx',
+      'docs/guide/nested.mdx',
     ]),
-    ...commit(50, 'Bob', 'bob@example.com', ['index.mdx', 'guide/legacy.mdx']),
+    ...commit(50, 'Bob', 'bob@example.com', [
+      'docs/index.mdx',
+      'docs/guide/legacy.mdx',
+    ]),
   ].join('\n');
 
-  return { execa: rs.fn(async () => ({ stdout })) };
+  return {
+    execa: rs.fn(async (_file: string, args: string[]) =>
+      args[0] === 'rev-parse' ? { stdout: 'docs/\n' } : { stdout },
+    ),
+  };
 });
 
 const DOC_ROOT = path.join(process.cwd(), 'docs');
@@ -89,7 +97,14 @@ describe('pluginLastUpdated', () => {
   it('should read the git log of the doc directory in one pass', async () => {
     await extendPages(pluginLastUpdated(), [pageData()]);
 
-    expect(execa).toHaveBeenCalledWith(
+    expect(execa).toHaveBeenNthCalledWith(
+      1,
+      'git',
+      ['rev-parse', '--show-prefix'],
+      { cwd: DOC_ROOT },
+    );
+    expect(execa).toHaveBeenNthCalledWith(
+      2,
       'git',
       [
         '-c',
@@ -97,8 +112,8 @@ describe('pluginLastUpdated', () => {
         'log',
         '--pretty=format:%x00%at%x00%an%x00%ae',
         '--name-only',
+        '--cc',
         '--no-renames',
-        '--relative',
         '--',
         '.',
       ],
@@ -106,7 +121,7 @@ describe('pluginLastUpdated', () => {
     );
   });
 
-  it('should spawn a single git process whatever the page count is', async () => {
+  it('should spawn a fixed number of git processes whatever the page count is', async () => {
     const pages = [
       pageData('guide/nested.mdx'),
       ...Array.from({ length: 100 }, (_, i) => pageData(`page-${i}.mdx`)),
@@ -114,7 +129,8 @@ describe('pluginLastUpdated', () => {
 
     await extendPages(pluginLastUpdated(true), pages);
 
-    expect(execa).toHaveBeenCalledTimes(1);
+    // One `rev-parse` for the repository root and one `log` for the site.
+    expect(execa).toHaveBeenCalledTimes(2);
     // The pages are still resolved from that single git log.
     expect(pages[0].lastUpdatedAuthor).toBe('Alice');
   });
@@ -134,6 +150,39 @@ describe('pluginLastUpdated', () => {
       new Date(50000).toLocaleString('en'),
     );
     expect(updatedOnce.lastUpdatedAuthor).toBe('Bob');
+  });
+
+  it('should fall back to the repository root when the common directory is outside of it', async () => {
+    const mocked = execa as unknown as ReturnType<typeof rs.fn>;
+    // The common directory of the pages is `/`, outside of any repository.
+    mocked.mockRejectedValueOnce(new Error('fatal: not a git repository'));
+    const inRepo = pageData();
+    const outsideRepo = {
+      _filepath: path.parse(DOC_ROOT).root + 'external.mdx',
+      lang: 'en',
+    } as TestPageIndexInfo;
+
+    await extendPages(pluginLastUpdated(true), [inRepo, outsideRepo]);
+
+    expect(execa).toHaveBeenCalledTimes(3);
+    // The retried `rev-parse` runs from the directory holding the most pages,
+    // and the log walks the repository it found.
+    expect(execa).toHaveBeenNthCalledWith(
+      2,
+      'git',
+      ['rev-parse', '--show-prefix'],
+      { cwd: DOC_ROOT },
+    );
+    expect(execa).toHaveBeenNthCalledWith(
+      3,
+      'git',
+      expect.arrayContaining(['log']),
+      {
+        cwd: process.cwd(),
+      },
+    );
+    expect(inRepo.lastUpdatedAuthor).toBe('Alice');
+    expect(outsideRepo.lastUpdatedTime).toBeUndefined();
   });
 
   it('should leave pages without any commit untouched', async () => {

--- a/packages/core/src/node/last-updated/index.test.ts
+++ b/packages/core/src/node/last-updated/index.test.ts
@@ -1,24 +1,53 @@
-import type { PageIndexInfo } from '@rspress/shared';
+import path from 'node:path';
+import type { PageIndexInfo, RouteMeta, RspressPlugin } from '@rspress/shared';
 import { beforeEach, describe, expect, it, rs } from '@rstest/core';
 import { execa } from 'execa';
 import { pluginLastUpdated } from './index';
 
-rs.mock('execa', () => ({
-  execa: rs.fn(async () => ({
-    stdout: '100\nAlice\nalice@example.com',
-  })),
-}));
+rs.mock('execa', () => {
+  // A commit as printed by `--pretty=format:%x00%at%x00%an%x00%ae --name-only`,
+  // commits being separated by an empty line.
+  const commit = (at: number, name: string, email: string, files: string[]) => [
+    `\u0000${at}\u0000${name}\u0000${email}`,
+    ...files,
+    '',
+  ];
+  const stdout = [
+    ...commit(100, 'Alice', 'alice@example.com', [
+      'index.mdx',
+      'guide/nested.mdx',
+    ]),
+    ...commit(50, 'Bob', 'bob@example.com', ['index.mdx', 'guide/legacy.mdx']),
+  ].join('\n');
+
+  return { execa: rs.fn(async () => ({ stdout })) };
+});
+
+const DOC_ROOT = path.join(process.cwd(), 'docs');
+
+const docPath = (relativePath: string) => path.join(DOC_ROOT, relativePath);
 
 type TestPageIndexInfo = PageIndexInfo & {
   lastUpdatedTime?: string;
   lastUpdatedAuthor?: string;
 };
 
-const pageData = (): TestPageIndexInfo =>
+const pageData = (relativePath = 'index.mdx'): TestPageIndexInfo =>
   ({
-    _filepath: 'docs/index.mdx',
+    _filepath: docPath(relativePath),
     lang: 'en',
   }) as TestPageIndexInfo;
+
+/**
+ * `routeGenerated` is what gives the plugin the whole page list, it always runs
+ * before the page data is created.
+ */
+async function extendPages(plugin: RspressPlugin, pages: TestPageIndexInfo[]) {
+  await plugin.routeGenerated?.(
+    pages.map(page => ({ absolutePath: page._filepath }) as RouteMeta),
+  );
+  await Promise.all(pages.map(page => plugin.extendPageData?.(page, true)));
+}
 
 describe('pluginLastUpdated', () => {
   beforeEach(() => {
@@ -28,7 +57,7 @@ describe('pluginLastUpdated', () => {
   it('should only add last updated time by default', async () => {
     const data = pageData();
 
-    await pluginLastUpdated().extendPageData?.(data, true);
+    await extendPages(pluginLastUpdated(), [data]);
 
     expect(data.lastUpdatedTime).toBe(new Date(100000).toLocaleString('en'));
     expect(data.lastUpdatedAuthor).toBeUndefined();
@@ -37,7 +66,7 @@ describe('pluginLastUpdated', () => {
   it('should add author name when author is enabled', async () => {
     const data = pageData();
 
-    await pluginLastUpdated(true).extendPageData?.(data, true);
+    await extendPages(pluginLastUpdated(true), [data]);
 
     expect(data.lastUpdatedAuthor).toBe('Alice');
   });
@@ -45,26 +74,74 @@ describe('pluginLastUpdated', () => {
   it('should support custom author display text', async () => {
     const data = pageData();
 
-    await pluginLastUpdated(({ name, email, filePath }) => {
-      return `${name} <${email}> ${filePath}`;
-    }).extendPageData?.(data, true);
+    await extendPages(
+      pluginLastUpdated(({ name, email, filePath }) => {
+        return `${name} <${email}> ${filePath}`;
+      }),
+      [data],
+    );
 
     expect(data.lastUpdatedAuthor).toBe(
-      'Alice <alice@example.com> docs/index.mdx',
+      `Alice <alice@example.com> ${docPath('index.mdx')}`,
     );
   });
 
-  it('should pass file path to git log', async () => {
-    const data = pageData();
+  it('should read the git log of the doc directory in one pass', async () => {
+    await extendPages(pluginLastUpdated(), [pageData()]);
 
-    await pluginLastUpdated().extendPageData?.(data, true);
+    expect(execa).toHaveBeenCalledWith(
+      'git',
+      [
+        '-c',
+        'core.quotePath=false',
+        'log',
+        '--pretty=format:%x00%at%x00%an%x00%ae',
+        '--name-only',
+        '--no-renames',
+        '--relative',
+        '--',
+        '.',
+      ],
+      { cwd: DOC_ROOT },
+    );
+  });
 
-    expect(execa).toHaveBeenCalledWith('git', [
-      'log',
-      '-1',
-      '--format=%at%n%an%n%ae',
-      '--',
-      'docs/index.mdx',
-    ]);
+  it('should spawn a single git process whatever the page count is', async () => {
+    const pages = [
+      pageData('guide/nested.mdx'),
+      ...Array.from({ length: 100 }, (_, i) => pageData(`page-${i}.mdx`)),
+    ];
+
+    await extendPages(pluginLastUpdated(true), pages);
+
+    expect(execa).toHaveBeenCalledTimes(1);
+    // The pages are still resolved from that single git log.
+    expect(pages[0].lastUpdatedAuthor).toBe('Alice');
+  });
+
+  it('should take the most recent commit of each file', async () => {
+    // `index.mdx` belongs to both commits, `guide/legacy.mdx` to the older one.
+    const updatedTwice = pageData('index.mdx');
+    const updatedOnce = pageData('guide/legacy.mdx');
+
+    await extendPages(pluginLastUpdated(true), [updatedTwice, updatedOnce]);
+
+    expect(updatedTwice.lastUpdatedTime).toBe(
+      new Date(100000).toLocaleString('en'),
+    );
+    expect(updatedTwice.lastUpdatedAuthor).toBe('Alice');
+    expect(updatedOnce.lastUpdatedTime).toBe(
+      new Date(50000).toLocaleString('en'),
+    );
+    expect(updatedOnce.lastUpdatedAuthor).toBe('Bob');
+  });
+
+  it('should leave pages without any commit untouched', async () => {
+    const data = pageData('untracked.mdx');
+
+    await extendPages(pluginLastUpdated(true), [data]);
+
+    expect(data.lastUpdatedTime).toBeUndefined();
+    expect(data.lastUpdatedAuthor).toBeUndefined();
   });
 });

--- a/packages/core/src/node/last-updated/index.ts
+++ b/packages/core/src/node/last-updated/index.ts
@@ -69,11 +69,65 @@ function getCommonDir(filePaths: string[]): string {
     }
     common = common.slice(0, i);
   }
-  return common.join(path.sep) || path.sep;
+  // A collapsed prefix is the filesystem root, spelled `C:\` and not `C:` on
+  // Windows so it stays usable as a `cwd`.
+  return common.length > 1
+    ? common.join(path.sep)
+    : path.parse(filePaths[0]).root;
+}
+
+/**
+ * The directory holding the largest number of files, which is inside the git
+ * repository even when stray pages have pushed the common directory out of it.
+ */
+function getMostCommonParent(filePaths: string[]): string {
+  const counts = new Map<string, number>();
+  let best = '';
+  let bestCount = 0;
+  for (const filePath of filePaths) {
+    const dir = path.dirname(filePath);
+    const count = (counts.get(dir) ?? 0) + 1;
+    counts.set(dir, count);
+    if (count > bestCount) {
+      best = dir;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+/**
+ * Where `dir` sits inside its repository, as `docs/guide/` — or `undefined`
+ * outside of any repository. Unlike `--show-toplevel` the prefix contains no
+ * absolute path, so it cannot disagree with the caller about symlinks.
+ */
+async function getRepoPrefix(dir: string): Promise<string | undefined> {
+  try {
+    const { stdout } = await execa('git', ['rev-parse', '--show-prefix'], {
+      cwd: dir,
+    });
+    return stdout.trim();
+  } catch (_e) {
+    return undefined;
+  }
+}
+
+/**
+ * `dir` with the final `prefix` segments removed: the repository root spelled
+ * the way the caller spells `dir`.
+ */
+function stripPrefix(dir: string, prefix: string): string {
+  let root = dir;
+  for (let i = prefix.split('/').filter(Boolean).length; i > 0; i--) {
+    root = path.dirname(root);
+  }
+  return root;
 }
 
 /**
  * Read the last commit of every file below `dir` with a single `git` process.
+ * The returned map is keyed by path relative to the repository root — the form
+ * git prints throughout, `--relative` being ignored by `--cc` output.
  */
 async function collectGitInfo(dir: string): Promise<Map<string, GitInfo>> {
   const infoByPath = new Map<string, GitInfo>();
@@ -88,10 +142,12 @@ async function collectGitInfo(dir: string): Promise<Map<string, GitInfo>> {
         'log',
         COMMIT_FORMAT,
         '--name-only',
+        // A merge commit only lists the files its conflict resolution touched,
+        // which are the ones `git log -1 -- <file>` attributes to the merge.
+        '--cc',
         // Only the touched paths matter, similarity detection is wasted work.
         '--no-renames',
-        // Print paths relative to `dir` and skip everything outside of it.
-        '--relative',
+        // Skip commits not touching anything below `dir`.
         '--',
         '.',
       ],
@@ -129,9 +185,25 @@ async function createLookup(filePaths: string[]): Promise<GitInfoLookup> {
   if (!filePaths.length) {
     return () => undefined;
   }
-  const dir = getCommonDir(filePaths);
+  let dir = getCommonDir(filePaths);
+  let prefix = await getRepoPrefix(dir);
+  if (prefix === undefined) {
+    // `addPages` may contribute pages living outside of the repository, moving
+    // the common directory above it. Retry from the repository holding the
+    // bulk of the pages, walking it from its root.
+    const candidate = getMostCommonParent(filePaths);
+    const candidatePrefix = await getRepoPrefix(candidate);
+    if (candidatePrefix === undefined) {
+      return () => undefined;
+    }
+    dir = stripPrefix(candidate, candidatePrefix);
+    prefix = '';
+  }
+  const repoPrefix = prefix;
+  const scope = dir;
   const infoByPath = await collectGitInfo(dir);
-  return filePath => infoByPath.get(slash(path.relative(dir, filePath)));
+  return filePath =>
+    infoByPath.get(repoPrefix + slash(path.relative(scope, filePath)));
 }
 
 /**

--- a/packages/core/src/node/last-updated/index.ts
+++ b/packages/core/src/node/last-updated/index.ts
@@ -1,5 +1,7 @@
+import path from 'node:path';
 import type { LastUpdatedAuthor, RspressPlugin } from '@rspress/shared';
 import { execa } from 'execa';
+import { slash } from '../utils';
 
 function transform(timestamp: number, lang: string) {
   return new Date(timestamp).toLocaleString(lang || 'zh');
@@ -11,25 +13,125 @@ interface GitInfo {
   authorEmail: string;
 }
 
-async function getGitInfo(filePath: string): Promise<GitInfo | undefined> {
-  try {
-    const { stdout } = await execa('git', [
-      'log',
-      '-1',
-      '--format=%at%n%an%n%ae',
-      '--',
-      filePath,
-    ]);
-    const [at, an, ae] = stdout.split('\n');
-    if (!at) return undefined;
-    return {
-      timestamp: Number(at) * 1000,
-      authorName: an ?? '',
-      authorEmail: ae ?? '',
-    };
-  } catch (_e) {
-    return undefined;
+type GitInfoLookup = (filePath: string) => GitInfo | undefined;
+
+/**
+ * A commit is printed as `\0<author date>\0<author name>\0<author email>`, so a
+ * header line can never be mistaken for one of the file paths that follow it.
+ */
+const COMMIT_FORMAT = '--pretty=format:%x00%at%x00%an%x00%ae';
+
+const ESCAPES: Record<string, string> = {
+  a: '\x07',
+  b: '\b',
+  t: '\t',
+  n: '\n',
+  v: '\v',
+  f: '\f',
+  r: '\r',
+  '"': '"',
+  '\\': '\\',
+};
+
+/**
+ * `git` wraps paths containing a control character, a quote or a backslash in
+ * double quotes and escapes them C-style. Non-ASCII bytes are left as they are
+ * thanks to `core.quotePath=false`, so an escape is always a single character.
+ */
+function unquotePath(filePath: string): string {
+  if (!filePath.startsWith('"')) {
+    return filePath;
   }
+  return filePath
+    .slice(1, -1)
+    .replace(/\\([0-7]{3}|.)/g, (_, escaped: string) =>
+      escaped.length === 3
+        ? String.fromCharCode(Number.parseInt(escaped, 8))
+        : (ESCAPES[escaped] ?? escaped),
+    );
+}
+
+/**
+ * The deepest directory containing every file, used to scope the `git log`
+ * walk. Pages living outside of the doc root widen it, up to the repository.
+ */
+function getCommonDir(filePaths: string[]): string {
+  let common = path.dirname(filePaths[0]).split(path.sep);
+  for (const filePath of filePaths.slice(1)) {
+    const segments = path.dirname(filePath).split(path.sep);
+    let i = 0;
+    while (
+      i < common.length &&
+      i < segments.length &&
+      common[i] === segments[i]
+    ) {
+      i++;
+    }
+    common = common.slice(0, i);
+  }
+  return common.join(path.sep) || path.sep;
+}
+
+/**
+ * Read the last commit of every file below `dir` with a single `git` process.
+ */
+async function collectGitInfo(dir: string): Promise<Map<string, GitInfo>> {
+  const infoByPath = new Map<string, GitInfo>();
+
+  let stdout: string;
+  try {
+    ({ stdout } = await execa(
+      'git',
+      [
+        '-c',
+        'core.quotePath=false',
+        'log',
+        COMMIT_FORMAT,
+        '--name-only',
+        // Only the touched paths matter, similarity detection is wasted work.
+        '--no-renames',
+        // Print paths relative to `dir` and skip everything outside of it.
+        '--relative',
+        '--',
+        '.',
+      ],
+      { cwd: dir },
+    ));
+  } catch (_e) {
+    return infoByPath;
+  }
+
+  let commit: GitInfo | undefined;
+  for (const line of stdout.split('\n')) {
+    if (line.startsWith('\0')) {
+      const [, at, an = '', ae = ''] = line.split('\0');
+      commit = {
+        timestamp: Number(at) * 1000,
+        authorName: an,
+        authorEmail: ae,
+      };
+      continue;
+    }
+    if (!line || !commit) {
+      continue;
+    }
+    const filePath = unquotePath(line);
+    // Commits are listed newest first, so the first entry of a path wins.
+    if (!infoByPath.has(filePath)) {
+      infoByPath.set(filePath, commit);
+    }
+  }
+
+  return infoByPath;
+}
+
+async function createLookup(filePaths: string[]): Promise<GitInfoLookup> {
+  if (!filePaths.length) {
+    return () => undefined;
+  }
+  const dir = getCommonDir(filePaths);
+  const infoByPath = await collectGitInfo(dir);
+  return filePath => infoByPath.get(slash(path.relative(dir, filePath)));
 }
 
 /**
@@ -38,11 +140,19 @@ async function getGitInfo(filePath: string): Promise<GitInfo | undefined> {
 export function pluginLastUpdated(
   authorOption: LastUpdatedAuthor = false,
 ): RspressPlugin {
+  let lookup: Promise<GitInfoLookup> | undefined;
+
   return {
     name: '@rspress/plugin-last-updated',
+    // Routes are known long before the page data is created, so the whole site
+    // is read by a single `git log` process instead of one process per page,
+    // running while the rest of the build is still warming up.
+    routeGenerated(routes) {
+      lookup = createLookup(routes.map(route => route.absolutePath));
+    },
     async extendPageData(pageData) {
       const { _filepath, lang } = pageData;
-      const info = await getGitInfo(_filepath);
+      const info = (await lookup)?.(_filepath);
       if (!info) return;
       // Property does not exist on type 'PageIndexInfo'.
       // @ts-expect-error


### PR DESCRIPTION
### Summary

`pluginLastUpdated` spawned **one `git` process per page**. `createPageData` fans `extendPageData` out over every page with a single `Promise.all`, so a site with N pages forks N concurrent `git log -1 -- <file>` processes.

The page list is already known much earlier, in `routeGenerated`. This reads the whole site there with one `git log --name-only` pass and turns `extendPageData` into a map lookup.

### Details

```ts
routeGenerated(routes) {
  lookup = createLookup(routes.map(route => route.absolutePath));
},
```

`build.ts` / `dev.ts` both `await pluginDriver.routeGenerated(routeService.getRoutes())` before `initRsbuild`, and `PageIndexInfo._filepath` *is* `route.absolutePath`, so the hook sees exactly the pages `extendPageData` will be called for — including pages contributed by `addPages`. The `git` process also starts before the bundler does, so it overlaps with the rest of the build instead of blocking page data generation.

The command:

```sh
git -c core.quotePath=false log --pretty=format:%x00%at%x00%an%x00%ae \
    --name-only --cc --no-renames -- .
```

- run with `cwd` set to the deepest common directory of the pages, so the revision walk is scoped to the docs tree rather than the whole repo;
- the lookup is keyed by repository-root-relative paths — the form git prints throughout (`--relative` is silently ignored by `--cc` output) — resolved with one `git rev-parse --show-prefix`, which unlike `--show-toplevel` contains no absolute path and therefore cannot disagree with the caller about symlinks (e.g. macOS `/var` → `/private/var`);
- `--cc` makes a merge commit list exactly the files its conflict resolution touched, which are the ones `git log -1 -- <file>` attributes to the merge; files merged cleanly keep their own branch commit (`-m` would over-attribute those to the merge);
- `--no-renames` skips similarity detection — only the touched paths matter (~1.6x faster on this repo);
- commits are listed newest first, so the first entry seen for a path is its last update — the same commit `git log -1 -- <file>` selects, and the author name/email come from the same pass;
- `core.quotePath=false` keeps CJK filenames intact; the C-quoted form `git` still uses for paths containing `"`, `\` or control characters is decoded.

When `addPages` contributes pages from outside the repository, the common directory can rise above it; in that case the repository is re-discovered from the directory holding the bulk of the pages and walked from its root, so regular docs pages keep their metadata.

Behaviour is unchanged otherwise: pages with no commit (untracked files) are left untouched, and a failing `git` (e.g. not a repository) degrades to no `lastUpdated` field, as before.

### Numbers

On this repo's own `website/docs` (208 pages), the plugin resolves every page from **2** `git` processes (`rev-parse` + `log`) in ~300 ms, independent of the page count. Verified against the previous implementation: for a sample of those pages, the batched result is identical to `git log -1 --format=%at%n%an%n%ae -- <file>`.

The reporter measured the old path on a 113-page site: 113 concurrent `git` processes stuck in uninterruptible wait for 2.5+ minutes, stalling unrelated `exec()`s system-wide (amplified by an Endpoint Security agent having to authorize every spawn).

### Tests

`index.test.ts` mocks the batched `git log` output and asserts, alongside the existing behaviour tests, that **101 pages produce a fixed two `execa` calls** while each page still resolves its own commit — plus newest-commit-wins, untracked-file, and outside-the-repository fallback cases.

A mocked stdout cannot catch a wrong assumption about the format itself, so `gitLog.test.ts` runs the real `git` over a throwaway repository created in `os.tmpdir()` (pinned author dates, a conflicted merge and a cleanly merged file) and checks that the conflict resolution is attributed to the merge commit, the cleanly merged file to its branch commit, and that an uncommitted page stays untouched. The `os.tmpdir()` symlink on macOS is what caught the `--show-toplevel` path mismatch in the first place.
