### PR TITLE
docs: update homepage tagline

### DIFF
--- a/website/docs/en/index.md
+++ b/website/docs/en/index.md
@@ -6,7 +6,7 @@ titleSuffix: 'Rsbuild-based Static Site Generator'
 hero:
   name: Rspress
   text: Lightning Fast Static Site Generator
-  tagline: Made for humans. Understood by AI.
+  tagline: Made for humans. Understood by AI
   actions:
     - theme: brand
       text: Introduction

--- a/website/docs/en/index.md
+++ b/website/docs/en/index.md
@@ -6,7 +6,7 @@ titleSuffix: 'Rsbuild-based Static Site Generator'
 hero:
   name: Rspress
   text: Lightning Fast Static Site Generator
-  tagline: Simple, efficient and easy to extend
+  tagline: Made for humans. Understood by AI.
   actions:
     - theme: brand
       text: Introduction

--- a/website/docs/zh/index.md
+++ b/website/docs/zh/index.md
@@ -8,7 +8,7 @@ hero:
   text: |
     快如闪电的
     静态站点生成器
-  tagline: 面向人，也面向 AI。
+  tagline: 面向人，也面向 AI
   image:
     src: https://assets.rspack.rs/rspress/rspress-logo.svg
     alt: Rspress Logo

--- a/website/docs/zh/index.md
+++ b/website/docs/zh/index.md
@@ -8,7 +8,7 @@ hero:
   text: |
     快如闪电的
     静态站点生成器
-  tagline: 简单、高性能、易于扩展
+  tagline: 面向人，也面向 AI。
   image:
     src: https://assets.rspack.rs/rspress/rspress-logo.svg
     alt: Rspress Logo


### PR DESCRIPTION
## Summary

This PR updates the homepage tagline to reflect that Rspress documentation serves both human readers and AI consumers. The English and Chinese homepages now use localized versions of the new slogan while preserving the existing hero title and content.

## Related Issue

N/A

## Screenshots

| Locale | Before | After |
| --- | --- | --- |
| English | `Simple, efficient and easy to extend` | `Made for humans. Understood by AI.` |
| Chinese | `简单、高性能、易于扩展` | `面向人，也面向 AI。` |

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).