### PR TITLE
docs: add version badges for config options

### DIFF
--- a/website/docs/components/VersionBadge.module.scss
+++ b/website/docs/components/VersionBadge.module.scss
@@ -1,0 +1,35 @@
+.wrapper {
+  margin-top: 1.5rem;
+}
+
+:global(h2) + .wrapper,
+:global(h3) + .wrapper {
+  margin-top: 0;
+}
+
+.badge {
+  display: inline-flex;
+  margin-right: 8px;
+  margin-bottom: 12px;
+  padding: 4px 10px;
+  color: #1c1c1c;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 18px;
+  background-color: hsl(162deg 60% 75%);
+  border-radius: 6px;
+
+  a {
+    color: inherit;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+:global(.dark) .badge {
+  color: #e1e1e1;
+  background-color: hsl(162deg 60% 25%);
+}

--- a/website/docs/components/VersionBadge.tsx
+++ b/website/docs/components/VersionBadge.tsx
@@ -1,3 +1,4 @@
+import { useLang } from '@rspress/core/runtime';
 import { Link } from '@rspress/core/theme';
 import styles from './VersionBadge.module.scss';
 
@@ -6,7 +7,8 @@ export interface VersionBadgeProps {
 }
 
 export function VersionBadge({ version }: VersionBadgeProps) {
-  const normalizedVersion = version.replace(/^v/, '');
+  const lang = useLang();
+  const normalizedVersion = version.trim().replace(/^v/i, '');
 
   return (
     <div className={`${styles.wrapper} rp-not-doc`}>
@@ -14,7 +16,7 @@ export function VersionBadge({ version }: VersionBadgeProps) {
         <Link
           href={`https://github.com/web-infra-dev/rspress/releases/tag/v${normalizedVersion}`}
         >
-          Added in v{normalizedVersion}
+          {lang === 'zh' ? '新增于' : 'Added in'} v{normalizedVersion}
         </Link>
       </span>
     </div>

--- a/website/docs/components/VersionBadge.tsx
+++ b/website/docs/components/VersionBadge.tsx
@@ -1,0 +1,22 @@
+import { Link } from '@rspress/core/theme';
+import styles from './VersionBadge.module.scss';
+
+export interface VersionBadgeProps {
+  version: string;
+}
+
+export function VersionBadge({ version }: VersionBadgeProps) {
+  const normalizedVersion = version.replace(/^v/, '');
+
+  return (
+    <div className={`${styles.wrapper} rp-not-doc`}>
+      <span className={styles.badge}>
+        <Link
+          href={`https://github.com/web-infra-dev/rspress/releases/tag/v${normalizedVersion}`}
+        >
+          Added in v{normalizedVersion}
+        </Link>
+      </span>
+    </div>
+  );
+}

--- a/website/docs/en/api/config/config-basic.mdx
+++ b/website/docs/en/api/config/config-basic.mdx
@@ -1,3 +1,5 @@
+import { VersionBadge } from '../../../components/VersionBadge';
+
 # Basic config
 
 ## root
@@ -40,6 +42,8 @@ export default defineConfig({
 ```
 
 ## siteOrigin
+
+<VersionBadge version="2.0.17" />
 
 - **Type**: `string`
 - **Default**: `""`
@@ -777,6 +781,8 @@ export default defineConfig({
 
 ### route.localeRedirect
 
+<VersionBadge version="2.0.18" />
+
 - **Type**: `'auto' | 'never' | 'only-default-lang'`
 - **Default**: `'auto'`
 
@@ -804,6 +810,8 @@ export default defineConfig({
 
 ### route.useTransitions
 
+<VersionBadge version="2.0.17" />
+
 - **Type**: `Boolean`
 - **Default**: `true`
 
@@ -822,6 +830,8 @@ export default defineConfig({
 ```
 
 ### route.prefetchLink
+
+<VersionBadge version="2.0.17" />
 
 - **Type**: `Boolean`
 - **Default**: `true`

--- a/website/docs/en/api/config/config-basic.mdx
+++ b/website/docs/en/api/config/config-basic.mdx
@@ -781,7 +781,7 @@ export default defineConfig({
 
 ### route.localeRedirect
 
-<VersionBadge version="2.0.18" />
+<VersionBadge version="2.0.19" />
 
 - **Type**: `'auto' | 'never' | 'only-default-lang'`
 - **Default**: `'auto'`

--- a/website/docs/en/api/config/config-frontmatter.mdx
+++ b/website/docs/en/api/config/config-frontmatter.mdx
@@ -1,3 +1,5 @@
+import { VersionBadge } from '../../../components/VersionBadge';
+
 # Frontmatter config
 
 This page explains how to configure page-level properties with frontmatter, including title, description, page type, and navbar visibility.
@@ -158,6 +160,8 @@ navbar: false
 ```
 
 ## icon
+
+<VersionBadge version="2.0.19" />
 
 - **Type**: `string`
 

--- a/website/docs/en/api/config/config-theme.mdx
+++ b/website/docs/en/api/config/config-theme.mdx
@@ -1,3 +1,5 @@
+import { VersionBadge } from '../../../components/VersionBadge';
+
 # Theme config
 
 Theme configuration is defined under `themeConfig`. For example:
@@ -634,6 +636,8 @@ export default defineConfig({
 ```
 
 ### injectLlmsHint
+
+<VersionBadge version="2.0.18" />
 
 - **Type**: `boolean`
 - **Default**: `true`

--- a/website/docs/zh/api/config/config-basic.mdx
+++ b/website/docs/zh/api/config/config-basic.mdx
@@ -1,3 +1,5 @@
+import { VersionBadge } from '../../../components/VersionBadge';
+
 # 基础配置
 
 ## root
@@ -40,6 +42,8 @@ export default defineConfig({
 ```
 
 ## siteOrigin
+
+<VersionBadge version="2.0.17" />
 
 - **类型**： `string`
 - **默认值**： `""`
@@ -771,6 +775,8 @@ export default defineConfig({
 
 ### route.localeRedirect
 
+<VersionBadge version="2.0.18" />
+
 - **类型**：`'auto' | 'never' | 'only-default-lang'`
 - **默认值**：`'auto'`
 
@@ -798,6 +804,8 @@ export default defineConfig({
 
 ### route.useTransitions
 
+<VersionBadge version="2.0.17" />
+
 - **类型**： `boolean`
 - **默认值**： `true`
 
@@ -816,6 +824,8 @@ export default defineConfig({
 ```
 
 ### route.prefetchLink
+
+<VersionBadge version="2.0.17" />
 
 - **类型**： `boolean`
 - **默认值**： `true`

--- a/website/docs/zh/api/config/config-basic.mdx
+++ b/website/docs/zh/api/config/config-basic.mdx
@@ -775,7 +775,7 @@ export default defineConfig({
 
 ### route.localeRedirect
 
-<VersionBadge version="2.0.18" />
+<VersionBadge version="2.0.19" />
 
 - **类型**：`'auto' | 'never' | 'only-default-lang'`
 - **默认值**：`'auto'`

--- a/website/docs/zh/api/config/config-frontmatter.mdx
+++ b/website/docs/zh/api/config/config-frontmatter.mdx
@@ -1,3 +1,5 @@
+import { VersionBadge } from '../../../components/VersionBadge';
+
 # Front matter 配置
 
 这篇文档介绍了如何使用 front matter 来配置页面的各种属性，包括标题、描述、页面类型、导航栏等。
@@ -158,6 +160,8 @@ navbar: false
 ```
 
 ## icon
+
+<VersionBadge version="2.0.19" />
 
 - **类型**： `string`
 

--- a/website/docs/zh/api/config/config-theme.mdx
+++ b/website/docs/zh/api/config/config-theme.mdx
@@ -1,3 +1,5 @@
+import { VersionBadge } from '../../../components/VersionBadge';
+
 # 主题配置
 
 主题配置位于 `doc` 配置中的 `themeConfig` 下。例如：
@@ -622,6 +624,8 @@ export default defineConfig({
 ```
 
 ### injectLlmsHint
+
+<VersionBadge version="2.0.18" />
 
 - **类型**：`boolean`
 - **默认值**：`true`


### PR DESCRIPTION
## Summary

Add a dependency-free `VersionBadge` component based on the Rspack documentation style so readers can identify when configuration options became available. Apply release-linked badges to six recently added options in both English and Chinese documentation.

## Related Issue

- Reference: https://github.com/web-infra-dev/rspack/blob/main/website/components/ApiMeta.tsx

## Screenshots

The `route.localeRedirect` badge was verified locally. Please use the website preview generated by CI for visual review.

## Checklist

- [x] Tests updated (not required).
- [x] Documentation updated.
