### PR TITLE
chore(deps): replace create-rstack with create-toolkit

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -60,7 +60,7 @@
         'rspack',
         'rstest',
         'rspress',
-        'create-rstack',
+        '@rstackjs/create-toolkit',
       ],
       groupSlug: 'rstack',
     },

--- a/packages/create-rspress/package.json
+++ b/packages/create-rspress/package.json
@@ -28,7 +28,7 @@
     "start": "node ./dist/index.js"
   },
   "dependencies": {
-    "create-rstack": "2.1.3"
+    "@rstackjs/create-toolkit": "2.1.4"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.12",

--- a/packages/create-rspress/src/index.ts
+++ b/packages/create-rspress/src/index.ts
@@ -7,7 +7,7 @@ import {
   type ESLintTemplateName,
   type RslintTemplateName,
   select,
-} from 'create-rstack';
+} from '@rstackjs/create-toolkit';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const templates = ['basic', 'basic-theme', 'i18n', 'i18n-theme'] as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2003,9 +2003,9 @@ importers:
 
   packages/create-rspress:
     dependencies:
-      create-rstack:
-        specifier: 2.1.3
-        version: 2.1.3
+      '@rstackjs/create-toolkit':
+        specifier: 2.1.4
+        version: 2.1.4
     devDependencies:
       '@microsoft/api-extractor':
         specifier: ^7.58.12
@@ -4302,6 +4302,10 @@ packages:
       '@rspress/core':
         optional: true
 
+  '@rstackjs/create-toolkit@2.1.4':
+    resolution: {integrity: sha512-kwPhfMdgWN7z/Op5UKMszhmZy7+hzqXeiQPli4uycYYTLxCVUGLlEW3etoGoZlrM2t5zLqXZQAgL60PTUR/ocw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   '@rstest/adapter-rslib@0.11.5':
     resolution: {integrity: sha512-ijVBmQ+uyJF4yw5HVbGhoXUEepnlb7mFXhuUm+C/OxKJim+IYUHGhDB9Mz6Zzo+ltgPVFqGpP4QQNGPAxJXXVQ==}
     peerDependencies:
@@ -5361,10 +5365,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  create-rstack@2.1.3:
-    resolution: {integrity: sha512-3n8JzuzbMYger7fnhIb8DDYs7b4lnNgLJm6kKve+qCKeqpCsTZaiZBQ3cYy7/FjWNtccbJ4XhfA/WNvzETD3vw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
 
   cross-env@10.1.0:
     resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
@@ -10208,6 +10208,8 @@ snapshots:
     optionalDependencies:
       '@rspress/core': link:packages/core
 
+  '@rstackjs/create-toolkit@2.1.4': {}
+
   '@rstest/adapter-rslib@0.11.5(@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.12(@types/node@22.19.15))(typescript@7.0.2))(@rstest/core@0.11.5)(typescript@7.0.2)':
     dependencies:
       '@rslib/core': 1.0.0-beta.1(@microsoft/api-extractor@7.58.12(@types/node@22.19.15))(typescript@7.0.2)
@@ -11303,8 +11305,6 @@ snapshots:
       path-type: 4.0.0
     optionalDependencies:
       typescript: 6.0.3
-
-  create-rstack@2.1.3: {}
 
   cross-env@10.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,6 +28,7 @@ minimumReleaseAgeExclude:
   - '@rsdoctor/*'
   - '@rslint/*'
   - '@rstack-dev/*'
+  - '@rstackjs/create-toolkit'
   # Renovate security update: nx@22.7.2
   - nx@22.7.2
 


### PR DESCRIPTION
## Summary

- Replace `create-rstack` with its renamed package, `@rstackjs/create-toolkit` v2.1.4.
- Update `create-rspress`, Renovate grouping, and workspace dependency policy without changing scaffolding behavior.

## Related Issue

- https://github.com/rstackjs/create-toolkit/releases/tag/v2.1.4

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).