### PR TITLE
test(e2e): avoid HMR restart race

### DIFF
--- a/e2e/fixtures/hmr/index.test.ts
+++ b/e2e/fixtures/hmr/index.test.ts
@@ -108,15 +108,15 @@ test.describe('hmr test', async () => {
   test('restart when routes or config dependencies change', async ({
     page,
   }) => {
+    const addedPageUrl = `http://localhost:${appPort}/guide/test-temp-added.html`;
+
     await fs.writeFile(TEST_ADDED_FILE, '# Added route');
     await expect.poll(getRestartCount).toBe(1);
 
     await expect
       .poll(async () => {
         try {
-          await page.goto(
-            `http://localhost:${appPort}/guide/test-temp-added.html`,
-          );
+          await page.goto(addedPageUrl, { timeout: 1000 });
           return page.locator('h1').textContent();
         } catch {
           return null;
@@ -126,6 +126,16 @@ test.describe('hmr test', async () => {
 
     await fs.rm(TEST_ADDED_FILE);
     await expect.poll(getRestartCount).toBe(2);
+    await expect
+      .poll(async () => {
+        try {
+          await page.goto(addedPageUrl, { timeout: 1000 });
+          return page.locator('body').textContent();
+        } catch {
+          return null;
+        }
+      })
+      .toContain('404');
 
     await fs.writeFile(
       TEST_RESTART_FILE,
@@ -136,7 +146,9 @@ test.describe('hmr test', async () => {
     await expect
       .poll(async () => {
         try {
-          await page.reload();
+          await page.goto(`http://localhost:${appPort}/guide/test.html`, {
+            timeout: 1000,
+          });
           return page.title();
         } catch {
           return '';

--- a/e2e/fixtures/hmr/index.test.ts
+++ b/e2e/fixtures/hmr/index.test.ts
@@ -33,27 +33,23 @@ test.describe('hmr test', async () => {
   const getRestartCount = () =>
     devOutput.match(/restarting server as .* changed/g)?.length ?? 0;
 
-  const startApp = async () => {
-    appPort = await getPort();
-    app = await runDevCommand(import.meta.dirname, appPort);
-    devOutput = '';
-    (app as { stdout?: NodeJS.ReadableStream }).stdout?.on('data', chunk => {
-      devOutput += chunk.toString();
-    });
-  };
-
   test.beforeAll(async () => {
     originalContent = await fs.readFile(TEST_FILE, 'utf-8');
     originalFragmentContent = await fs.readFile(TEST_FRAGMENT_FILE, 'utf-8');
     originalNavContent = await fs.readFile(TEST_NAV_FILE, 'utf-8');
     originalMetaContent = await fs.readFile(TEST_META_FILE, 'utf-8');
     originalRestartFileContent = await fs.readFile(TEST_RESTART_FILE, 'utf-8');
+
+    appPort = await getPort();
+    app = await runDevCommand(import.meta.dirname, appPort);
+    (app as { stdout?: NodeJS.ReadableStream }).stdout?.on('data', chunk => {
+      devOutput += chunk.toString();
+    });
   });
 
-  test.afterEach(async () => {
+  test.afterAll(async () => {
     if (app) {
       await killProcess(app);
-      app = null;
     }
     await fs.writeFile(TEST_FILE, originalContent);
     await fs.writeFile(TEST_FRAGMENT_FILE, originalFragmentContent);
@@ -63,8 +59,7 @@ test.describe('hmr test', async () => {
     await fs.rm(TEST_ADDED_FILE, { force: true });
   });
 
-  test('Test page', async ({ page }) => {
-    await startApp();
+  test('update page content without restarting', async ({ page }) => {
     await page.goto(`http://localhost:${appPort}/guide/test.html`, {
       waitUntil: 'networkidle',
     });
@@ -113,9 +108,9 @@ test.describe('hmr test', async () => {
   test('restart when routes or config dependencies change', async ({
     page,
   }) => {
-    await startApp();
     const addedPageUrl = `http://localhost:${appPort}/guide/test-temp-added.html`;
     const stablePageUrl = `http://localhost:${appPort}/guide/test.html`;
+    // Ensure the initial file watchers are ready before the first mutation.
     await page.goto(stablePageUrl, {
       waitUntil: 'networkidle',
     });
@@ -140,6 +135,7 @@ test.describe('hmr test', async () => {
     await fs.rm(TEST_ADDED_FILE);
     await expect.poll(getRestartCount, { timeout: 30_000 }).toBe(2);
 
+    // The 404 confirms that the unlink restart finished before the next change.
     await expect
       .poll(
         async () => {

--- a/e2e/fixtures/hmr/index.test.ts
+++ b/e2e/fixtures/hmr/index.test.ts
@@ -110,10 +110,13 @@ test.describe('hmr test', async () => {
     expect(getRestartCount()).toBe(0);
   });
 
-  test('restart when a route is added', async ({ page }) => {
+  test('restart when routes or config dependencies change', async ({
+    page,
+  }) => {
     await startApp();
     const addedPageUrl = `http://localhost:${appPort}/guide/test-temp-added.html`;
-    await page.goto(`http://localhost:${appPort}/guide/test.html`, {
+    const stablePageUrl = `http://localhost:${appPort}/guide/test.html`;
+    await page.goto(stablePageUrl, {
       waitUntil: 'networkidle',
     });
 
@@ -133,17 +136,9 @@ test.describe('hmr test', async () => {
         { timeout: 30_000 },
       )
       .toContain('Added route');
-  });
-
-  test('restart when a route is removed', async ({ page }) => {
-    await fs.writeFile(TEST_ADDED_FILE, '# Added route');
-    await startApp();
-    const addedPageUrl = `http://localhost:${appPort}/guide/test-temp-added.html`;
-    await page.goto(addedPageUrl, { waitUntil: 'networkidle' });
-    await expect(page.locator('h1')).toContainText('Added route');
 
     await fs.rm(TEST_ADDED_FILE);
-    await expect.poll(getRestartCount, { timeout: 30_000 }).toBe(1);
+    await expect.poll(getRestartCount, { timeout: 30_000 }).toBe(2);
 
     await expect
       .poll(
@@ -158,25 +153,18 @@ test.describe('hmr test', async () => {
         { timeout: 30_000 },
       )
       .toContain('404');
-  });
-
-  test('restart when config dependencies change', async ({ page }) => {
-    await startApp();
-    await page.goto(`http://localhost:${appPort}/guide/test.html`, {
-      waitUntil: 'networkidle',
-    });
 
     await fs.writeFile(
       TEST_RESTART_FILE,
       originalRestartFileContent.replace('HMR fixture', 'Restarted fixture'),
     );
-    await expect.poll(getRestartCount, { timeout: 30_000 }).toBe(1);
+    await expect.poll(getRestartCount, { timeout: 30_000 }).toBe(3);
 
     await expect
       .poll(
         async () => {
           try {
-            await page.goto(`http://localhost:${appPort}/guide/test.html`, {
+            await page.goto(stablePageUrl, {
               timeout: 10_000,
             });
             return page.title();

--- a/e2e/fixtures/hmr/index.test.ts
+++ b/e2e/fixtures/hmr/index.test.ts
@@ -22,7 +22,7 @@ const TEST_RESTART_FILE = path.resolve(import.meta.dirname, 'siteConfig.ts');
 
 test.describe('hmr test', async () => {
   let appPort: number;
-  let app: Awaited<ReturnType<typeof runDevCommand>>;
+  let app: Awaited<ReturnType<typeof runDevCommand>> | null = null;
   let originalContent: string;
   let originalFragmentContent: string;
   let originalNavContent: string;
@@ -33,13 +33,16 @@ test.describe('hmr test', async () => {
   const getRestartCount = () =>
     devOutput.match(/restarting server as .* changed/g)?.length ?? 0;
 
-  test.beforeAll(async () => {
-    const appDir = import.meta.dirname;
+  const startApp = async () => {
     appPort = await getPort();
-    app = await runDevCommand(appDir, appPort);
+    app = await runDevCommand(import.meta.dirname, appPort);
+    devOutput = '';
     (app as { stdout?: NodeJS.ReadableStream }).stdout?.on('data', chunk => {
       devOutput += chunk.toString();
     });
+  };
+
+  test.beforeAll(async () => {
     originalContent = await fs.readFile(TEST_FILE, 'utf-8');
     originalFragmentContent = await fs.readFile(TEST_FRAGMENT_FILE, 'utf-8');
     originalNavContent = await fs.readFile(TEST_NAV_FILE, 'utf-8');
@@ -47,9 +50,10 @@ test.describe('hmr test', async () => {
     originalRestartFileContent = await fs.readFile(TEST_RESTART_FILE, 'utf-8');
   });
 
-  test.afterAll(async () => {
+  test.afterEach(async () => {
     if (app) {
       await killProcess(app);
+      app = null;
     }
     await fs.writeFile(TEST_FILE, originalContent);
     await fs.writeFile(TEST_FRAGMENT_FILE, originalFragmentContent);
@@ -60,6 +64,7 @@ test.describe('hmr test', async () => {
   });
 
   test('Test page', async ({ page }) => {
+    await startApp();
     await page.goto(`http://localhost:${appPort}/guide/test.html`, {
       waitUntil: 'networkidle',
     });
@@ -105,55 +110,82 @@ test.describe('hmr test', async () => {
     expect(getRestartCount()).toBe(0);
   });
 
-  test('restart when routes or config dependencies change', async ({
-    page,
-  }) => {
+  test('restart when a route is added', async ({ page }) => {
+    await startApp();
     const addedPageUrl = `http://localhost:${appPort}/guide/test-temp-added.html`;
+    await page.goto(`http://localhost:${appPort}/guide/test.html`, {
+      waitUntil: 'networkidle',
+    });
 
     await fs.writeFile(TEST_ADDED_FILE, '# Added route');
-    await expect.poll(getRestartCount).toBe(1);
+    await expect.poll(getRestartCount, { timeout: 30_000 }).toBe(1);
 
     await expect
-      .poll(async () => {
-        try {
-          await page.goto(addedPageUrl, { timeout: 1000 });
-          return page.locator('h1').textContent();
-        } catch {
-          return null;
-        }
-      })
+      .poll(
+        async () => {
+          try {
+            await page.goto(addedPageUrl, { timeout: 10_000 });
+            return page.locator('h1').textContent();
+          } catch {
+            return null;
+          }
+        },
+        { timeout: 30_000 },
+      )
       .toContain('Added route');
+  });
+
+  test('restart when a route is removed', async ({ page }) => {
+    await fs.writeFile(TEST_ADDED_FILE, '# Added route');
+    await startApp();
+    const addedPageUrl = `http://localhost:${appPort}/guide/test-temp-added.html`;
+    await page.goto(addedPageUrl, { waitUntil: 'networkidle' });
+    await expect(page.locator('h1')).toContainText('Added route');
 
     await fs.rm(TEST_ADDED_FILE);
-    await expect.poll(getRestartCount).toBe(2);
+    await expect.poll(getRestartCount, { timeout: 30_000 }).toBe(1);
+
     await expect
-      .poll(async () => {
-        try {
-          await page.goto(addedPageUrl, { timeout: 1000 });
-          return page.locator('body').textContent();
-        } catch {
-          return null;
-        }
-      })
+      .poll(
+        async () => {
+          try {
+            await page.goto(addedPageUrl, { timeout: 10_000 });
+            return page.locator('body').textContent();
+          } catch {
+            return null;
+          }
+        },
+        { timeout: 30_000 },
+      )
       .toContain('404');
+  });
+
+  test('restart when config dependencies change', async ({ page }) => {
+    await startApp();
+    await page.goto(`http://localhost:${appPort}/guide/test.html`, {
+      waitUntil: 'networkidle',
+    });
 
     await fs.writeFile(
       TEST_RESTART_FILE,
       originalRestartFileContent.replace('HMR fixture', 'Restarted fixture'),
     );
-    await expect.poll(getRestartCount).toBe(3);
+    await expect.poll(getRestartCount, { timeout: 30_000 }).toBe(1);
 
     await expect
-      .poll(async () => {
-        try {
-          await page.goto(`http://localhost:${appPort}/guide/test.html`, {
-            timeout: 1000,
-          });
-          return page.title();
-        } catch {
-          return '';
-        }
-      })
+      .poll(
+        async () => {
+          try {
+            await page.goto(`http://localhost:${appPort}/guide/test.html`, {
+              timeout: 10_000,
+            });
+            return page.title();
+          } catch {
+            return '';
+          }
+        },
+        { timeout: 30_000 },
+      )
       .toContain('Restarted fixture');
   });
 });


### PR DESCRIPTION
## Summary

- reuse one dev server for the two HMR cases instead of starting it inside each test
- keep regular HMR and restart behavior as separate, readable test cases
- keep route add, route removal, and config dependency changes in one restart sequence with observable readiness gates

## Related Issue

- Rspack eco-ci failure: https://github.com/rstackjs/rstack-ecosystem-ci/actions/runs/30904945128/job/91977832928

## Validation

- `pnpm exec playwright test e2e/fixtures/hmr/index.test.ts --repeat-each=20 --workers=1` (40 passed in 2.2m; previous revision took 3.6m)
- macOS CI: regular HMR 12.3s → 9.7s; restart sequence 19.0s → 10.2s
- Windows CI: regular HMR 6.3s → 3.3s; restart sequence 9.4s → 6.1s
- `pnpm exec rslint e2e/fixtures/hmr/index.test.ts`
- `pnpm exec prettier e2e/fixtures/hmr/index.test.ts --check`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
