### PR TITLE
test(e2e): stabilize fully parallel execution

### DIFF
--- a/e2e/fixtures/basic/rspress.config.ts
+++ b/e2e/fixtures/basic/rspress.config.ts
@@ -1,8 +1,10 @@
 import * as path from 'node:path';
 import { defineConfig } from '@rspress/core';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc'),
+  outDir: getTestOutDir(),
   globalStyles: path.join(import.meta.dirname, 'styles/index.css'),
   themeConfig: {
     socialLinks: [

--- a/e2e/fixtures/basic/rspress.dark.config.ts
+++ b/e2e/fixtures/basic/rspress.dark.config.ts
@@ -1,8 +1,10 @@
 import * as path from 'node:path';
 import { defineConfig } from '@rspress/core';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc'),
+  outDir: getTestOutDir('rspress.dark.config.ts'),
   themeConfig: {
     darkMode: 'dark',
   },

--- a/e2e/fixtures/basic/rspress.force-dark.config.ts
+++ b/e2e/fixtures/basic/rspress.force-dark.config.ts
@@ -1,8 +1,10 @@
 import * as path from 'node:path';
 import { defineConfig } from '@rspress/core';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc'),
+  outDir: getTestOutDir('rspress.force-dark.config.ts'),
   themeConfig: {
     darkMode: 'force-dark',
   },

--- a/e2e/fixtures/basic/rspress.true.config.ts
+++ b/e2e/fixtures/basic/rspress.true.config.ts
@@ -1,8 +1,10 @@
 import * as path from 'node:path';
 import { defineConfig } from '@rspress/core';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc'),
+  outDir: getTestOutDir('rspress.true.config.ts'),
   themeConfig: {
     darkMode: true,
   },

--- a/e2e/fixtures/check-dead-link/index.test.ts
+++ b/e2e/fixtures/check-dead-link/index.test.ts
@@ -8,10 +8,11 @@ import {
 
 test.describe('check dead links', async () => {
   let appPort: number;
-  let app: Awaited<ReturnType<typeof runPreviewCommand>>;
-  test.afterAll(async () => {
+  let app: Awaited<ReturnType<typeof runPreviewCommand>> | undefined;
+  test.afterEach(async () => {
     if (app) {
       await killProcess(app);
+      app = undefined;
     }
   });
 
@@ -91,7 +92,10 @@ test.describe('check dead links', async () => {
     const appDir = import.meta.dirname;
     appPort = await getPort();
     await runBuildCommand(appDir, 'rspress-no-prefix.config.ts');
-    app = await runPreviewCommand(appDir, appPort);
+    app = await runPreviewCommand(appDir, appPort, [
+      '-c',
+      'rspress-no-prefix.config.ts',
+    ]);
 
     const getLinks = async (url: string) => {
       await page.goto(url, {
@@ -163,7 +167,10 @@ test.describe('check dead links', async () => {
     const appDir = import.meta.dirname;
     appPort = await getPort();
     await runBuildCommand(appDir, 'rspress-clean.config.ts');
-    app = await runPreviewCommand(appDir, appPort);
+    app = await runPreviewCommand(appDir, appPort, [
+      '-c',
+      'rspress-clean.config.ts',
+    ]);
 
     const getLinks = async (url: string) => {
       await page.goto(url, {

--- a/e2e/fixtures/check-dead-link/rspress-anchor-error.config.ts
+++ b/e2e/fixtures/check-dead-link/rspress-anchor-error.config.ts
@@ -1,8 +1,10 @@
 import * as path from 'node:path';
 import { defineConfig } from '@rspress/core';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc-anchor-error'),
+  outDir: getTestOutDir('rspress-anchor-error.config.ts'),
   markdown: {
     link: {
       checkAnchors: true,

--- a/e2e/fixtures/check-dead-link/rspress-clean.config.ts
+++ b/e2e/fixtures/check-dead-link/rspress-clean.config.ts
@@ -1,8 +1,10 @@
 import * as path from 'node:path';
 import { defineConfig } from '@rspress/core';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc'),
+  outDir: getTestOutDir('rspress-clean.config.ts'),
   lang: 'zh',
   base: '/base',
   route: {

--- a/e2e/fixtures/check-dead-link/rspress-no-prefix.config.ts
+++ b/e2e/fixtures/check-dead-link/rspress-no-prefix.config.ts
@@ -1,8 +1,10 @@
 import * as path from 'node:path';
 import { defineConfig } from '@rspress/core';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc'),
+  outDir: getTestOutDir('rspress-no-prefix.config.ts'),
   lang: 'zh',
   base: '/base',
   markdown: {

--- a/e2e/fixtures/check-dead-link/rspress.config.ts
+++ b/e2e/fixtures/check-dead-link/rspress.config.ts
@@ -1,8 +1,10 @@
 import * as path from 'node:path';
 import { defineConfig } from '@rspress/core';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc'),
+  outDir: getTestOutDir(),
   lang: 'zh',
   base: '/base',
   route: {

--- a/e2e/fixtures/code-block/rspress.config.ts
+++ b/e2e/fixtures/code-block/rspress.config.ts
@@ -6,9 +6,11 @@ import {
   transformerNotationFocus,
   transformerNotationHighlight,
 } from '@shikijs/transformers';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc'),
+  outDir: getTestOutDir(),
   markdown: {
     shiki: {
       langAlias: {

--- a/e2e/fixtures/custom-headers/rspress.config.ts
+++ b/e2e/fixtures/custom-headers/rspress.config.ts
@@ -1,8 +1,10 @@
 import * as path from 'node:path';
 import { defineConfig } from '@rspress/core';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc'),
+  outDir: getTestOutDir(),
   head: [
     '<meta name="config-string-head" content="config-string-head-value">',
     ['meta', { name: 'config-tuple-head', content: 'config-tuple-head-value' }],

--- a/e2e/fixtures/hmr/index.test.ts
+++ b/e2e/fixtures/hmr/index.test.ts
@@ -20,6 +20,16 @@ const TEST_ADDED_FILE = path.resolve(
 );
 const TEST_RESTART_FILE = path.resolve(import.meta.dirname, 'siteConfig.ts');
 
+test.describe.configure({ mode: 'serial' });
+
+function createRestartCounter(app: Awaited<ReturnType<typeof runDevCommand>>) {
+  let devOutput = '';
+  (app as { stdout?: NodeJS.ReadableStream }).stdout?.on('data', chunk => {
+    devOutput += chunk.toString();
+  });
+  return () => devOutput.match(/restarting server as .* changed/g)?.length ?? 0;
+}
+
 test.describe('hmr test', async () => {
   let appPort: number;
   let app: Awaited<ReturnType<typeof runDevCommand>>;
@@ -27,36 +37,30 @@ test.describe('hmr test', async () => {
   let originalFragmentContent: string;
   let originalNavContent: string;
   let originalMetaContent: string;
-  let originalRestartFileContent: string;
-  let devOutput = '';
-
-  const getRestartCount = () =>
-    devOutput.match(/restarting server as .* changed/g)?.length ?? 0;
+  let getRestartCount: () => number;
 
   test.beforeAll(async () => {
     const appDir = import.meta.dirname;
     appPort = await getPort();
     app = await runDevCommand(appDir, appPort);
-    (app as { stdout?: NodeJS.ReadableStream }).stdout?.on('data', chunk => {
-      devOutput += chunk.toString();
-    });
+    getRestartCount = createRestartCounter(app);
     originalContent = await fs.readFile(TEST_FILE, 'utf-8');
     originalFragmentContent = await fs.readFile(TEST_FRAGMENT_FILE, 'utf-8');
     originalNavContent = await fs.readFile(TEST_NAV_FILE, 'utf-8');
     originalMetaContent = await fs.readFile(TEST_META_FILE, 'utf-8');
-    originalRestartFileContent = await fs.readFile(TEST_RESTART_FILE, 'utf-8');
   });
 
   test.afterAll(async () => {
-    if (app) {
-      await killProcess(app);
+    try {
+      if (app) {
+        await killProcess(app);
+      }
+    } finally {
+      await fs.writeFile(TEST_FILE, originalContent);
+      await fs.writeFile(TEST_FRAGMENT_FILE, originalFragmentContent);
+      await fs.writeFile(TEST_NAV_FILE, originalNavContent);
+      await fs.writeFile(TEST_META_FILE, originalMetaContent);
     }
-    await fs.writeFile(TEST_FILE, originalContent);
-    await fs.writeFile(TEST_FRAGMENT_FILE, originalFragmentContent);
-    await fs.writeFile(TEST_NAV_FILE, originalNavContent);
-    await fs.writeFile(TEST_META_FILE, originalMetaContent);
-    await fs.writeFile(TEST_RESTART_FILE, originalRestartFileContent);
-    await fs.rm(TEST_ADDED_FILE, { force: true });
   });
 
   test('Test page', async ({ page }) => {
@@ -104,10 +108,36 @@ test.describe('hmr test', async () => {
     ).toBeVisible();
     expect(getRestartCount()).toBe(0);
   });
+});
 
-  test('restart when routes or config dependencies change', async ({
-    page,
-  }) => {
+test.describe('route restart test', async () => {
+  let appPort: number;
+  let app: Awaited<ReturnType<typeof runDevCommand>>;
+  let getRestartCount: () => number;
+
+  test.beforeAll(async () => {
+    const appDir = import.meta.dirname;
+    appPort = await getPort();
+    app = await runDevCommand(appDir, appPort);
+    getRestartCount = createRestartCounter(app);
+  });
+
+  test.afterAll(async () => {
+    try {
+      if (app) {
+        await killProcess(app);
+      }
+    } finally {
+      await fs.rm(TEST_ADDED_FILE, { force: true });
+    }
+  });
+
+  test('restart when routes are added or removed', async ({ page }) => {
+    await page.goto(`http://localhost:${appPort}/guide/test.html`, {
+      waitUntil: 'networkidle',
+    });
+    await expect(page).toHaveTitle(/HMR fixture/);
+
     await fs.writeFile(TEST_ADDED_FILE, '# Added route');
     await expect.poll(getRestartCount).toBe(1);
 
@@ -127,16 +157,60 @@ test.describe('hmr test', async () => {
     await fs.rm(TEST_ADDED_FILE);
     await expect.poll(getRestartCount).toBe(2);
 
+    await expect
+      .poll(async () => {
+        try {
+          await page.goto(
+            `http://localhost:${appPort}/guide/test-temp-added.html`,
+          );
+          return page.locator('body').textContent();
+        } catch {
+          return null;
+        }
+      })
+      .toContain('404');
+  });
+});
+
+test.describe('config dependency restart test', async () => {
+  let appPort: number;
+  let app: Awaited<ReturnType<typeof runDevCommand>>;
+  let originalRestartFileContent: string;
+  let getRestartCount: () => number;
+
+  test.beforeAll(async () => {
+    const appDir = import.meta.dirname;
+    originalRestartFileContent = await fs.readFile(TEST_RESTART_FILE, 'utf-8');
+    appPort = await getPort();
+    app = await runDevCommand(appDir, appPort);
+    getRestartCount = createRestartCounter(app);
+  });
+
+  test.afterAll(async () => {
+    try {
+      if (app) {
+        await killProcess(app);
+      }
+    } finally {
+      await fs.writeFile(TEST_RESTART_FILE, originalRestartFileContent);
+    }
+  });
+
+  test('restart when config dependencies change', async ({ page }) => {
+    const pageUrl = `http://localhost:${appPort}/guide/test.html`;
+    await page.goto(pageUrl, { waitUntil: 'networkidle' });
+    await expect(page).toHaveTitle(/HMR fixture/);
+
     await fs.writeFile(
       TEST_RESTART_FILE,
       originalRestartFileContent.replace('HMR fixture', 'Restarted fixture'),
     );
-    await expect.poll(getRestartCount).toBe(3);
+    await expect.poll(getRestartCount).toBe(1);
 
     await expect
       .poll(async () => {
         try {
-          await page.reload();
+          await page.goto(pageUrl);
           return page.title();
         } catch {
           return '';

--- a/e2e/fixtures/markdown-link-asset/index.test.ts
+++ b/e2e/fixtures/markdown-link-asset/index.test.ts
@@ -8,10 +8,11 @@ import {
 
 test.describe('basic test', async () => {
   let appPort: number;
-  let app: Awaited<ReturnType<typeof runPreviewCommand>> | null;
-  test.afterAll(async () => {
+  let app: Awaited<ReturnType<typeof runPreviewCommand>> | undefined;
+  test.afterEach(async () => {
     if (app) {
       await killProcess(app);
+      app = undefined;
     }
   });
 
@@ -89,7 +90,10 @@ test.describe('basic test', async () => {
     const appDir = import.meta.dirname;
     appPort = await getPort();
     await runBuildCommand(appDir, 'rspress-clean.config.ts');
-    app = await runPreviewCommand(appDir, appPort);
+    app = await runPreviewCommand(appDir, appPort, [
+      '-c',
+      'rspress-clean.config.ts',
+    ]);
     await testAssetLink(page, false, true);
   });
 
@@ -99,7 +103,10 @@ test.describe('basic test', async () => {
     const appDir = import.meta.dirname;
     appPort = await getPort();
     await runBuildCommand(appDir, 'rspress-clean.config.ts');
-    app = await runPreviewCommand(appDir, appPort);
+    app = await runPreviewCommand(appDir, appPort, [
+      '-c',
+      'rspress-clean.config.ts',
+    ]);
     await testAssetLink(page, true, true);
   });
 });

--- a/e2e/fixtures/markdown-link-asset/rspress-clean.config.ts
+++ b/e2e/fixtures/markdown-link-asset/rspress-clean.config.ts
@@ -1,9 +1,11 @@
 import * as path from 'node:path';
 import { defineConfig } from '@rspress/core';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   base: '/base/',
   root: path.join(import.meta.dirname, 'doc'),
+  outDir: getTestOutDir('rspress-clean.config.ts'),
   lang: 'en',
   route: {
     cleanUrls: true,

--- a/e2e/fixtures/markdown-link-asset/rspress.config.ts
+++ b/e2e/fixtures/markdown-link-asset/rspress.config.ts
@@ -1,9 +1,11 @@
 import * as path from 'node:path';
 import { defineConfig } from '@rspress/core';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   base: '/base/',
   root: path.join(import.meta.dirname, 'doc'),
+  outDir: getTestOutDir(),
   lang: 'en',
   route: {
     cleanUrls: false,

--- a/e2e/fixtures/page-head-tags/rspress.config.ts
+++ b/e2e/fixtures/page-head-tags/rspress.config.ts
@@ -1,6 +1,8 @@
 import * as path from 'node:path';
 import { defineConfig } from '@rspress/core';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc'),
+  outDir: getTestOutDir(),
 });

--- a/e2e/fixtures/plugin-llms/index.test.ts
+++ b/e2e/fixtures/plugin-llms/index.test.ts
@@ -1,6 +1,7 @@
 import { access, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { expect, test } from '@playwright/test';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 import { runBuildCommand } from '../../utils/runCommands';
 
 /**
@@ -29,23 +30,18 @@ async function pathExists(path: string): Promise<boolean> {
 test.describe('plugin-llms', async () => {
   test('should generate llms.txt llms-full.txt mdFiles', async () => {
     const appDir = import.meta.dirname;
+    const docBuildDir = path.resolve(appDir, getTestOutDir());
     await runBuildCommand(appDir);
 
-    expect(
-      pathExists(path.resolve(appDir, 'doc_build', 'llms.txt')),
-    ).toBeTruthy();
+    expect(pathExists(path.resolve(docBuildDir, 'llms.txt'))).toBeTruthy();
 
-    expect(
-      pathExists(path.resolve(appDir, 'doc_build', 'llms-full.txt')),
-    ).toBeTruthy();
+    expect(pathExists(path.resolve(docBuildDir, 'llms-full.txt'))).toBeTruthy();
 
-    expect(
-      pathExists(path.resolve(appDir, 'doc_build', 'index.md')),
-    ).toBeTruthy();
+    expect(pathExists(path.resolve(docBuildDir, 'index.md'))).toBeTruthy();
 
     // Verify llms.txt content: nav sections should group routes correctly
     const llmsTxt = await readFile(
-      path.resolve(appDir, 'doc_build', 'llms.txt'),
+      path.resolve(docBuildDir, 'llms.txt'),
       'utf-8',
     );
     // Should have nav-based sections, not everything in "Other"
@@ -62,7 +58,7 @@ test.describe('plugin-llms', async () => {
 
     // Verify llms-full.txt has markdown content with url frontmatter
     const llmsFullTxt = await readFile(
-      path.resolve(appDir, 'doc_build', 'llms-full.txt'),
+      path.resolve(docBuildDir, 'llms-full.txt'),
       'utf-8',
     );
     expect(llmsFullTxt).toContain(
@@ -75,10 +71,11 @@ test.describe('plugin-llms', async () => {
 
   test('should order llms.txt entries according to _meta.json', async () => {
     const appDir = import.meta.dirname;
+    const docBuildDir = path.resolve(appDir, getTestOutDir());
     await runBuildCommand(appDir);
 
     const llmsTxt = await readFile(
-      path.resolve(appDir, 'doc_build', 'llms.txt'),
+      path.resolve(docBuildDir, 'llms.txt'),
       'utf-8',
     );
 
@@ -119,31 +116,29 @@ test.describe('plugin-llms', async () => {
 
   test('multiple configuration - should generate llms.txt llms-full.txt mdFiles', async () => {
     const appDir = import.meta.dirname;
+    const docBuildDir = path.resolve(
+      appDir,
+      getTestOutDir('rspress-i18n.config.ts'),
+    );
     await runBuildCommand(appDir, 'rspress-i18n.config.ts');
 
+    expect(pathExists(path.resolve(docBuildDir, 'llms.txt'))).toBeTruthy();
+
+    expect(pathExists(path.resolve(docBuildDir, 'llms-full.txt'))).toBeTruthy();
+
+    expect(pathExists(path.resolve(docBuildDir, 'index.md'))).toBeTruthy();
+
     expect(
-      pathExists(path.resolve(appDir, 'doc_build', 'llms.txt')),
+      pathExists(path.resolve(docBuildDir, 'zh', 'llms.txt')),
     ).toBeTruthy();
 
     expect(
-      pathExists(path.resolve(appDir, 'doc_build', 'llms-full.txt')),
-    ).toBeTruthy();
-
-    expect(
-      pathExists(path.resolve(appDir, 'doc_build', 'index.md')),
-    ).toBeTruthy();
-
-    expect(
-      pathExists(path.resolve(appDir, 'doc_build', 'zh', 'llms.txt')),
-    ).toBeTruthy();
-
-    expect(
-      pathExists(path.resolve(appDir, 'doc_build', 'zh', 'llms-full.txt')),
+      pathExists(path.resolve(docBuildDir, 'zh', 'llms-full.txt')),
     ).toBeTruthy();
 
     // Verify zh/llms.txt has Chinese content grouped by nav
     const zhLlmsTxt = await readFile(
-      path.resolve(appDir, 'doc_build', 'zh', 'llms.txt'),
+      path.resolve(docBuildDir, 'zh', 'llms.txt'),
       'utf-8',
     );
     expect(zhLlmsTxt).toContain('## Guide');
@@ -152,7 +147,7 @@ test.describe('plugin-llms', async () => {
 
     // FIXME: should work
     // expect(
-    //   pathExists(path.resolve(appDir, 'doc_build', 'zh', 'index.md')),
+    //   pathExists(path.resolve(docBuildDir, 'zh', 'index.md')),
     // ).toBeTruthy();
   });
 });

--- a/e2e/fixtures/plugin-llms/rspress-i18n.config.ts
+++ b/e2e/fixtures/plugin-llms/rspress-i18n.config.ts
@@ -1,9 +1,11 @@
 import * as path from 'node:path';
 import { defineConfig } from '@rspress/core';
 import { pluginLlms } from '@rspress/plugin-llms';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc-i18n'),
+  outDir: getTestOutDir('rspress-i18n.config.ts'),
   lang: 'en',
   themeConfig: {
     darkMode: false,

--- a/e2e/fixtures/plugin-llms/rspress.config.ts
+++ b/e2e/fixtures/plugin-llms/rspress.config.ts
@@ -1,9 +1,11 @@
 import path from 'node:path';
 import { defineConfig } from '@rspress/core';
 import { pluginLlms } from '@rspress/plugin-llms';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc'),
+  outDir: getTestOutDir(),
   base: '/docs/',
   siteOrigin: 'https://example.com',
   ssg: false,

--- a/e2e/fixtures/plugin-playground-preview/index.test.ts
+++ b/e2e/fixtures/plugin-playground-preview/index.test.ts
@@ -1,13 +1,18 @@
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 
+test.describe.configure({ mode: 'serial' });
+
 test.describe('plugin-playground-preview combined test', async () => {
   let appPort;
   let app;
   test.beforeAll(async () => {
     const appDir = import.meta.dirname;
     appPort = await getPort();
-    app = await runDevCommand(appDir, appPort);
+    const iframeDevPort = await getPort();
+    app = await runDevCommand(appDir, appPort, undefined, [], {
+      RSPRESS_IFRAME_DEV_PORT: iframeDevPort.toString(),
+    });
   });
 
   test.afterAll(async () => {

--- a/e2e/fixtures/plugin-playground-preview/index.test.ts
+++ b/e2e/fixtures/plugin-playground-preview/index.test.ts
@@ -1,8 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 
-test.describe.configure({ mode: 'serial' });
-
 test.describe('plugin-playground-preview combined test', async () => {
   let appPort;
   let app;

--- a/e2e/fixtures/plugin-playground-preview/rspress.config.ts
+++ b/e2e/fixtures/plugin-playground-preview/rspress.config.ts
@@ -5,5 +5,14 @@ import { pluginPreview } from '@rspress/plugin-preview';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc'),
-  plugins: [pluginPreview(), pluginPlayground()],
+  plugins: [
+    pluginPreview({
+      iframeOptions: {
+        devPort: process.env.RSPRESS_IFRAME_DEV_PORT
+          ? Number(process.env.RSPRESS_IFRAME_DEV_PORT)
+          : undefined,
+      },
+    }),
+    pluginPlayground(),
+  ],
 });

--- a/e2e/fixtures/plugin-preview-custom-entry/index.test.ts
+++ b/e2e/fixtures/plugin-preview-custom-entry/index.test.ts
@@ -1,8 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 
-test.describe.configure({ mode: 'serial' });
-
 test.describe('plugin test', async () => {
   let appPort;
   let app;

--- a/e2e/fixtures/plugin-preview-custom-entry/index.test.ts
+++ b/e2e/fixtures/plugin-preview-custom-entry/index.test.ts
@@ -1,13 +1,18 @@
 import { expect, test } from '@playwright/test';
 import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
 
+test.describe.configure({ mode: 'serial' });
+
 test.describe('plugin test', async () => {
   let appPort;
   let app;
   test.beforeAll(async () => {
     const appDir = import.meta.dirname;
     appPort = await getPort();
-    app = await runDevCommand(appDir, appPort);
+    const iframeDevPort = await getPort();
+    app = await runDevCommand(appDir, appPort, undefined, [], {
+      RSPRESS_IFRAME_DEV_PORT: iframeDevPort.toString(),
+    });
   });
 
   test.afterAll(async () => {

--- a/e2e/fixtures/plugin-preview-custom-entry/rspress.config.ts
+++ b/e2e/fixtures/plugin-preview-custom-entry/rspress.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
   plugins: [
     pluginPreview({
       iframeOptions: {
+        devPort: process.env.RSPRESS_IFRAME_DEV_PORT
+          ? Number(process.env.RSPRESS_IFRAME_DEV_PORT)
+          : undefined,
         customEntry: ({ demoPath }) => {
           if (demoPath.endsWith('.vue')) {
             return `

--- a/e2e/fixtures/plugin-preview/index.test.ts
+++ b/e2e/fixtures/plugin-preview/index.test.ts
@@ -11,13 +11,18 @@ import {
 
 const HMR_TEST_FILE = path.resolve(import.meta.dirname, 'doc/hmr.mdx');
 
+test.describe.configure({ mode: 'serial' });
+
 test.describe('plugin test', async () => {
   let appPort;
   let app;
   test.beforeAll(async () => {
     const appDir = import.meta.dirname;
     appPort = await getPort();
-    app = await runDevCommand(appDir, appPort);
+    const iframeDevPort = await getPort();
+    app = await runDevCommand(appDir, appPort, undefined, [], {
+      RSPRESS_IFRAME_DEV_PORT: iframeDevPort.toString(),
+    });
   });
 
   test.afterAll(async () => {
@@ -222,7 +227,10 @@ test.describe('plugin preview HMR', async () => {
   test.beforeAll(async () => {
     const appDir = import.meta.dirname;
     appPort = await getPort();
-    app = await runDevCommand(appDir, appPort);
+    const iframeDevPort = await getPort();
+    app = await runDevCommand(appDir, appPort, undefined, [], {
+      RSPRESS_IFRAME_DEV_PORT: iframeDevPort.toString(),
+    });
     originalContent = await fs.readFile(HMR_TEST_FILE, 'utf-8');
   });
 

--- a/e2e/fixtures/plugin-preview/index.test.ts
+++ b/e2e/fixtures/plugin-preview/index.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { expect, test } from '@playwright/test';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 import {
   getPort,
   killProcess,
@@ -196,7 +197,10 @@ test.describe('plugin preview build', async () => {
   }) => {
     const appDir = import.meta.dirname;
     const noIframePort = await getPort();
-    const distDir = path.join(appDir, 'doc_build');
+    const distDir = path.join(
+      appDir,
+      getTestOutDir('rspress.no-iframe.config.ts'),
+    );
 
     await fs.rm(distDir, { recursive: true, force: true });
     await runBuildCommand(appDir, 'rspress.no-iframe.config.ts');

--- a/e2e/fixtures/plugin-preview/rspress.config.ts
+++ b/e2e/fixtures/plugin-preview/rspress.config.ts
@@ -1,9 +1,11 @@
 import path from 'node:path';
 import { defineConfig } from '@rspress/core';
 import { pluginPreview } from '@rspress/plugin-preview';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc'),
+  outDir: getTestOutDir(),
   plugins: [
     pluginPreview({
       iframeOptions: {

--- a/e2e/fixtures/plugin-preview/rspress.config.ts
+++ b/e2e/fixtures/plugin-preview/rspress.config.ts
@@ -7,6 +7,9 @@ export default defineConfig({
   plugins: [
     pluginPreview({
       iframeOptions: {
+        devPort: process.env.RSPRESS_IFRAME_DEV_PORT
+          ? Number(process.env.RSPRESS_IFRAME_DEV_PORT)
+          : undefined,
         framework: 'react',
       },
       defaultPreviewMode: 'iframe-fixed',

--- a/e2e/fixtures/plugin-preview/rspress.no-iframe.config.ts
+++ b/e2e/fixtures/plugin-preview/rspress.no-iframe.config.ts
@@ -1,9 +1,11 @@
 import path from 'node:path';
 import { defineConfig } from '@rspress/core';
 import { pluginPreview } from '@rspress/plugin-preview';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc-no-iframe'),
+  outDir: getTestOutDir('rspress.no-iframe.config.ts'),
   plugins: [
     pluginPreview({
       defaultPreviewMode: 'internal',

--- a/e2e/fixtures/plugin-rss/rspress.config.ts
+++ b/e2e/fixtures/plugin-rss/rspress.config.ts
@@ -2,9 +2,11 @@ import * as NodePath from 'node:path';
 import { defineConfig } from '@rspress/core';
 import { pluginRss } from '@rspress/plugin-rss';
 import fixture from './fixture.json' with { type: 'json' };
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   root: NodePath.resolve(import.meta.dirname, 'doc'),
+  outDir: getTestOutDir(),
   title: fixture.title,
   base: fixture.base,
   plugins: [

--- a/e2e/fixtures/plugin-twoslash/rspress.config.ts
+++ b/e2e/fixtures/plugin-twoslash/rspress.config.ts
@@ -1,8 +1,10 @@
 import path from 'node:path';
 import { defineConfig } from '@rspress/core';
 import { pluginTwoslash } from '@rspress/plugin-twoslash';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc'),
+  outDir: getTestOutDir(),
   plugins: [pluginTwoslash()],
 });

--- a/e2e/fixtures/public-dir/index.test.ts
+++ b/e2e/fixtures/public-dir/index.test.ts
@@ -17,6 +17,8 @@ async function pathExists(path: string): Promise<boolean> {
   }
 }
 
+test.describe.configure({ mode: 'serial' });
+
 test.describe('basic test', async () => {
   test('should not generate the routes for html/js/mdx files in publicDir', async () => {
     const appDir = import.meta.dirname;

--- a/e2e/fixtures/public-dir/index.test.ts
+++ b/e2e/fixtures/public-dir/index.test.ts
@@ -1,8 +1,10 @@
 import { access, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { expect, test } from '@playwright/test';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 import {
   getPort,
+  killProcess,
   runBuildCommand,
   runDevCommand,
   runPreviewCommand,
@@ -17,32 +19,25 @@ async function pathExists(path: string): Promise<boolean> {
   }
 }
 
-test.describe.configure({ mode: 'serial' });
-
 test.describe('basic test', async () => {
   test('should not generate the routes for html/js/mdx files in publicDir', async () => {
     const appDir = import.meta.dirname;
+    const outDir = path.resolve(appDir, getTestOutDir());
     await runBuildCommand(appDir);
 
-    const existsImg = pathExists(
-      path.resolve(appDir, 'doc_build', 'rspress-icon.png'),
-    );
+    const existsImg = pathExists(path.resolve(outDir, 'rspress-icon.png'));
     expect(existsImg).toBeTruthy();
 
-    const existsTestHtml = await pathExists(
-      path.resolve(appDir, 'doc_build', 'test.html'),
-    );
+    const existsTestHtml = await pathExists(path.resolve(outDir, 'test.html'));
     expect(existsTestHtml).toBeTruthy();
 
-    const testJsPath = path.resolve(appDir, 'doc_build', 'test.js');
+    const testJsPath = path.resolve(outDir, 'test.js');
     const existsTestJs = await pathExists(testJsPath);
     const testJsRaw = await readFile(testJsPath, 'utf-8');
     expect(existsTestJs).toBeTruthy();
     expect(testJsRaw.startsWith("console.log('test.js');")).toBeTruthy();
 
-    const existsTestMDX = await pathExists(
-      path.resolve(appDir, 'doc_build', 'test.mdx'),
-    );
+    const existsTestMDX = await pathExists(path.resolve(outDir, 'test.mdx'));
     expect(existsTestMDX).toBeTruthy();
   });
 
@@ -52,13 +47,18 @@ test.describe('basic test', async () => {
     const appDir = import.meta.dirname;
     const appPort = await getPort();
     await runBuildCommand(appDir);
-    await runPreviewCommand(appDir, appPort);
-    await page.goto(`http://localhost:${appPort}/base/`, {
-      waitUntil: 'networkidle',
-    });
+    const app = await runPreviewCommand(appDir, appPort);
 
-    const img = page.locator('.rspress-doc img');
-    await expect(img).toHaveAttribute('src', '/base/rspress-icon.png');
+    try {
+      await page.goto(`http://localhost:${appPort}/base/`, {
+        waitUntil: 'networkidle',
+      });
+
+      const img = page.locator('.rspress-doc img');
+      await expect(img).toHaveAttribute('src', '/base/rspress-icon.png');
+    } finally {
+      await killProcess(app);
+    }
   });
 
   test('should load public dir img successfully under "rspress dev"', async ({
@@ -66,12 +66,17 @@ test.describe('basic test', async () => {
   }) => {
     const appDir = import.meta.dirname;
     const appPort = await getPort();
-    await runDevCommand(appDir, appPort);
-    await page.goto(`http://localhost:${appPort}/base/`, {
-      waitUntil: 'networkidle',
-    });
+    const app = await runDevCommand(appDir, appPort);
 
-    const img = page.locator('.rspress-doc img');
-    await expect(img).toHaveAttribute('src', '/base/rspress-icon.png');
+    try {
+      await page.goto(`http://localhost:${appPort}/base/`, {
+        waitUntil: 'networkidle',
+      });
+
+      const img = page.locator('.rspress-doc img');
+      await expect(img).toHaveAttribute('src', '/base/rspress-icon.png');
+    } finally {
+      await killProcess(app);
+    }
   });
 });

--- a/e2e/fixtures/public-dir/rspress.config.ts
+++ b/e2e/fixtures/public-dir/rspress.config.ts
@@ -1,7 +1,9 @@
 import * as path from 'node:path';
 import { defineConfig } from '@rspress/core';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc'),
+  outDir: getTestOutDir(),
   base: '/base/',
 });

--- a/e2e/fixtures/ssg-md/index.test.ts
+++ b/e2e/fixtures/ssg-md/index.test.ts
@@ -1,13 +1,14 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { expect, test } from '@playwright/test';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 import { runBuildCommand } from '../../utils/runCommands';
 
 test('llms should be successful', async () => {
   const appDir = import.meta.dirname;
   await runBuildCommand(appDir);
 
-  const docBuildDir = path.join(appDir, 'doc_build');
+  const docBuildDir = path.join(appDir, getTestOutDir());
   const files = [
     'llms.txt',
     'index.md',
@@ -77,10 +78,14 @@ test('llms should be successful', async () => {
 
 test('custom llms.txt renderer should be successful', async () => {
   const appDir = import.meta.dirname;
+  const docBuildDir = path.join(
+    appDir,
+    getTestOutDir('rspress-custom-llms-txt.config.ts'),
+  );
   await runBuildCommand(appDir, 'rspress-custom-llms-txt.config.ts');
 
   const llmsTxt = await fs.readFile(
-    path.join(appDir, 'doc_build', 'llms.txt'),
+    path.join(docBuildDir, 'llms.txt'),
     'utf-8',
   );
   expect(llmsTxt).toContain('# Custom Rspress SSG MDX Test');
@@ -105,10 +110,14 @@ test('csr should be successful', async () => {
 
 test('llms directive hint should be configurable', async () => {
   const appDir = import.meta.dirname;
+  const docBuildDir = path.join(
+    appDir,
+    getTestOutDir('rspress-no-llms-hint.config.ts'),
+  );
   await runBuildCommand(appDir, 'rspress-no-llms-hint.config.ts');
 
   const indexHtml = await fs.readFile(
-    path.join(appDir, 'doc_build', 'index.html'),
+    path.join(docBuildDir, 'index.html'),
     'utf-8',
   );
   expect(indexHtml).not.toContain('For AI agents:');

--- a/e2e/fixtures/ssg-md/rspress-csr.config.ts
+++ b/e2e/fixtures/ssg-md/rspress-csr.config.ts
@@ -1,8 +1,10 @@
 import * as path from 'node:path';
 import { defineConfig } from '@rspress/core';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc'),
+  outDir: getTestOutDir('rspress-csr.config.ts'),
   ssg: false,
   title: 'Rspress SSG MDX Test',
   description: 'Rspress SSG MDX Test Description',

--- a/e2e/fixtures/ssg-md/rspress-custom-llms-txt.config.ts
+++ b/e2e/fixtures/ssg-md/rspress-custom-llms-txt.config.ts
@@ -1,8 +1,10 @@
 import * as path from 'node:path';
 import { defineConfig } from '@rspress/core';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc'),
+  outDir: getTestOutDir('rspress-custom-llms-txt.config.ts'),
   base: '/docs/',
   siteOrigin: 'https://example.com',
   ssg: true,

--- a/e2e/fixtures/ssg-md/rspress-no-llms-hint.config.ts
+++ b/e2e/fixtures/ssg-md/rspress-no-llms-hint.config.ts
@@ -1,7 +1,9 @@
 import baseConfig from './rspress.config';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default {
   ...baseConfig,
+  outDir: getTestOutDir('rspress-no-llms-hint.config.ts'),
   themeConfig: {
     ...baseConfig.themeConfig,
     llmsUI: {

--- a/e2e/fixtures/ssg-md/rspress.config.ts
+++ b/e2e/fixtures/ssg-md/rspress.config.ts
@@ -1,8 +1,10 @@
 import * as path from 'node:path';
 import { defineConfig } from '@rspress/core';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc'),
+  outDir: getTestOutDir(),
   base: '/docs/',
   siteOrigin: 'https://example.com',
   ssg: true,

--- a/e2e/fixtures/with-base/index.test.ts
+++ b/e2e/fixtures/with-base/index.test.ts
@@ -7,6 +7,7 @@ import {
   runBuildCommand,
   runPreviewCommand,
 } from '../../utils/runCommands';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 test.describe('plugin test', async () => {
   let appPort;
@@ -102,14 +103,15 @@ test.describe('plugin test', async () => {
 
 test('Should resolve an auto asset prefix for route preload', async () => {
   const appDir = import.meta.dirname;
+  const outDir = getTestOutDir(
+    'rspress-auto-asset-prefix.config.ts',
+    'doc_build_auto',
+  );
   await runBuildCommand(appDir, 'rspress-auto-asset-prefix.config.ts');
 
   const [rootHtml, nestedHtml] = await Promise.all([
-    readFile(path.join(appDir, 'doc_build_auto/index.html'), 'utf-8'),
-    readFile(
-      path.join(appDir, 'doc_build_auto/en/guide/quick-start.html'),
-      'utf-8',
-    ),
+    readFile(path.join(appDir, outDir, 'index.html'), 'utf-8'),
+    readFile(path.join(appDir, outDir, 'en/guide/quick-start.html'), 'utf-8'),
   ]);
 
   expect(rootHtml).toMatch(

--- a/e2e/fixtures/with-base/rspress-auto-asset-prefix.config.ts
+++ b/e2e/fixtures/with-base/rspress-auto-asset-prefix.config.ts
@@ -1,9 +1,13 @@
 import { defineConfig } from '@rspress/core';
 import baseConfig from './rspress.config';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   ...baseConfig,
-  outDir: 'doc_build_auto',
+  outDir: getTestOutDir(
+    'rspress-auto-asset-prefix.config.ts',
+    'doc_build_auto',
+  ),
   ssg: false,
   builderConfig: {
     ...baseConfig.builderConfig,

--- a/e2e/fixtures/with-base/rspress.config.ts
+++ b/e2e/fixtures/with-base/rspress.config.ts
@@ -1,8 +1,10 @@
 import * as path from 'node:path';
 import { defineConfig } from '@rspress/core';
+import { getTestOutDir } from '../../utils/getTestOutDir';
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'doc'),
+  outDir: getTestOutDir(),
   lang: 'zh',
   base: '/base',
   route: {

--- a/e2e/utils/getTestOutDir.ts
+++ b/e2e/utils/getTestOutDir.ts
@@ -1,0 +1,15 @@
+import path from 'node:path';
+
+export function getTestOutDir(
+  configFile = 'rspress.config.ts',
+  fallback = 'doc_build',
+) {
+  const parallelIndex = process.env.TEST_PARALLEL_INDEX;
+
+  if (parallelIndex === undefined) {
+    return fallback;
+  }
+
+  const configName = path.basename(configFile).replace(/\.config\.ts$/, '');
+  return path.join('doc_build', parallelIndex, configName);
+}

--- a/e2e/utils/runCommands.ts
+++ b/e2e/utils/runCommands.ts
@@ -121,8 +121,8 @@ export async function runBuildCommand(
     {
       appDir,
       env: {
-        // Multiple Playwright workers can build the same fixture concurrently.
-        // Keep them from sharing the same persistent cache directory.
+        // Fully parallel builds use isolated outDirs but still share the fixture cache.
+        // Disable it to avoid stale route output across workers.
         RSPRESS_PERSISTENT_CACHE: 'false',
       },
     },

--- a/e2e/utils/runCommands.ts
+++ b/e2e/utils/runCommands.ts
@@ -48,10 +48,9 @@ export async function runNpmScript(
       const markers = {
         dev: /built in/i,
         preview: /Local:/i,
-        build: /File (web)/,
       };
 
-      if (markers[commandName].test(message)) {
+      if (commandName !== 'build' && markers[commandName].test(message)) {
         if (!didResolve) {
           didResolve = true;
           resolve(instance);
@@ -72,6 +71,7 @@ export async function runNpmScript(
 
       if (!didResolve) {
         if (code !== 0) {
+          process.stderr.write(stderrOutput);
           reject(
             new Error(
               `process unexpected exit with code: ${code} signal: ${signal}`,
@@ -120,7 +120,11 @@ export async function runBuildCommand(
     'build',
     {
       appDir,
-      env: {},
+      env: {
+        // Multiple Playwright workers can build the same fixture concurrently.
+        // Keep them from sharing the same persistent cache directory.
+        RSPRESS_PERSISTENT_CACHE: 'false',
+      },
     },
     [...(configFile ? ['-c', configFile] : []), ...extraArgs],
   );
@@ -144,8 +148,17 @@ export async function runPreviewCommand(
 }
 
 export async function getPort() {
+  const parallelIndex = process.env.TEST_PARALLEL_INDEX;
+  const preferredPorts =
+    parallelIndex === undefined
+      ? undefined
+      : getRandomPort.makeRange(
+          20_000 + Number(parallelIndex) * 1_000,
+          20_999 + Number(parallelIndex) * 1_000,
+        );
+
   while (true) {
-    const port = await getRandomPort();
+    const port = await getRandomPort({ port: preferredPorts });
     if (!portMap.get(port)) {
       portMap.set(port, 1);
       return port;

--- a/e2e/utils/runCommands.ts
+++ b/e2e/utils/runCommands.ts
@@ -91,6 +91,7 @@ export async function runDevCommand(
   port: number,
   configFile?: string,
   extraArgs: string[] = [],
+  extraEnv: Record<string, string> = {},
 ) {
   return runNpmScript(
     'dev',
@@ -103,6 +104,7 @@ export async function runDevCommand(
 
         // FIXME: disable lazy compilation to avoid windows flaky test in rspack prerelease
         RSPRESS_LAZY_COMPILATION: 'false',
+        ...extraEnv,
       },
     },
     [...(configFile ? ['-c', configFile] : []), ...extraArgs],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   globalTimeout: 30 * 60 * 1000,
   // 1 min for each test
   timeout: 60 * 1000,
+  fullyParallel: true,
   // Pin CI to two workers (Playwright defaults to 1 worker on CI)
   workers: isCI ? 2 : undefined,
   quiet: true,


### PR DESCRIPTION
## Summary

- Enable Playwright `fullyParallel` mode while keeping CI at two workers.
- Isolate build output by Playwright parallel index and Rspress config, partition server ports by worker, disable the shared build cache for E2E builds, and wait for build processes to exit before starting preview.
- Keep serial execution only for the HMR suites that mutate shared source files, while using independent iframe ports and server lifecycles for preview fixtures.
- Preserve the measured macOS two-worker speedup: adjacent CI runs improved the E2E step from 6.1 minutes to 5.0 minutes (about 18%) and the full job from 7m38s to 6m42s (about 12%).

## Related Issue

- https://github.com/web-infra-dev/rspress/pull/2988
- https://github.com/web-infra-dev/rspress/pull/3570

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Testing

- `CI=1 ./node_modules/.bin/playwright test --workers=2 --retries=0` — 222 passed in 4.8m.
- Repeated the previously failing output/preview fixtures five times with two workers and no retries — 65 passed in 2.2m.
- Rslint type checking and Prettier checks passed for all changed files.
