### PR TITLE
fix(theme/outline): hide dividers without content

### DIFF
--- a/packages/core/src/theme/components/NavScreen/index.scss
+++ b/packages/core/src/theme/components/NavScreen/index.scss
@@ -34,4 +34,8 @@
   height: 1px;
   background-color: var(--rp-c-divider-light);
   margin: 1rem 0;
+
+  &:last-child {
+    display: none;
+  }
 }

--- a/packages/core/src/theme/components/Outline/index.scss
+++ b/packages/core/src/theme/components/Outline/index.scss
@@ -35,6 +35,10 @@
     background: var(--rp-c-divider-light);
     margin-top: 16px;
     margin-bottom: 16px;
+
+    &:has(+ .rp-outline__bottom:empty) {
+      display: none;
+    }
   }
 
   &__toc {


### PR DESCRIPTION
## Summary

This PR hides the trailing navigation divider when no social links are rendered and hides the outline divider while its action section is empty. The dividers remain visible whenever their related content becomes available.




## Screenshots

### before


- Before: Empty navigation and outline action sections still display a divider.

<img width="1534" height="709" alt="image" src="https://github.com/user-attachments/assets/0f220051-de46-4495-8562-b5d6d70c56a2" />

<img width="1076" height="520" alt="image" src="https://github.com/user-attachments/assets/0a8be29f-ae39-4f79-8cc0-5a17e8423ba3" />


### after

- After: The divider is hidden until related content is rendered.

<img width="1499" height="570" alt="image" src="https://github.com/user-attachments/assets/eff7dc12-a7ba-4af1-933d-73163015aa34" />

<img width="1078" height="449" alt="image" src="https://github.com/user-attachments/assets/28d71372-7deb-4311-9b70-9ac42796d2ec" />



## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).