### PR TITLE
perf(runtime): mark sideEffects: false for @rspress/shared

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,6 +7,7 @@
     "directory": "packages/shared"
   },
   "license": "MIT",
+  "sideEffects": false,
   "type": "module",
   "exports": {
     ".": {

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -151,6 +151,17 @@ export default defineConfig({
     }),
   ],
   builderConfig: {
+    splitChunks: {
+      cacheGroups: {
+        // Avoid duplicating the global FileTree component in route chunks.
+        fileTree: {
+          chunks: 'async',
+          enforce: true,
+          name: 'file-tree',
+          test: /rspress-plugin-file-tree/,
+        },
+      },
+    },
     plugins: [
       pluginSass(),
       pluginGoogleAnalytics({ id: 'G-66B2Z6KG0J' }),


### PR DESCRIPTION
## Summary

- Mark `@rspress/shared` as side-effect-free so bundlers can tree-shake its helpers correctly.
- Extract the global FileTree component into one reusable async chunk instead of duplicating it across route chunks.
- Clear browser-build Rsdoctor E1002/E1007 warnings and reduce the website JavaScript output by 31 assets, 211,458 raw bytes, and 52,626 gzip bytes compared with the baseline.

<details>

```
⚠ [E1007:Warn:TREE-SHAKING-SIDE-EFFECTS-ONLY] Module "/home/runner/work/rspress/rspress/packages/shared/dist/lodash-es.js" is only imported for its side effects by 1 importer(s). This may indicate an unintended tree-shaking failure causing redundant bundle output.


⚠ [E1002:Warn:CROSS-CHUNKS-PACKAGE] The same package @rspress/docs was bundled into different chunks:


⚠ [E1007:Warn:TREE-SHAKING-SIDE-EFFECTS-ONLY] Module "/home/runner/work/rspress/rspress/packages/shared/dist/lodash-es.js" is only imported for its side effects by 1 importer(s). This may indicate an unintended tree-shaking failure causing redundant bundle output.
ready   built in 26.8s (node)


⚠ [E1002:Warn:CROSS-CHUNKS-PACKAGE] The same package @rspress/docs was bundled into different chunks:


⚠ [E1002:Warn:CROSS-CHUNKS-PACKAGE] The same package unhead was bundled into different chunks:


⚠ [E1002:Warn:CROSS-CHUNKS-PACKAGE] The same package @rspress/plugin-twoslash was bundled into different chunks:


⚠ [E1007:Warn:TREE-SHAKING-SIDE-EFFECTS-ONLY] Module "/home/runner/work/rspress/rspress/website/.rspress/runtime/virtual-global-components.js" is only imported for its side effects by 1 importer(s). This may indicate an unintended tree-shaking failure causing redundant bundle output.


⚠ [E1007:Warn:TREE-SHAKING-SIDE-EFFECTS-ONLY] Module "/home/runner/work/rspress/rspress/packages/plugin-preview/static/global-components/icons/Refresh.tsx" is only imported for its side effects by 1 importer(s). This may indicate an unintended tree-shaking failure causing redundant bundle output.


⚠ [E1007:Warn:TREE-SHAKING-SIDE-EFFECTS-ONLY] Module "/home/runner/work/rspress/rspress/packages/plugin-preview/static/global-components/FixedDevice.tsx" is only imported for its side effects by 1 importer(s). This may indicate an unintended tree-shaking failure causing redundant bundle output.


⚠ [E1007:Warn:TREE-SHAKING-SIDE-EFFECTS-ONLY] Module "/home/runner/work/rspress/rspress/website/theme/components/HeroInteractive.tsx" is only imported for its side effects by 1 importer(s). This may indicate an unintended tree-shaking failure causing redundant bundle output.


⚠ [E1007:Warn:TREE-SHAKING-SIDE-EFFECTS-ONLY] Module "/home/runner/work/rspress/rspress/packages/plugin-preview/static/global-components/common/PreviewOperations.tsx" is only imported for its side effects by 1 importer(s). This may indicate an unintended tree-shaking failure causing redundant bundle output.


⚠ [E1007:Warn:TREE-SHAKING-SIDE-EFFECTS-ONLY] Module "/home/runner/work/rspress/rspress/packages/shared/dist/github-slugger.js" is only imported for its side effects by 1 importer(s). This may indicate an unintended tree-shaking failure causing redundant bundle output.


⚠ [E1007:Warn:TREE-SHAKING-SIDE-EFFECTS-ONLY] Module "/home/runner/work/rspress/rspress/packages/plugin-preview/static/global-components/icons/Qrcode.tsx" is only imported for its side effects by 1 importer(s). This may indicate an unintended tree-shaking failure causing redundant bundle output.


⚠ [E1007:Warn:TREE-SHAKING-SIDE-EFFECTS-ONLY] Module "/home/runner/work/rspress/rspress/packages/plugin-preview/static/global-components/icons/Launch.tsx" is only imported for its side effects by 1 importer(s). This may indicate an unintended tree-shaking failure causing redundant bundle output.


⚠ [E1007:Warn:TREE-SHAKING-SIDE-EFFECTS-ONLY] Module "/home/runner/work/rspress/rspress/packages/shared/dist/lodash-es.js" is only imported for its side effects by 1 importer(s). This may indicate an unintended tree-shaking failure causing redundant bundle output.


⚠ [E1007:Warn:TREE-SHAKING-SIDE-EFFECTS-ONLY] Module "/home/runner/work/rspress/rspress/packages/plugin-twoslash/static/global-components/TwoslashPopup.tsx" is only imported for its side effects by 1 importer(s). This may indicate an unintended tree-shaking failure causing redundant bundle output.
```

</details>

## Related Issue

N/A — follow-up to the Rsdoctor E1002/E1007 report.

## Checklist

- [x] Tests updated (not required for package metadata and build configuration).
- [x] Documentation updated (not required).