### PR TITLE
docs: refresh Rstack slogan

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Go to the [Quick start](https://rspress.rs/guide/start/getting-started.html) to 
 
 ## 🦀 Rstack
 
-Rstack is a unified JavaScript toolchain centered on Rspack, with high performance and consistent architecture.
+Rspress is part of Rstack, the fast, unified JavaScript toolchain for developers and agents.
 
 | Name                                                  | Description              | Version                                                                                                                                                                          |
 | ----------------------------------------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1831,8 +1831,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/plugin-twoslash
       '@rstack-dev/doc-ui':
-        specifier: ^1.14.5
-        version: 1.14.5(@rspress/core@packages+core)
+        specifier: ^1.14.7
+        version: 1.14.7(@rspress/core@packages+core)
       '@shikijs/transformers':
         specifier: ^4.2.0
         version: 4.2.0
@@ -3531,8 +3531,8 @@ packages:
   '@rspack/resolver@0.2.8':
     resolution: {integrity: sha512-FBWqdHhzS8mcf/WN4Ktzr7EaeaN+hsxbN98EweegX3924beZuY6H70CSFWCv1fIHAieCUv/9XCjKggHvhCsLwA==}
 
-  '@rstack-dev/doc-ui@1.14.5':
-    resolution: {integrity: sha512-yIwvhLvmY9CxbYNKktysBMDvuxKFkpF2kcYWV/lv6tDGYCsv+8ARQMJLTAEiyK0sXkjB8YUILASDitgxqweUhQ==}
+  '@rstack-dev/doc-ui@1.14.7':
+    resolution: {integrity: sha512-PnY2JKleZxQTbSrxRAyG84lBKNwXwB+v05sUOFxF5qD1UPmBn/bzRmL4zNOPq1qG4d0PjTG62weetryub40M2A==}
     peerDependencies:
       '@rspress/core': '>=2.0.0'
     peerDependenciesMeta:
@@ -9517,7 +9517,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@rstack-dev/doc-ui@1.14.5(@rspress/core@packages+core)':
+  '@rstack-dev/doc-ui@1.14.7(@rspress/core@packages+core)':
     optionalDependencies:
       '@rspress/core': link:packages/core
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,6 +27,7 @@ minimumReleaseAgeExclude:
   - '@rstest/*'
   - '@rsdoctor/*'
   - '@rslint/*'
+  - '@rstack-dev/*'
 
 # Prevent un-reviewed build scripts
 strictDepBuilds: true

--- a/website/package.json
+++ b/website/package.json
@@ -18,7 +18,7 @@
     "@rspress/plugin-preview": "workspace:*",
     "@rspress/plugin-sitemap": "workspace:*",
     "@rspress/plugin-twoslash": "workspace:*",
-    "@rstack-dev/doc-ui": "^1.14.5",
+    "@rstack-dev/doc-ui": "^1.14.7",
     "@shikijs/transformers": "^4.2.0",
     "@types/react": "^19.2.17",
     "react": "^19.2.7",


### PR DESCRIPTION
## Summary

This PR refreshes the Rstack slogan in the README and upgrades `@rstack-dev/doc-ui` to v1.14.7 so the shared website UI uses the latest messaging.

It also allows `@rstack-dev/*` packages to bypass the minimum release age check, matching other trusted Rstack packages.

## Related Links

- https://github.com/rstackjs/rstack-doc-ui/releases/tag/v1.14.7
- https://github.com/web-infra-dev/rsbuild/pull/8179

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
