### PR TITLE
style(theme/Llms): make LLMS buttons more compact

### DIFF
--- a/packages/core/src/theme/components/Llms/LlmsCopyButton.scss
+++ b/packages/core/src/theme/components/Llms/LlmsCopyButton.scss
@@ -27,14 +27,14 @@
 }
 
 .rp-llms-copy-button__icon-wrapper {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   position: relative;
 }
 
 .rp-llms-copy-button__icon-copy {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -43,8 +43,8 @@
 }
 
 .rp-llms-copy-button__icon-success {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   position: absolute;
   top: 50%;
   left: 50%;

--- a/packages/core/src/theme/components/Llms/LlmsViewOptions.scss
+++ b/packages/core/src/theme/components/Llms/LlmsViewOptions.scss
@@ -9,7 +9,10 @@
 }
 
 .rp-llms-view-options__arrow {
+  width: 14px;
+  height: 14px;
   transition: transform 0.2s ease;
+
   &--rotated {
     transform: rotate(180deg);
   }

--- a/packages/core/src/theme/components/Llms/index.scss
+++ b/packages/core/src/theme/components/Llms/index.scss
@@ -2,11 +2,11 @@
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  height: 36px;
-  padding: 0 12px;
+  height: 32px;
+  padding: 0 10px;
   gap: 6px;
 
-  border-radius: 8px;
+  border-radius: 6px;
   border: 1px solid var(--rp-c-divider-light);
   background: var(--rp-c-bg);
   color: var(--rp-c-text-2);


### PR DESCRIPTION
## Summary

This PR makes the LLMS action buttons more compact so they better match the visual hierarchy of content pages. It reduces the shared button height, padding, and radius, and aligns the `LlmsCopyButton` icons and `LlmsViewOptions` arrow at 14px while keeping the dropdown menu unchanged.

## Related Issue

N/A

## Screenshots

Reference: [Fumadocs Quick Start](https://www.fumadocs.dev/docs)

- Before: 36px height, 12px horizontal padding, 8px radius, and 16px copy icons.
- After: 32px height, 10px horizontal padding, 6px radius, and 14px action icons.

## Checklist

- [x] Tests updated (not required).
- [x] Documentation updated (not required).