### PR TITLE
fix(theme/Llms): omit redundant Markdown page hint

### DIFF
--- a/e2e/fixtures/ssg-md/index.test.ts
+++ b/e2e/fixtures/ssg-md/index.test.ts
@@ -51,7 +51,7 @@ test('llms should be successful', async () => {
     indexMd
       .trimStart()
       .startsWith(
-        '> For AI agents: the complete documentation index is available at https://example.com/docs/llms.txt, the full documentation bundle is available at https://example.com/docs/llms-full.txt, and this page is available as Markdown at https://example.com/docs/index.md.',
+        '> For AI agents: the complete documentation index is available at https://example.com/docs/llms.txt, the full documentation bundle is available at https://example.com/docs/llms-full.txt.',
       ),
   ).toBeTruthy();
 

--- a/packages/core/src/theme/components/Llms/LlmsHint.test.tsx
+++ b/packages/core/src/theme/components/Llms/LlmsHint.test.tsx
@@ -64,7 +64,7 @@ describe('LlmsHint', () => {
     setSsgMd(true);
 
     expect(await renderToMarkdownString(<LlmsHint />)).toBe(
-      '> For AI agents: the complete documentation index is available at https://example.com/docs/llms.txt, the full documentation bundle is available at https://example.com/docs/llms-full.txt, and this page is available as Markdown at https://example.com/docs/guide/index.md.\n\n',
+      '> For AI agents: the complete documentation index is available at https://example.com/docs/llms.txt, the full documentation bundle is available at https://example.com/docs/llms-full.txt.\n\n',
     );
   });
 

--- a/packages/core/src/theme/components/Llms/LlmsHint.tsx
+++ b/packages/core/src/theme/components/Llms/LlmsHint.tsx
@@ -27,9 +27,12 @@ function createLlmsHintText({
 }: {
   llmsTxtUrl: string;
   llmsFullTxtUrl: string;
-  pageMdUrl: string;
+  pageMdUrl?: string;
 }) {
-  return `For AI agents: the complete documentation index is available at ${llmsTxtUrl}, the full documentation bundle is available at ${llmsFullTxtUrl}, and this page is available as Markdown at ${pageMdUrl}.`;
+  const text = `For AI agents: the complete documentation index is available at ${llmsTxtUrl}, the full documentation bundle is available at ${llmsFullTxtUrl}`;
+  return pageMdUrl
+    ? `${text}, and this page is available as Markdown at ${pageMdUrl}.`
+    : `${text}.`;
 }
 
 export function LlmsHint() {
@@ -51,16 +54,17 @@ export function LlmsHint() {
   const llmsFullTxtUrl = withSiteOrigin(
     withBase(`/${versionPrefix}${langPrefix}llms-full.txt`),
   );
+
+  if (import.meta.env.SSG_MD) {
+    return `> ${createLlmsHintText({ llmsTxtUrl, llmsFullTxtUrl })}\n\n`;
+  }
+
   const pageMdUrl = withSiteOrigin(routePathToMdPath(page.routePath));
   const hintText = createLlmsHintText({
     llmsTxtUrl,
     llmsFullTxtUrl,
     pageMdUrl,
   });
-
-  if (import.meta.env.SSG_MD) {
-    return `> ${hintText}\n\n`;
-  }
 
   return (
     <div className="rp-llms-hint" style={visuallyHiddenStyle}>

--- a/website/docs/en/api/config/config-theme.mdx
+++ b/website/docs/en/api/config/config-theme.mdx
@@ -653,10 +653,10 @@ Assuming [`siteOrigin`](/api/config/config-basic#siteorigin) is `https://example
 The SSG-MD Markdown output for the same page starts with:
 
 ```md
-> For AI agents: the complete documentation index is available at https://example.com/llms.txt, the full documentation bundle is available at https://example.com/llms-full.txt, and this page is available as Markdown at https://example.com/guide/index.md.
+> For AI agents: the complete documentation index is available at https://example.com/llms.txt, the full documentation bundle is available at https://example.com/llms-full.txt.
 ```
 
-The URLs automatically include the configured `siteOrigin`, [`base`](/api/config/config-basic#base), locale, and version prefixes. The page-specific Markdown URL is derived from the current route. Without `siteOrigin`, the URLs remain base-aware paths.
+The URLs automatically include the configured `siteOrigin`, [`base`](/api/config/config-basic#base), locale, and version prefixes. Without `siteOrigin`, the URLs remain base-aware paths.
 
 Set `injectLlmsHint` to `false` to disable this behavior:
 

--- a/website/docs/zh/api/config/config-theme.mdx
+++ b/website/docs/zh/api/config/config-theme.mdx
@@ -641,10 +641,10 @@ export default defineConfig({
 同一页面的 SSG-MD Markdown 输出会以以下内容开头：
 
 ```md
-> For AI agents: the complete documentation index is available at https://example.com/llms.txt, the full documentation bundle is available at https://example.com/llms-full.txt, and this page is available as Markdown at https://example.com/guide/index.md.
+> For AI agents: the complete documentation index is available at https://example.com/llms.txt, the full documentation bundle is available at https://example.com/llms-full.txt.
 ```
 
-其中的 URL 会自动包含配置的 `siteOrigin`、[`base`](/api/config/config-basic#base)、语言和版本前缀，当前页面的 Markdown URL 会根据当前路由生成。未配置 `siteOrigin` 时，则保留带 `base` 前缀的路径。
+其中的 URL 会自动包含配置的 `siteOrigin`、[`base`](/api/config/config-basic#base)、语言和版本前缀。未配置 `siteOrigin` 时，则保留带 `base` 前缀的路径。
 
 将 `injectLlmsHint` 设置为 `false`，可以禁用这一行为：
 


### PR DESCRIPTION
## Summary

SSG-MD output already represents the current page as Markdown, so repeating its page-specific Markdown URL in the directive provides no useful guidance. This PR omits that URL from SSG-MD directives while preserving it in SSG HTML output, and updates the focused tests and bilingual documentation.

## Checklist

- [x] Tests updated.
- [x] Documentation updated.