### PR TITLE
fix(ssg-md): preserve MDX exports

### DIFF
--- a/packages/core/src/node/ssg-md/remarkSplitMdx.test.ts
+++ b/packages/core/src/node/ssg-md/remarkSplitMdx.test.ts
@@ -246,6 +246,38 @@ export function Thing() {
     `);
   });
 
+  it('should preserve imports and referenced exports together', async () => {
+    const input = `import Badge from '@components/Badge'
+export const a = 1;
+export function Thing() {
+  return <>World</>
+}
+
+# Hello <Badge /> <Thing /> {a}
+
+{a}`;
+
+    const result = await processMdx(input);
+
+    expect(result).toMatchInlineSnapshot(`
+      "/*@jsxRuntime automatic*/
+      /*@jsxImportSource react*/
+      import Badge from '@components/Badge';
+      export const a = 1;
+      export function Thing() {
+        return <>World</>;
+      }
+      function _createMdxContent(props) {
+        return <><>{"# Hello "}<Badge />{" "}<Thing />{" "}{a}</>{"\\n"}{a}</>;
+      }
+      export default function MDXContent(props = {}) {
+        const {wrapper: MDXLayout} = props.components || ({});
+        return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);
+      }
+      "
+    `);
+  });
+
   it('should preserve inline mdxTextExpression in headings', async () => {
     const input = `# hello {window.foo}`;
 

--- a/packages/core/src/node/ssg-md/remarkSplitMdx.test.ts
+++ b/packages/core/src/node/ssg-md/remarkSplitMdx.test.ts
@@ -216,6 +216,36 @@ End of content.`;
     `);
   });
 
+  it('should preserve referenced exports', async () => {
+    const input = `export const a = 1;
+export function Thing() {
+  return <>World</>
+}
+
+# Hello <Thing /> {a}
+
+{a}`;
+
+    const result = await processMdx(input);
+
+    expect(result).toMatchInlineSnapshot(`
+      "/*@jsxRuntime automatic*/
+      /*@jsxImportSource react*/
+      export const a = 1;
+      export function Thing() {
+        return <>World</>;
+      }
+      function _createMdxContent(props) {
+        return <><>{"# Hello "}<Thing />{" "}{a}</>{"\\n"}{a}</>;
+      }
+      export default function MDXContent(props = {}) {
+        const {wrapper: MDXLayout} = props.components || ({});
+        return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);
+      }
+      "
+    `);
+  });
+
   it('should preserve inline mdxTextExpression in headings', async () => {
     const input = `# hello {window.foo}`;
 

--- a/packages/core/src/node/ssg-md/remarkSplitMdx.ts
+++ b/packages/core/src/node/ssg-md/remarkSplitMdx.ts
@@ -57,9 +57,11 @@ export function remarkSplitMdx(
 ): (tree: Root) => void {
   return (tree: Root) => {
     const newChildren: RootContent[] = [];
-    const { importMap, importNodes } = buildImportMap(tree);
+    const { importMap, esmNodes } = collectEsmMetadata(tree);
 
-    newChildren.push(...importNodes);
+    // Keep ESM declarations available to the MDX compiler. They are omitted
+    // only when content is stringified to Markdown.
+    newChildren.push(...esmNodes);
 
     for (const node of tree.children) {
       if (node.type === 'mdxjsEsm') {
@@ -535,14 +537,16 @@ function serializeNodeToMarkdown(node: RootContent): string {
  * Build a map of component names to their import sources
  * Example: { Table: '@lynx', Button: 'react' }
  */
-function buildImportMap(tree: Root): {
+function collectEsmMetadata(tree: Root): {
   importMap: Map<string, string>;
-  importNodes: Set<MdxjsEsm>;
+  esmNodes: Set<MdxjsEsm>;
 } {
   const importMap = new Map<string, string>();
-  const importNodes: Set<MdxjsEsm> = new Set();
+  const esmNodes = new Set<MdxjsEsm>();
 
   visit(tree, 'mdxjsEsm', node => {
+    esmNodes.add(node);
+
     const estree = node.data?.estree;
     if (!estree) {
       return;
@@ -556,13 +560,12 @@ function buildImportMap(tree: Root): {
         const localName = specifier.local?.name;
         if (localName) {
           importMap.set(localName, source as string);
-          importNodes.add(node);
         }
       }
     }
   });
 
-  return { importMap, importNodes };
+  return { importMap, esmNodes };
 }
 
 /**


### PR DESCRIPTION
## Summary

Referenced top-level MDX exports were dropped by `remarkSplitMdx`, which could cause SSG-MD to emit an empty Markdown artifact. This PR preserves ESM nodes for MDX compilation and removes them only during Markdown stringification, with regression coverage for exported values and components.

## Related Issue

Fixes https://github.com/web-infra-dev/rspress/issues/3560

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).