### PR TITLE
refactor(core): remove redundant AST filtering

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -98,7 +98,6 @@
     "scroll-into-view-if-needed": "^3.1.0",
     "shiki": "^4.2.0",
     "unified": "^11.0.5",
-    "unist-util-remove": "^4.0.0",
     "unist-util-visit": "^5.1.0",
     "unist-util-visit-children": "^3.0.0",
     "vfile": "^6.0.3"

--- a/packages/core/src/node/route/extractPageData.ts
+++ b/packages/core/src/node/route/extractPageData.ts
@@ -11,9 +11,7 @@ import { loadFrontMatter } from '@rspress/shared/node-utils';
 import type { Node, Nodes, Root } from 'mdast';
 import remarkGFM from 'remark-gfm';
 import remarkParse from 'remark-parse';
-import type { Plugin } from 'unified';
 import { unified } from 'unified';
-import { remove } from 'unist-util-remove';
 import { importStatementRegex } from '../constants';
 import { parseToc } from '../mdx/remarkPlugins/toc';
 import { flattenMdxContent } from '../utils';
@@ -51,38 +49,10 @@ interface ExtractPageDataOptions {
 }
 
 /**
- * Remark plugin to remove code blocks from the AST
- * Used when searchCodeBlocks is false to exclude code from search index
+ * Cached processor instance for performance optimization
+ * Reusing the processor avoids the overhead of creating a new instance for each file
  */
-const remarkRemoveCodeBlocks: Plugin<[], Root> = () => {
-  return tree => {
-    remove(tree, 'code');
-  };
-};
-
-/**
- * Remark plugin to remove images from the AST
- * Images should not appear in search content
- */
-const remarkRemoveImages: Plugin<[], Root> = () => {
-  return tree => {
-    remove(tree, 'image');
-  };
-};
-
-/**
- * Cached processor instances for performance optimization
- * Reusing processors avoids the overhead of creating new instances for each file
- */
-const createProcessor = (searchCodeBlocks: boolean) =>
-  unified()
-    .use(remarkParse)
-    .use(remarkGFM)
-    .use(remarkRemoveImages)
-    .use(searchCodeBlocks ? [] : [remarkRemoveCodeBlocks]);
-
-const processorWithCode = createProcessor(true);
-const processorWithoutCode = createProcessor(false);
+const processor = unified().use(remarkParse).use(remarkGFM);
 
 /**
  * Extract text content from a node recursively
@@ -390,9 +360,6 @@ async function getPageIndexInfoByRoute(
   // Normalize line endings to LF for cross-platform consistency
   content = content.replace(/\r\n/g, '\n');
 
-  // Use cached processor based on searchCodeBlocks config
-  const processor = searchCodeBlocks ? processorWithCode : processorWithoutCode;
-
   // Parse markdown to AST
   const tree = processor.parse(content);
 
@@ -421,12 +388,9 @@ async function getPageIndexInfoByRoute(
     } satisfies PageIndexInfo;
   }
 
-  // Run plugins and stringify to markdown for search content
-  const processedTree = await processor.run(tree);
-
   // Walk the AST to extract plain text content and compute heading positions
   const { content: processedContent, toc } = buildSearchContent(
-    processedTree as Root,
+    tree,
     rawToc,
     searchCodeBlocks,
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1130,9 +1130,6 @@ importers:
       unified:
         specifier: ^11.0.5
         version: 11.0.5
-      unist-util-remove:
-        specifier: ^4.0.0
-        version: 4.0.0
       unist-util-visit:
         specifier: ^5.1.0
         version: 5.1.0
@@ -7334,9 +7331,6 @@ packages:
 
   unist-util-position@5.0.0:
     resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
-
-  unist-util-remove@4.0.0:
-    resolution: {integrity: sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg==}
 
   unist-util-stringify-position@3.0.3:
     resolution: {integrity: sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==}
@@ -14001,12 +13995,6 @@ snapshots:
   unist-util-position@5.0.0:
     dependencies:
       '@types/unist': 3.0.3
-
-  unist-util-remove@4.0.0:
-    dependencies:
-      '@types/unist': 3.0.3
-      unist-util-is: 6.0.1
-      unist-util-visit-parents: 6.0.2
 
   unist-util-stringify-position@3.0.3:
     dependencies:


### PR DESCRIPTION
## Summary

Search content extraction already skips images and conditionally skips code blocks, so the `unist-util-remove` preprocessing duplicated the same filtering. This removes the redundant remark plugins and processes the parsed tree directly, eliminating the direct dependency without changing searchable content or normal search behavior.

## Related Links

- https://github.com/web-infra-dev/rspress/pull/3557

## Checklist

- [x] Tests updated (not required).
- [x] Documentation updated (not required).