### PR TITLE
feat(core): add pluggable documentation search providers

### DIFF
--- a/.changeset/bright-search-providers.md
+++ b/.changeset/bright-search-providers.md
@@ -1,0 +1,6 @@
+---
+'@rspress/core': minor
+'@rspress/plugin-algolia': patch
+---
+
+Add a shared documentation search provider API and integrate Algolia DocSearch as a provider.

--- a/packages/core/src/node/runtimeModule/siteData/createSiteData.test.ts
+++ b/packages/core/src/node/runtimeModule/siteData/createSiteData.test.ts
@@ -1,0 +1,35 @@
+import type { UserConfig } from '@rspress/shared';
+import { describe, expect, test } from '@rstest/core';
+import { createSiteData } from './createSiteData';
+
+describe('createSiteData', () => {
+  test('preserves the default local search configuration', async () => {
+    const { siteData } = await createSiteData({});
+
+    expect(siteData.search).toEqual({
+      mode: 'local',
+      searchHooks: undefined,
+    });
+  });
+
+  test('preserves disabled search in runtime site data', async () => {
+    const { siteData } = await createSiteData({ search: false });
+
+    expect(siteData.search).toBe(false);
+  });
+
+  test('removes search hooks without mutating user config', async () => {
+    const search = {
+      mode: 'local',
+      searchHooks: '/absolute/search-hooks.ts',
+    } satisfies NonNullable<UserConfig['search']>;
+
+    const { siteData } = await createSiteData({ search });
+
+    expect(siteData.search).toEqual({
+      mode: 'local',
+      searchHooks: undefined,
+    });
+    expect(search.searchHooks).toBe('/absolute/search-hooks.ts');
+  });
+});

--- a/packages/core/src/node/runtimeModule/siteData/createSiteData.ts
+++ b/packages/core/src/node/runtimeModule/siteData/createSiteData.ts
@@ -5,13 +5,15 @@ import { normalizeThemeConfig } from './normalizeThemeConfig';
 export async function createSiteData(userConfig: UserConfig): Promise<{
   siteData: Omit<SiteData, 'root' | 'pages'>;
 }> {
-  // prevent modify the origin config object
-  const tempSearchObj = Object.assign({}, userConfig.search);
-
-  // searchHooks is a absolute path which may leak information
-  if (tempSearchObj) {
-    tempSearchObj.searchHooks = undefined;
-  }
+  const search =
+    userConfig.search === false
+      ? false
+      : {
+          mode: 'local' as const,
+          ...userConfig.search,
+          // searchHooks is an absolute path which may leak information
+          searchHooks: undefined,
+        };
 
   const siteData: Omit<SiteData, 'root' | 'pages'> = {
     base: userConfig.base ?? '/',
@@ -33,7 +35,7 @@ export async function createSiteData(userConfig: UserConfig): Promise<{
       default: userConfig?.multiVersion?.default || '',
       versions: userConfig?.multiVersion?.versions || [],
     },
-    search: tempSearchObj ?? { mode: 'local' },
+    search,
     markdown: {
       showLineNumbers: userConfig?.markdown?.showLineNumbers ?? false,
       defaultWrapCode: userConfig?.markdown?.defaultWrapCode ?? false,

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -125,6 +125,13 @@ export { copyToClipboard } from './logic/copyToClipboard';
 export { getCopyableText } from './logic/getCopyableText';
 // logic
 export { mergeRefs } from './logic/mergeRefs';
+export {
+  registerSearchProvider,
+  type SearchProvider,
+  type SearchResultGroup,
+  useSearchProvider,
+} from './logic/searchProvider';
+export { useDocsSearch } from './logic/useDocsSearch';
 export { useFullTextSearch } from './logic/useFullTextSearch';
 export { usePrevNextPage } from './logic/usePrevNextPage';
 export { useScrollAfterNav } from './logic/useScrollAfterNav';

--- a/packages/core/src/theme/logic/searchProvider.test.ts
+++ b/packages/core/src/theme/logic/searchProvider.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, test } from '@rstest/core';
+import {
+  getSearchProvider,
+  registerSearchProvider,
+  type SearchProvider,
+} from './searchProvider';
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups.splice(0).reverse()) {
+    cleanup();
+  }
+});
+
+function provider(name: string): SearchProvider {
+  return {
+    search: async () => [{ group: name, result: [] }],
+  };
+}
+
+describe('search providers', () => {
+  test('uses the most recently registered provider', () => {
+    const first = provider('first');
+    const second = provider('second');
+    const unregisterFirst = registerSearchProvider(first);
+    const unregisterSecond = registerSearchProvider(second);
+    cleanups.push(unregisterFirst, unregisterSecond);
+
+    expect(getSearchProvider()).toBe(second);
+    unregisterSecond();
+    expect(getSearchProvider()).toBe(first);
+  });
+
+  test('supports idempotent cleanup', () => {
+    const searchProvider = provider('provider');
+    const unregister = registerSearchProvider(searchProvider);
+    cleanups.push(unregister);
+
+    unregister();
+    unregister();
+    expect(getSearchProvider()).toBeUndefined();
+  });
+});

--- a/packages/core/src/theme/logic/searchProvider.ts
+++ b/packages/core/src/theme/logic/searchProvider.ts
@@ -1,0 +1,50 @@
+import { useSyncExternalStore } from 'react';
+
+export interface SearchResultGroup<TResult = unknown> {
+  group: string;
+  result: TResult;
+}
+
+export interface SearchProvider {
+  search: (query: string, limit?: number) => Promise<SearchResultGroup[]>;
+}
+
+const providers: SearchProvider[] = [];
+const listeners = new Set<() => void>();
+
+export function getSearchProvider(): SearchProvider | undefined {
+  return providers.at(-1);
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function notify() {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function registerSearchProvider(provider: SearchProvider): () => void {
+  providers.push(provider);
+  notify();
+
+  return () => {
+    const index = providers.lastIndexOf(provider);
+    if (index === -1) {
+      return;
+    }
+
+    const wasActive = index === providers.length - 1;
+    providers.splice(index, 1);
+    if (wasActive) {
+      notify();
+    }
+  };
+}
+
+export function useSearchProvider(): SearchProvider | undefined {
+  return useSyncExternalStore(subscribe, getSearchProvider, getSearchProvider);
+}

--- a/packages/core/src/theme/logic/useDocsSearch.test.ts
+++ b/packages/core/src/theme/logic/useDocsSearch.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, rs, test } from '@rstest/core';
+import { useFullTextSearch } from './useFullTextSearch';
+import { useDocsSearch } from './useDocsSearch';
+import { useSearchProvider } from './searchProvider';
+
+rs.mock('./useFullTextSearch', () => ({
+  useFullTextSearch: rs.fn(),
+}));
+
+rs.mock('./searchProvider', () => ({
+  useSearchProvider: rs.fn(),
+}));
+
+const mockUseFullTextSearch = rs.mocked(useFullTextSearch);
+const mockUseSearchProvider = rs.mocked(useSearchProvider);
+
+beforeEach(() => {
+  mockUseSearchProvider.mockReturnValue(undefined);
+  mockUseFullTextSearch.mockReturnValue({
+    initialized: false,
+    search: undefined,
+  });
+});
+
+describe('useDocsSearch', () => {
+  test('falls back to local search', () => {
+    const search = rs.fn();
+    mockUseFullTextSearch.mockReturnValue({ initialized: true, search });
+
+    expect(useDocsSearch()).toEqual({ initialized: true, search });
+  });
+
+  test('prefers a registered provider', () => {
+    const search = rs.fn();
+    mockUseSearchProvider.mockReturnValue({ search });
+
+    expect(useDocsSearch()).toEqual({ initialized: true, search });
+  });
+
+  test('is unavailable without any search provider', () => {
+    expect(useDocsSearch()).toEqual({
+      initialized: false,
+      search: undefined,
+    });
+  });
+});

--- a/packages/core/src/theme/logic/useDocsSearch.ts
+++ b/packages/core/src/theme/logic/useDocsSearch.ts
@@ -1,0 +1,16 @@
+import { useFullTextSearch } from './useFullTextSearch';
+import { type SearchProvider, useSearchProvider } from './searchProvider';
+
+type DocsSearchState =
+  | { initialized: false; search: undefined }
+  | { initialized: true; search: SearchProvider['search'] };
+
+export function useDocsSearch(): DocsSearchState {
+  const provider = useSearchProvider();
+  const localSearch = useFullTextSearch();
+
+  if (provider) {
+    return { initialized: true, search: provider.search };
+  }
+  return localSearch;
+}

--- a/packages/core/src/theme/logic/useFullTextSearch.ts
+++ b/packages/core/src/theme/logic/useFullTextSearch.ts
@@ -1,38 +1,59 @@
 import { usePageData } from '@rspress/core/runtime';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { PageSearcher } from '../components/Search/logic/search';
 import type { MatchResult } from '../components/Search/logic/types';
 
-export function useFullTextSearch(): {
-  initialized: boolean;
-  search: (keyword: string, limit?: number) => Promise<MatchResult>;
-} {
+type Search = (keyword: string, limit?: number) => Promise<MatchResult>;
+
+type FullTextSearchState =
+  | { initialized: false; search: undefined }
+  | { initialized: true; search: Search };
+
+export function useFullTextSearch(): FullTextSearchState {
   const { siteData, page } = usePageData();
-  const [initialized, setInitialized] = useState(false);
-  const searchRef = useRef<PageSearcher | null>(null);
+  const searchOptions = siteData.search;
+  const versionedSearch =
+    searchOptions !== false && (searchOptions.versioned ?? true);
+  const currentVersion = versionedSearch ? page.version : '';
+  const searcher = useMemo(
+    () =>
+      searchOptions === false
+        ? null
+        : new PageSearcher({
+            ...searchOptions,
+            mode: 'local',
+            currentLang: page.lang,
+            currentVersion,
+          }),
+    [searchOptions, page.lang, currentVersion],
+  );
+  const [initializedSearcher, setInitializedSearcher] =
+    useState<PageSearcher | null>(null);
 
   useEffect(() => {
-    async function init() {
-      if (!initialized) {
-        const searcher = new PageSearcher({
-          ...siteData.search,
-          mode: 'local',
-          currentLang: page.lang,
-          currentVersion: page.version,
-        });
-        searchRef.current = searcher;
-        await searcher.init();
-        setInitialized(true);
-      }
+    setInitializedSearcher(null);
+    if (!searcher) {
+      return;
     }
-    init();
-  }, []);
+
+    let active = true;
+    void searcher.init().then(() => {
+      if (active) {
+        setInitializedSearcher(searcher);
+      }
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [searcher]);
+
+  if (initializedSearcher !== searcher || !searcher) {
+    return { initialized: false, search: undefined };
+  }
 
   return {
-    initialized,
-    search: searchRef.current?.match.bind(searchRef.current) as (
-      keyword: string,
-      limit?: number,
-    ) => Promise<MatchResult>,
+    initialized: true,
+    search: searcher.match.bind(searcher),
   };
 }

--- a/packages/plugin-algolia/package.json
+++ b/packages/plugin-algolia/package.json
@@ -40,7 +40,8 @@
   },
   "dependencies": {
     "@docsearch/css": "^4.7.0",
-    "@docsearch/react": "^4.7.0"
+    "@docsearch/react": "^4.7.0",
+    "algoliasearch": "^5.50.0"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.12",

--- a/packages/plugin-algolia/src/runtime/Search.tsx
+++ b/packages/plugin-algolia/src/runtime/Search.tsx
@@ -1,11 +1,23 @@
-import type { DocSearchProps } from '@docsearch/react';
+import type {
+  DocSearchProps,
+  DocSearchTransformClient,
+} from '@docsearch/react';
 import { DocSearch } from '@docsearch/react';
-import { removeBase, safePreconnect, useLang } from '@rspress/core/runtime';
-import { Link, useLinkNavigate } from '@rspress/core/theme';
+import { safePreconnect, useLang } from '@rspress/core/runtime';
+import {
+  Link,
+  registerSearchProvider,
+  useLinkNavigate,
+} from '@rspress/core/theme';
+import { liteClient } from 'algoliasearch/lite';
 import '@docsearch/css';
 import './Search.css';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import type { Locales } from './locales';
+import {
+  createAlgoliaSearchProvider,
+  normalizeDocSearchItems,
+} from './searchProvider';
 
 const Hit: DocSearchProps['hitComponent'] = ({ hit, children }) => {
   return <Link href={hit.url}>{children}</Link>;
@@ -26,6 +38,25 @@ function Search({ locales = {}, docSearchProps }: SearchProps) {
   const { translations, placeholder } = locales?.[lang] ?? {};
 
   const appId = docSearchProps.appId;
+  const searchClient = useMemo(() => {
+    const client = liteClient(docSearchProps.appId, docSearchProps.apiKey);
+    return (docSearchProps.transformSearchClient?.(client) ??
+      client) as DocSearchTransformClient;
+  }, [
+    docSearchProps.appId,
+    docSearchProps.apiKey,
+    docSearchProps.transformSearchClient,
+  ]);
+  const searchProvider = useMemo(
+    () => createAlgoliaSearchProvider(docSearchProps, searchClient),
+    [docSearchProps, searchClient],
+  );
+
+  useEffect(
+    () => (searchProvider ? registerSearchProvider(searchProvider) : undefined),
+    [searchProvider],
+  );
+
   if (appId) {
     if (typeof safePreconnect === 'function') {
       safePreconnect(`https://${appId}-dsn.algolia.net`, { crossOrigin: '' });
@@ -61,18 +92,12 @@ function Search({ locales = {}, docSearchProps }: SearchProps) {
             navigate(itemUrl);
           },
         }}
-        transformItems={(items: any[]) => {
-          return items.map(item => {
-            const url = new URL(item.url);
-            return {
-              ...item,
-              // we already have basename, so pass the url without base to Link and navigate
-              url: removeBase(item.url.replace(url.origin, '')),
-            };
-          });
-        }}
         hitComponent={Hit}
         {...docSearchProps}
+        transformItems={
+          docSearchProps.transformItems ?? normalizeDocSearchItems
+        }
+        transformSearchClient={() => searchClient}
       />
     </>
   );

--- a/packages/plugin-algolia/src/runtime/searchProvider.ts
+++ b/packages/plugin-algolia/src/runtime/searchProvider.ts
@@ -1,0 +1,74 @@
+import type {
+  DocSearchHit,
+  DocSearchIndex,
+  DocSearchProps,
+  DocSearchTransformClient,
+} from '@docsearch/react';
+import { removeBase } from '@rspress/core/runtime';
+import type { SearchProvider } from '@rspress/core/theme';
+import type { SearchResponses } from 'algoliasearch/lite';
+
+function getIndices({
+  indexName,
+  indices,
+  searchParameters,
+}: DocSearchProps): DocSearchIndex[] {
+  if (indices?.length) {
+    return indices.map(index =>
+      typeof index === 'string'
+        ? { name: index, searchParameters }
+        : {
+            ...index,
+            searchParameters: {
+              ...searchParameters,
+              ...index.searchParameters,
+            },
+          },
+    );
+  }
+  return indexName ? [{ name: indexName, searchParameters }] : [];
+}
+
+export function normalizeDocSearchItems(items: DocSearchHit[]): DocSearchHit[] {
+  return items.map(item => {
+    const url = new URL(item.url);
+    return {
+      ...item,
+      url: removeBase(item.url.replace(url.origin, '')),
+    };
+  });
+}
+
+export function createAlgoliaSearchProvider(
+  docSearchProps: DocSearchProps,
+  searchClient: DocSearchTransformClient,
+): SearchProvider | undefined {
+  const indices = getIndices(docSearchProps);
+  if (!indices.length) {
+    return undefined;
+  }
+
+  const transformItems =
+    docSearchProps.transformItems ?? normalizeDocSearchItems;
+  const defaultLimit = docSearchProps.maxResultsPerGroup ?? 20;
+
+  return {
+    async search(query, limit = defaultLimit) {
+      const response: SearchResponses<DocSearchHit> =
+        await searchClient.search<DocSearchHit>({
+          requests: indices.map(index => ({
+            ...index.searchParameters,
+            indexName: index.name,
+            query,
+            hitsPerPage: limit,
+          })),
+        });
+
+      return response.results.map((result, index) => ({
+        group: indices[index].name,
+        result:
+          'hits' in result ? transformItems(result.hits as DocSearchHit[]) : [],
+      }));
+    },
+  };
+}

--- a/packages/plugin-algolia/tests/searchProvider.test.ts
+++ b/packages/plugin-algolia/tests/searchProvider.test.ts
@@ -1,0 +1,121 @@
+import type {
+  DocSearchHit,
+  DocSearchProps,
+  DocSearchTransformClient,
+} from '@docsearch/react';
+import { describe, expect, rs, test } from '@rstest/core';
+import { createAlgoliaSearchProvider } from '../src/runtime/searchProvider';
+
+rs.mock('@rspress/core/runtime', () => ({
+  removeBase: (url: string) => url.replace('/docs', ''),
+}));
+
+function hit(url: string): DocSearchHit {
+  return {
+    objectID: url,
+    content: 'Search content',
+    url,
+    url_without_anchor: url,
+    type: 'content',
+    anchor: null,
+    hierarchy: {
+      lvl0: 'Guide',
+      lvl1: 'Search',
+      lvl2: null,
+      lvl3: null,
+      lvl4: null,
+      lvl5: null,
+      lvl6: null,
+    },
+    _highlightResult: {} as DocSearchHit['_highlightResult'],
+    _snippetResult: {} as DocSearchHit['_snippetResult'],
+  };
+}
+
+function setup(props: Partial<DocSearchProps>) {
+  const search = rs.fn().mockResolvedValue({
+    results: [{ hits: [hit('https://example.com/docs/guide#search')] }],
+  });
+  const client = { search } as unknown as DocSearchTransformClient;
+  const provider = createAlgoliaSearchProvider(
+    { appId: 'app', apiKey: 'key', ...props },
+    client,
+  );
+  return { provider, search };
+}
+
+describe('Algolia search provider', () => {
+  test('searches a legacy index and normalizes result URLs', async () => {
+    const { provider, search } = setup({
+      indexName: 'docs',
+      searchParameters: { facetFilters: ['lang:en'] },
+    });
+
+    await expect(provider?.search('routing', 5)).resolves.toEqual([
+      {
+        group: 'docs',
+        result: [expect.objectContaining({ url: '/guide#search' })],
+      },
+    ]);
+    expect(search).toHaveBeenCalledWith({
+      requests: [
+        {
+          facetFilters: ['lang:en'],
+          indexName: 'docs',
+          query: 'routing',
+          hitsPerPage: 5,
+        },
+      ],
+    });
+  });
+
+  test('supports multiple indices and custom item transforms', async () => {
+    const transformItems = rs.fn((items: DocSearchHit[]) =>
+      items.map(item => ({ ...item, content: 'transformed' })),
+    );
+    const { provider, search } = setup({
+      indices: [
+        'main',
+        { name: 'api', searchParameters: { facetFilters: ['kind:api'] } },
+      ],
+      searchParameters: { facetFilters: ['lang:en'], typoTolerance: false },
+      maxResultsPerGroup: 8,
+      transformItems,
+    });
+    search.mockResolvedValueOnce({
+      results: [
+        { hits: [hit('https://example.com/docs/main')] },
+        { hits: [hit('https://example.com/docs/api')] },
+      ],
+    });
+
+    const results = await provider?.search('config');
+    expect(results?.map(result => result.group)).toEqual(['main', 'api']);
+    expect(results?.[0].result).toEqual([
+      expect.objectContaining({ content: 'transformed' }),
+    ]);
+    expect(search).toHaveBeenCalledWith({
+      requests: [
+        {
+          facetFilters: ['lang:en'],
+          typoTolerance: false,
+          indexName: 'main',
+          query: 'config',
+          hitsPerPage: 8,
+        },
+        {
+          facetFilters: ['kind:api'],
+          typoTolerance: false,
+          indexName: 'api',
+          query: 'config',
+          hitsPerPage: 8,
+        },
+      ],
+    });
+    expect(transformItems).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not create a provider without an index', () => {
+    expect(setup({}).provider).toBeUndefined();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2034,6 +2034,9 @@ importers:
       '@rspress/core':
         specifier: workspace:^2.0.10
         version: link:../core
+      algoliasearch:
+        specifier: ^5.50.0
+        version: 5.50.0
     devDependencies:
       '@microsoft/api-extractor':
         specifier: ^7.58.12


### PR DESCRIPTION
## Summary

Add a shared runtime search provider API so integrations can expose their active documentation search implementation. Local search remains the fallback, while the Algolia search component automatically registers and cleans up its provider.

## Context

Extracted from #3520 as an independently reviewable Core prerequisite. The other prerequisites split from that PR are #3590 and #3592.

## Related Issue

N/A

## Checklist

- [x] Tests updated.
- [x] Documentation updated (not required).
