### PR TITLE
fix(theme): Fixed ToC tooltips that could contain html strings

### DIFF
--- a/.changeset/ninety-houses-spend.md
+++ b/.changeset/ninety-houses-spend.md
@@ -1,0 +1,6 @@
+---
+'@rspress/core': patch
+---
+
+Strip the HTML from the toc item tooltip, so that a heading which renders a component, a badge for example, no longer
+shows the markup of that component as raw text on hover.

--- a/e2e/fixtures/dynamic-toc/index.test.ts
+++ b/e2e/fixtures/dynamic-toc/index.test.ts
@@ -31,6 +31,12 @@ test.describe('dynamic toc', async () => {
     await expect(heading).toContainText('Term dynamic & content');
 
     await expect(tocItem).toHaveText('Term dynamic & content');
+
+    // The header text collected from the DOM is HTML, its entities should not be shown in the tooltip
+    await expect(page.locator('.rp-toc-item').first()).toHaveAttribute(
+      'title',
+      'Term dynamic & content',
+    );
   });
 
   test('Data depth attribute', async ({ page }) => {

--- a/e2e/fixtures/inline-markdown/index.test.ts
+++ b/e2e/fixtures/inline-markdown/index.test.ts
@@ -237,12 +237,14 @@ test.describe('Inline markdown test', async () => {
     );
 
     // The tooltip of an aside item should be its plain text, without any markup
+    const tocItems = page.locator('.rp-toc-item');
+    await expect(tocItems).toHaveCount(asideCount);
     const asideTitles = await Promise.all(
       Array.from({ length: asideCount }, (_, index) =>
-        page.locator('.rp-toc-item').nth(index).getAttribute('title'),
+        tocItems.nth(index).getAttribute('title'),
       ),
     );
-    expect(asideTitles.join(',')).toEqual(asideTexts.join(','));
+    expect(asideTitles).toEqual(asideTexts);
   });
 
   test('Should generate header anchor and id with inline markdown syntax correctly', async ({

--- a/e2e/fixtures/inline-markdown/index.test.ts
+++ b/e2e/fixtures/inline-markdown/index.test.ts
@@ -235,6 +235,14 @@ test.describe('Inline markdown test', async () => {
         '<code>This is a long string to test regex performance</code>',
       ].join(','),
     );
+
+    // The tooltip of an aside item should be its plain text, without any markup
+    const asideTitles = await Promise.all(
+      Array.from({ length: asideCount }, (_, index) =>
+        page.locator('.rp-toc-item').nth(index).getAttribute('title'),
+      ),
+    );
+    expect(asideTitles.join(',')).toEqual(asideTexts.join(','));
   });
 
   test('Should generate header anchor and id with inline markdown syntax correctly', async ({

--- a/packages/core/src/theme/logic/utils.test.tsx
+++ b/packages/core/src/theme/logic/utils.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it } from '@rstest/core';
+
+import { parseInlineMarkdownText } from './utils';
+
+describe('parseInlineMarkdownText', () => {
+  it('strips the inline markdown syntax', () => {
+    expect(parseInlineMarkdownText('this is bold **rsbuild**')).toBe(
+      'this is bold rsbuild',
+    );
+    expect(parseInlineMarkdownText('this is emphasis *rsbuild*')).toBe(
+      'this is emphasis rsbuild',
+    );
+    expect(parseInlineMarkdownText('this is delete ~~rsbuild~~')).toBe(
+      'this is delete rsbuild',
+    );
+    expect(parseInlineMarkdownText('this is code `rsbuild`')).toBe(
+      'this is code rsbuild',
+    );
+  });
+
+  it('keeps the HTML written in inline code', () => {
+    expect(parseInlineMarkdownText('this is component `<Badge />`')).toBe(
+      'this is component <Badge />',
+    );
+  });
+
+  // The headers collected by `useDynamicToc` carry the innerHTML of the heading, so the markup of the components
+  // rendered in the heading, a badge for example, must not end up in the toc item tooltip.
+  it('strips the HTML collected from the DOM', () => {
+    expect(
+      parseInlineMarkdownText(
+        'this is badge <span class="rp-badge">2.0.19</span>',
+      ),
+    ).toBe('this is badge 2.0.19');
+    expect(parseInlineMarkdownText('this is code <code>rsbuild</code>')).toBe(
+      'this is code rsbuild',
+    );
+    expect(
+      parseInlineMarkdownText('this is image <img src="/badge.png" alt="" />'),
+    ).toBe('this is image');
+  });
+
+  it('decodes the HTML entities collected from the DOM', () => {
+    expect(parseInlineMarkdownText('dynamic &amp; content')).toBe(
+      'dynamic & content',
+    );
+    expect(parseInlineMarkdownText('this is generic &lt;T&gt;')).toBe(
+      'this is generic <T>',
+    );
+    expect(parseInlineMarkdownText('this&nbsp;is&nbsp;nbsp')).toBe(
+      'this\u00A0is\u00A0nbsp',
+    );
+    expect(parseInlineMarkdownText('this is &#39;quoted&#39;')).toBe(
+      "this is 'quoted'",
+    );
+    expect(parseInlineMarkdownText('this is &#x27;quoted&#x27;')).toBe(
+      "this is 'quoted'",
+    );
+  });
+
+  it('does not decode an escaped HTML entity twice', () => {
+    expect(parseInlineMarkdownText('&amp;lt;')).toBe('&lt;');
+  });
+});

--- a/packages/core/src/theme/logic/utils.test.tsx
+++ b/packages/core/src/theme/logic/utils.test.tsx
@@ -61,4 +61,25 @@ describe('parseInlineMarkdownText', () => {
   it('does not decode an escaped HTML entity twice', () => {
     expect(parseInlineMarkdownText('&amp;lt;')).toBe('&lt;');
   });
+
+  it('keeps a numeric entity which is not a Unicode scalar value', () => {
+    // Out of the Unicode range, `String.fromCodePoint` would throw
+    expect(parseInlineMarkdownText('out of range &#x110000;')).toBe(
+      'out of range &#x110000;',
+    );
+    expect(parseInlineMarkdownText('out of range &#1114112;')).toBe(
+      'out of range &#1114112;',
+    );
+    // Lone surrogates, `String.fromCodePoint` would return an ill-formed string
+    expect(parseInlineMarkdownText('lone surrogate &#xD800;')).toBe(
+      'lone surrogate &#xD800;',
+    );
+    expect(parseInlineMarkdownText('lone surrogate &#57343;')).toBe(
+      'lone surrogate &#57343;',
+    );
+    // Astral characters are still decoded
+    expect(parseInlineMarkdownText('astral &#x1F600;')).toBe(
+      'astral \u{1F600}',
+    );
+  });
 });

--- a/packages/core/src/theme/logic/utils.tsx
+++ b/packages/core/src/theme/logic/utils.tsx
@@ -46,6 +46,39 @@ const CODE_TEXT_PATTERN = /`(.*?)`/g;
 const STRONG_TEXT_PATTERN = /\*{2}(?!\*)(.*?)\*{2}(?!\*)/g;
 const EMPHASIS_TEXT_PATTERN = /\*(?!\*)(.*?)\*(?!\*)/g;
 const DELETE_TEXT_PATTERN = /~{2}(.*?)~{2}/g;
+const INLINE_CODE_PATTERN = /`[^`]+`/g;
+// <\/?[a-z]: Matches an opening or a closing tag, a tag name always starts with a letter.
+// [^>]*: Matches the rest of the tag, including its attributes.
+const HTML_TAG_PATTERN = /<\/?[a-z][^>]*>/gi;
+// Matches named entities like `&amp;` as well as numeric ones like `&#39;` and `&#x27;`.
+const HTML_ENTITY_PATTERN = /&(#\d+|#x[0-9a-f]+|[a-z][0-9a-z]*);/gi;
+
+// The entities which can be produced by `Element.innerHTML`, plus the most common ones.
+const NAMED_HTML_ENTITIES: Record<string, string> = {
+  amp: '&',
+  apos: "'",
+  gt: '>',
+  lt: '<',
+  nbsp: '\u00A0',
+  quot: '"',
+};
+
+// The entities are decoded in a single pass, so an already escaped entity like `&amp;lt;` is decoded to `&lt;` instead
+// of `<`.
+function decodeHtmlEntities(text: string) {
+  return text.replace(HTML_ENTITY_PATTERN, (match, entity: string) => {
+    if (!entity.startsWith('#')) {
+      return NAMED_HTML_ENTITIES[entity.toLowerCase()] ?? match;
+    }
+    const isHex = entity[1] === 'x' || entity[1] === 'X';
+    const codePoint = Number.parseInt(
+      isHex ? entity.slice(2) : entity.slice(1),
+      isHex ? 16 : 10,
+    );
+    // `String.fromCodePoint` throws for code points outside of the Unicode range.
+    return codePoint > 0x10ffff ? match : String.fromCodePoint(codePoint);
+  });
+}
 
 /**
  * In this method, we will render the markdown text to inline html and support basic markdown syntax, including the following:
@@ -60,7 +93,7 @@ const DELETE_TEXT_PATTERN = /~{2}(.*?)~{2}/g;
 export function renderInlineMarkdown(text: string) {
   const htmlText = text
     // replace `<list>` to prevent disappearing in dom, but not replace \<number\>
-    .replace(/`[^`]+`/g, match => match.replace(/</g, '&lt;'))
+    .replace(INLINE_CODE_PATTERN, match => match.replace(/</g, '&lt;'))
     .replace(STRONG_TEXT_PATTERN, '<strong>$1</strong>')
     .replace(EMPHASIS_TEXT_PATTERN, '<em>$1</em>')
     .replace(DELETE_TEXT_PATTERN, '<del>$1</del>')
@@ -70,13 +103,22 @@ export function renderInlineMarkdown(text: string) {
 }
 
 /**
+ * Parse a header text to plain text, which can be used in attributes like `title`. Both the inline markdown syntax and
+ * the HTML are stripped, because a header is markdown when it comes from the remark toc plugin, and HTML when it is
+ * collected from the DOM by `useDynamicToc`, carrying the markup of the components rendered in the heading.
+ * @param mdx The header text to parse, either markdown or HTML.
  * @internal
  * @private
  */
 export function parseInlineMarkdownText(mdx: string) {
-  return mdx
+  const plainText = mdx
+    // escape `<list>` in inline code, so that it is not stripped as an HTML tag
+    .replace(INLINE_CODE_PATTERN, match => match.replace(/</g, '&lt;'))
     .replace(STRONG_TEXT_PATTERN, '$1')
     .replace(EMPHASIS_TEXT_PATTERN, '$1')
     .replace(DELETE_TEXT_PATTERN, '$1')
-    .replace(CODE_TEXT_PATTERN, '$1');
+    .replace(CODE_TEXT_PATTERN, '$1')
+    .replace(HTML_TAG_PATTERN, '');
+
+  return decodeHtmlEntities(plainText).trim();
 }

--- a/packages/core/src/theme/logic/utils.tsx
+++ b/packages/core/src/theme/logic/utils.tsx
@@ -75,8 +75,12 @@ function decodeHtmlEntities(text: string) {
       isHex ? entity.slice(2) : entity.slice(1),
       isHex ? 16 : 10,
     );
-    // `String.fromCodePoint` throws for code points outside of the Unicode range.
-    return codePoint > 0x10ffff ? match : String.fromCodePoint(codePoint);
+    // Keep the entity as written when it does not denote a standalone character: outside of the Unicode range, which
+    // makes `String.fromCodePoint` throw, or a lone surrogate, which would leave the result ill-formed and break
+    // consumers like `encodeURIComponent`. A `NaN` code point fails both comparisons and is kept as well.
+    const isScalarValue =
+      codePoint <= 0x10ffff && !(codePoint >= 0xd800 && codePoint <= 0xdfff);
+    return isScalarValue ? String.fromCodePoint(codePoint) : match;
   });
 }
 


### PR DESCRIPTION
## Summary

The `title` attribute on the toc items could contain unescaped html if any components or html were used in the markdown header. For example using a <Badge> would result in a span html showing in the tooltip.

## Related Issue

N/A

## Screenshots

<!--- Required for theme or other visual changes. Add before and after screenshots when applicable. Otherwise, remove this section. -->

<img width="1238" height="101" alt="image" src="https://github.com/user-attachments/assets/9a8f7d85-ac52-4cfc-8c40-4fbbaa1b36af" />

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
