### PR TITLE
test(e2e): use two workers in CI

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
   globalTimeout: 30 * 60 * 1000,
   // 1 min for each test
   timeout: 60 * 1000,
+  // Avoid Playwright falling back to one worker on macOS CI
+  workers: isCI ? 2 : undefined,
   quiet: true,
   reporter: 'list',
   use: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   globalTimeout: 30 * 60 * 1000,
   // 1 min for each test
   timeout: 60 * 1000,
-  // Avoid Playwright falling back to one worker on macOS CI
+  // Pin CI to two workers (Playwright defaults to 1 worker on CI)
   workers: isCI ? 2 : undefined,
   quiet: true,
   reporter: 'list',


### PR DESCRIPTION
## Summary

The macOS E2E job currently runs with one Playwright worker, while Windows already uses two. This PR pins CI to two workers without changing local defaults or test behavior.

## CI performance

### macOS (1 → 2 workers)

| Run | Workers | Flaky retries | E2E step | Change | Whole job | Change |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| [Before](https://github.com/web-infra-dev/rspress/actions/runs/30601231986) | 1 | 1 | 364.09s | — | 456.57s | — |
| [After, first run](https://github.com/web-infra-dev/rspress/actions/runs/30602243533) | 2 | 1 | 218.87s | **-39.9%** | 308.84s | **-32.4%** |
| [After, current head](https://github.com/web-infra-dev/rspress/actions/runs/30602685392) | 2 | 2 | 298.95s | **-17.9%** | 397.69s | **-12.9%** |
| Post-change mean | 2 | — | 258.91s | **-28.9%** | 353.27s | **-22.6%** |

The first before/after pair has the same retry count and shows the clearest configuration effect. The current-head run included one additional full 60-second timeout, which reduced the observed gain.

### Windows (2 → 2 workers)

| Run | Workers | Flaky retries | E2E step | Observed change | Whole job | Observed change |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| [Before](https://github.com/web-infra-dev/rspress/actions/runs/30601232029) | 2 | 2 | 419.74s | — | 636.13s | — |
| [After, first run](https://github.com/web-infra-dev/rspress/actions/runs/30602243535) | 2 | 1 | 360.75s | -14.1% | 570.85s | -10.3% |
| [After, current head](https://github.com/web-infra-dev/rspress/actions/runs/30602685389) | 2 | 2 | 372.72s | -11.2% | 571.57s | -10.1% |

Windows used two workers both before and after this change, so its observed difference should be treated as run-to-run variance rather than attributed to this PR. Windows remains the overall CI critical path.

### Local benchmark

| Suite | 1 worker | 2 workers | Change | Result |
| --- | ---: | ---: | ---: | --- |
| Stable subset (212 tests) | 378.30s | 179.98s | **-52.4%** | 212 passed |
| Complete suite (221 tests) | — | 181.16s | — | 221 passed, no retries |

## Checklist

- [x] Tests updated (not required; test logic is unchanged).
- [x] Documentation updated (not required).