### PR TITLE
fix(plugin-playground): scope Monaco preloads to playground pages

### DIFF
--- a/e2e/fixtures/plugin-playground/doc/pure.mdx
+++ b/e2e/fixtures/plugin-playground/doc/pure.mdx
@@ -1,0 +1,3 @@
+# Pure page
+
+This page does not contain a playground.

--- a/e2e/fixtures/plugin-playground/index.test.ts
+++ b/e2e/fixtures/plugin-playground/index.test.ts
@@ -1,8 +1,35 @@
 import fs from 'node:fs/promises';
+import path from 'node:path';
 import { expect, test } from '@playwright/test';
-import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
+import {
+  getPort,
+  killProcess,
+  runBuildCommand,
+  runDevCommand,
+} from '../../utils/runCommands';
 
 const DOC_FILE = new URL('./doc/index.mdx', import.meta.url);
+const MONACO_PREFIX =
+  'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.43.0/min/vs';
+const MONACO_PRELOAD_URLS = [
+  `${MONACO_PREFIX}/loader.js`,
+  `${MONACO_PREFIX}/editor/editor.main.js`,
+];
+
+test('Should only preload Monaco on pages containing playgrounds', async () => {
+  const appDir = import.meta.dirname;
+  await runBuildCommand(appDir);
+
+  const [playgroundHtml, pureHtml] = await Promise.all([
+    fs.readFile(path.join(appDir, 'doc_build/index.html'), 'utf-8'),
+    fs.readFile(path.join(appDir, 'doc_build/pure.html'), 'utf-8'),
+  ]);
+
+  for (const url of MONACO_PRELOAD_URLS) {
+    expect(playgroundHtml.split(url)).toHaveLength(2);
+    expect(pureHtml).not.toContain(url);
+  }
+});
 
 test.describe('plugin test', async () => {
   test.describe.configure({ mode: 'serial' });
@@ -12,9 +39,9 @@ test.describe('plugin test', async () => {
   let originalContent: string;
   test.beforeAll(async () => {
     const appDir = import.meta.dirname;
+    originalContent = await fs.readFile(DOC_FILE, 'utf-8');
     appPort = await getPort();
     app = await runDevCommand(appDir, appPort);
-    originalContent = await fs.readFile(DOC_FILE, 'utf-8');
   });
 
   test.afterAll(async () => {

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -29,6 +29,7 @@ export { useVersion } from './hooks/useVersion';
 export { useWindowSize } from './hooks/useWindowSize';
 export { initPageData, warmPageData } from './initPageData';
 export { NoSSR } from './NoSSR';
+export { safePreconnect, safePreload } from './reactDom';
 export { isActive, pathnameToRouteService, preloadLink } from './route';
 export {
   addLeadingSlash,

--- a/packages/core/src/runtime/reactDom.ts
+++ b/packages/core/src/runtime/reactDom.ts
@@ -1,0 +1,50 @@
+import * as ReactDOM from 'react-dom';
+
+type CrossOrigin = '' | 'anonymous' | 'use-credentials';
+
+type Preconnect = (
+  href: string,
+  options?: {
+    crossOrigin?: CrossOrigin;
+  },
+) => void;
+
+type Preload = (
+  href: string,
+  options?: {
+    as:
+      | 'audio'
+      | 'document'
+      | 'embed'
+      | 'fetch'
+      | 'font'
+      | 'image'
+      | 'object'
+      | 'script'
+      | 'style'
+      | 'track'
+      | 'video'
+      | 'worker';
+    crossOrigin?: CrossOrigin;
+    fetchPriority?: 'high' | 'low' | 'auto';
+    imageSizes?: string;
+    imageSrcSet?: string;
+    integrity?: string;
+    media?: string;
+    nonce?: string;
+    referrerPolicy?: ReferrerPolicy;
+    type?: string;
+  },
+) => void;
+
+type ReactDOMCompat = {
+  preconnect?: Preconnect;
+  preload?: Preload;
+  default?: ReactDOMCompat;
+};
+
+const reactDOM = ReactDOM as unknown as ReactDOMCompat;
+
+export const safePreconnect =
+  reactDOM.preconnect ?? reactDOM.default?.preconnect;
+export const safePreload = reactDOM.preload ?? reactDOM.default?.preload;

--- a/packages/plugin-algolia/src/runtime/Search.tsx
+++ b/packages/plugin-algolia/src/runtime/Search.tsx
@@ -1,25 +1,15 @@
 import type { DocSearchProps } from '@docsearch/react';
 import { DocSearch } from '@docsearch/react';
-import { removeBase, useLang } from '@rspress/core/runtime';
+import { removeBase, safePreconnect, useLang } from '@rspress/core/runtime';
 import { Link, useLinkNavigate } from '@rspress/core/theme';
 import '@docsearch/css';
 import './Search.css';
 import { useEffect } from 'react';
-import * as ReactDOM from 'react-dom';
 import type { Locales } from './locales';
 
 const Hit: DocSearchProps['hitComponent'] = ({ hit, children }) => {
   return <Link href={hit.url}>{children}</Link>;
 };
-
-type ReactDOMWithPreconnect = typeof ReactDOM & {
-  preconnect?: (
-    href: string,
-    options?: { crossOrigin?: '' | 'anonymous' | 'use-credentials' },
-  ) => void;
-};
-
-const safePreconnect = (ReactDOM as ReactDOMWithPreconnect).preconnect;
 
 type SearchProps = {
   /**

--- a/packages/plugin-playground/src/cli/index.ts
+++ b/packages/plugin-playground/src/cli/index.ts
@@ -7,7 +7,7 @@ import type {
 import type { RouteMeta, RspressPlugin } from '@rspress/core';
 import { getNodeAttribute } from '@rspress/core';
 import { RspackVirtualModulePlugin } from 'rspack-plugin-virtual-module';
-import { DEFAULT_BABEL_URL, DEFAULT_MONACO_URL } from '../web/constant';
+import { DEFAULT_BABEL_URL } from '../web/constant';
 import { remarkPlugin } from './remarkPlugin';
 import { parseImports } from './utils';
 
@@ -60,14 +60,6 @@ export function pluginPlayground(
       '[Playground]: render should ends with Playground.(jsx?|tsx?)',
     );
   }
-
-  const preloads: string[] = [];
-  const monacoPrefix = (monacoLoader.paths?.vs || DEFAULT_MONACO_URL).replace(
-    /\/+$/,
-    '',
-  );
-  preloads.push(`${monacoPrefix}/loader.js`);
-  preloads.push(`${monacoPrefix}/editor/editor.main.js`);
 
   return {
     name: '@rspress/plugin-playground',
@@ -214,17 +206,6 @@ export function pluginPlayground(
         },
         include: [pkgRootPath],
       },
-      html: {
-        tags: preloads.map(url => ({
-          tag: 'link',
-          head: true,
-          attrs: {
-            rel: 'preload',
-            href: url,
-            as: 'script',
-          },
-        })),
-      },
       tools: {
         rspack: {
           plugins: [playgroundVirtualModule],
@@ -233,7 +214,14 @@ export function pluginPlayground(
     },
     markdown: {
       remarkPlugins: [
-        [remarkPlugin, { getRouteMeta, editorPosition, defaultRenderMode }],
+        [
+          remarkPlugin,
+          {
+            getRouteMeta,
+            editorPosition,
+            defaultRenderMode,
+          },
+        ],
       ],
       globalComponents: [
         render

--- a/packages/plugin-playground/src/web/editor.tsx
+++ b/packages/plugin-playground/src/web/editor.tsx
@@ -2,7 +2,7 @@ import MonacoEditor, {
   loader,
   type EditorProps as MonacoEditorProps,
 } from '@monaco-editor/react';
-import { useDark } from '@rspress/core/runtime';
+import { safePreload, useDark } from '@rspress/core/runtime';
 import { useMemo } from 'react';
 import { DEFAULT_MONACO_URL } from './constant';
 
@@ -13,7 +13,7 @@ declare global {
   const __PLAYGROUND_MONACO_OPTIONS__: MonacoEditorProps['options'];
 }
 
-function initLoader() {
+function getLoaderConfig() {
   let loaderConfig: Parameters<typeof loader.config>[0] = {
     paths: {
       vs: DEFAULT_MONACO_URL,
@@ -30,9 +30,15 @@ function initLoader() {
     // ignore
   }
 
-  loader.config(loaderConfig);
+  return loaderConfig;
 }
-initLoader();
+
+const loaderConfig = getLoaderConfig();
+const monacoPrefix = (loaderConfig.paths?.vs || DEFAULT_MONACO_URL).replace(
+  /\/+$/,
+  '',
+);
+loader.config(loaderConfig);
 
 function getMonacoOptions() {
   try {
@@ -46,6 +52,9 @@ function getMonacoOptions() {
 export type EditorProps = Partial<MonacoEditorProps>;
 
 export function Editor(props: EditorProps) {
+  safePreload?.(`${monacoPrefix}/loader.js`, { as: 'script' });
+  safePreload?.(`${monacoPrefix}/editor/editor.main.js`, { as: 'script' });
+
   const { options, className = '', theme: themeProp, ...rest } = props || {};
 
   const dark = useDark();


### PR DESCRIPTION
## Summary

- Avoid preloading Monaco resources on pages that do not contain a playground.
- Trigger React DOM preloads when the Playground editor renders, with a shared React 18-compatible helper alongside `safePreconnect`.
- Cover production HTML output separately from the existing dev rendering and HMR tests.


link tag should not exist in non-playground page

<img width="1327" height="527" alt="image" src="https://github.com/user-attachments/assets/e0dd714b-9bcc-41ea-bd8e-a0a10432d93d" />


## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
