### PR TITLE
fix: configure Rslint type checking for workspace projects

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --ignore-scripts
 
+      - name: Build
+        run: pnpm run build
+
       - name: Lint
         run: pnpm run lint
 

--- a/packages/core/src/node/last-updated/gitLog.test.ts
+++ b/packages/core/src/node/last-updated/gitLog.test.ts
@@ -91,6 +91,7 @@ describe('pluginLastUpdated against a real repository', () => {
 
     await plugin.routeGenerated?.(
       pages.map(page => ({ absolutePath: page._filepath }) as RouteMeta),
+      false,
     );
     await Promise.all(pages.map(page => plugin.extendPageData?.(page, true)));
 

--- a/packages/core/src/node/last-updated/index.test.ts
+++ b/packages/core/src/node/last-updated/index.test.ts
@@ -53,6 +53,7 @@ const pageData = (relativePath = 'index.mdx'): TestPageIndexInfo =>
 async function extendPages(plugin: RspressPlugin, pages: TestPageIndexInfo[]) {
   await plugin.routeGenerated?.(
     pages.map(page => ({ absolutePath: page._filepath }) as RouteMeta),
+    false,
   );
   await Promise.all(pages.map(page => plugin.extendPageData?.(page, true)));
 }

--- a/packages/core/src/node/last-updated/index.ts
+++ b/packages/core/src/node/last-updated/index.ts
@@ -107,7 +107,7 @@ async function getRepoPrefix(dir: string): Promise<string | undefined> {
       cwd: dir,
     });
     return stdout.trim();
-  } catch (_e) {
+  } catch {
     return undefined;
   }
 }
@@ -153,7 +153,7 @@ async function collectGitInfo(dir: string): Promise<Map<string, GitInfo>> {
       ],
       { cwd: dir },
     ));
-  } catch (_e) {
+  } catch {
     return infoByPath;
   }
 

--- a/packages/core/src/node/mdx/rehypePlugins/transformers/add-title.test.ts
+++ b/packages/core/src/node/mdx/rehypePlugins/transformers/add-title.test.ts
@@ -29,7 +29,12 @@ function callTransformerPre(
       meta: rawMeta !== undefined ? { __raw: rawMeta } : undefined,
     },
   } satisfies TransformerPreContext;
-  return transformer.pre!.call(context, pre) as Element;
+  return transformer.pre!.call(
+    context as unknown as ThisParameterType<
+      NonNullable<typeof transformer.pre>
+    >,
+    pre,
+  ) as Element;
 }
 
 describe('transformerAddTitle', () => {

--- a/packages/core/src/node/mdx/remarkPlugins/link.ts
+++ b/packages/core/src/node/mdx/remarkPlugins/link.ts
@@ -233,6 +233,7 @@ function normalizeLink(
     return { url: nodeUrl };
   }
 
+  // rslint-disable-next-line prefer-const
   let { url, hash, search } = parseUrl(nodeUrl);
 
   // 1. [](/api/getting-started) or [](/en/api/getting-started)

--- a/packages/core/src/node/mdx/remarkPlugins/toc.test.ts
+++ b/packages/core/src/node/mdx/remarkPlugins/toc.test.ts
@@ -214,7 +214,7 @@ describe('parseToc', () => {
   test('collects h1-h6 anchor ids', () => {
     const tree: MdastRoot = {
       type: 'root',
-      children: [1, 2, 3, 4, 5, 6].map(depth => ({
+      children: ([1, 2, 3, 4, 5, 6] as const).map(depth => ({
         type: 'heading',
         depth,
         children: [{ type: 'text', value: `Heading ${depth}` }],

--- a/packages/core/src/node/route/extractPageData.test.ts
+++ b/packages/core/src/node/route/extractPageData.test.ts
@@ -9,12 +9,14 @@ const fixtureContentProcessingDir = join(
 );
 
 function createRoute(relativePath: string, fixtureDir: string) {
+  const routePath = `/${relativePath.replace(/\.(mdx?|md)$/, '')}`;
   return {
     absolutePath: join(fixtureDir, relativePath),
     lang: '',
     pageName: relativePath.replace(/\.(mdx?|md)$/, ''),
+    pureRoutePath: routePath,
     relativePath,
-    routePath: `/${relativePath.replace(/\.(mdx?|md)$/, '')}`,
+    routePath,
     version: '',
   };
 }
@@ -33,6 +35,7 @@ describe('extractPageData', async () => {
               absolutePath: absolutize('/a.mdx'),
               lang: '',
               pageName: 'a',
+              pureRoutePath: '/a',
               relativePath: 'a.mdx',
               routePath: '/a',
               version: '',
@@ -41,6 +44,7 @@ describe('extractPageData', async () => {
               absolutePath: absolutize('/guide/b.mdx'),
               lang: '',
               pageName: 'guide_b',
+              pureRoutePath: '/guide/b',
               relativePath: 'guide/b.mdx',
               routePath: '/guide/b',
               version: '',
@@ -49,6 +53,7 @@ describe('extractPageData', async () => {
               absolutePath: absolutize('/guide/c.tsx'),
               lang: '',
               pageName: 'guide_c',
+              pureRoutePath: '/guide/c',
               relativePath: 'guide/c.tsx',
               routePath: '/guide/c',
               version: '',
@@ -57,13 +62,14 @@ describe('extractPageData', async () => {
               absolutePath: absolutize('/index.mdx'),
               lang: '',
               pageName: 'index',
+              pureRoutePath: '/',
               relativePath: 'index.mdx',
               routePath: '/',
               version: '',
             },
           }),
         getRoutePageByRoutePath: () => undefined,
-      } as RouteService,
+      } as unknown as RouteService,
       {
         alias: {},
         replaceRules: [],
@@ -149,6 +155,7 @@ describe('getPageIndexInfoByRoute', async () => {
         absolutePath: absolutize('/index.mdx'),
         lang: '',
         pageName: 'index',
+        pureRoutePath: '/',
         relativePath: 'index.mdx',
         routePath: '/',
         version: '',

--- a/packages/core/src/node/ssg/renderHtmlTemplate.test.ts
+++ b/packages/core/src/node/ssg/renderHtmlTemplate.test.ts
@@ -5,6 +5,7 @@ import { renderHtmlTemplate } from './renderHtmlTemplate';
 
 const route: RouteMeta = {
   routePath: '/guide/',
+  pureRoutePath: '/guide/',
   absolutePath: '/root/guide/index.md',
   relativePath: 'guide/index.md',
   pageName: 'guide_index',

--- a/packages/core/src/node/utils/flattenMdxContent.ts
+++ b/packages/core/src/node/utils/flattenMdxContent.ts
@@ -98,7 +98,7 @@ export async function flattenMdxContent(
         path.dirname(basePath),
         alias,
       );
-    } catch (_e) {
+    } catch {
       continue;
     }
 

--- a/packages/core/src/theme/logic/getCopyableText.test.ts
+++ b/packages/core/src/theme/logic/getCopyableText.test.ts
@@ -9,15 +9,15 @@ const SHOW_TEXT = 4;
 type FakeNode = FakeElement | FakeTextNode;
 
 interface FakeTextNode {
-  nodeType: number;
+  nodeType: typeof TEXT_NODE;
   nodeName: '#text';
   nodeValue: string;
-  parentElement: FakeElement;
+  parentElement: FakeElement | null;
   previousSibling: FakeNode | null;
 }
 
 interface FakeElement {
-  nodeType: number;
+  nodeType: typeof ELEMENT_NODE;
   nodeName: string;
   tagName: string;
   ownerDocument: FakeDocument;
@@ -63,7 +63,7 @@ afterEach(() => {
   if (originalNode) {
     globalScope.Node = originalNode;
   } else {
-    delete globalScope.Node;
+    Reflect.deleteProperty(globalScope, 'Node');
   }
 });
 
@@ -159,12 +159,12 @@ function createElement(
   return element;
 }
 
-function createText(ownerDocument: FakeDocument, value: string): FakeTextNode {
+function createText(value: string): FakeTextNode {
   return {
     nodeType: TEXT_NODE,
     nodeName: '#text',
     nodeValue: value,
-    parentElement: null as unknown as FakeElement,
+    parentElement: null,
     previousSibling: null,
   };
 }
@@ -193,7 +193,7 @@ describe('getCopyableText', () => {
     const p = createElement(document, 'P');
     const pre = createElement(document, 'PRE');
     const code = createElement(document, 'CODE');
-    const codeText = createText(document, 'npm install package-name');
+    const codeText = createText('npm install package-name');
 
     appendChild(ol, li);
     appendChild(li, p);
@@ -211,7 +211,7 @@ describe('getCopyableText', () => {
     const li = createElement(document, 'LI');
     const pre = createElement(document, 'PRE');
     const code = createElement(document, 'CODE');
-    const codeText = createText(document, 'docker run image');
+    const codeText = createText('docker run image');
 
     appendChild(ul, li);
     appendChild(li, pre);
@@ -227,8 +227,8 @@ describe('getCopyableText', () => {
     const ul = createElement(document, 'UL');
     const firstLi = createElement(document, 'LI');
     const secondLi = createElement(document, 'LI');
-    const firstText = createText(document, 'First step');
-    const secondText = createText(document, 'Second step');
+    const firstText = createText('First step');
+    const secondText = createText('Second step');
 
     appendChild(ul, firstLi);
     appendChild(ul, secondLi);
@@ -245,7 +245,7 @@ describe('getCopyableText', () => {
     const li = createElement(document, 'LI');
     const pre = createElement(document, 'PRE');
     const code = createElement(document, 'CODE');
-    const codeText = createText(document, 'command1 arg1\ncommand2 arg2');
+    const codeText = createText('command1 arg1\ncommand2 arg2');
 
     appendChild(ol, li);
     appendChild(li, pre);

--- a/packages/create-rspress/tsconfig.json
+++ b/packages/create-rspress/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@rspress/config/tsconfig",
   "compilerOptions": {
-    "declaration": true
+    "declaration": true,
+    "types": ["node"]
   },
   "include": ["src"],
   "exclude": ["**/node_modules", "**/template/**"]

--- a/packages/plugin-playground/src/web/editor.tsx
+++ b/packages/plugin-playground/src/web/editor.tsx
@@ -26,7 +26,7 @@ function getLoaderConfig() {
     if (keys.length > 0) {
       loaderConfig = __PLAYGROUND_MONACO_LOADER__;
     }
-  } catch (_e) {
+  } catch {
     // ignore
   }
 
@@ -43,7 +43,7 @@ loader.config(loaderConfig);
 function getMonacoOptions() {
   try {
     return __PLAYGROUND_MONACO_OPTIONS__;
-  } catch (_e) {
+  } catch {
     // ignore
   }
   return {};

--- a/packages/plugin-playground/tests/error.test.ts
+++ b/packages/plugin-playground/tests/error.test.ts
@@ -18,16 +18,20 @@ describe('plugin-playground errors', () => {
       }
 
       await expect(
-        plugin.routeGenerated([
-          {
-            absolutePath: filepath,
-            routePath: '/',
-            relativePath: 'index.mdx',
-            pageName: 'index',
-            lang: '',
-            version: '',
-          },
-        ]),
+        plugin.routeGenerated(
+          [
+            {
+              absolutePath: filepath,
+              routePath: '/',
+              pureRoutePath: '/',
+              relativePath: 'index.mdx',
+              pageName: 'index',
+              lang: '',
+              version: '',
+            },
+          ],
+          false,
+        ),
       ).rejects.toThrow(
         `[Playground]: Failed to parse ${filepath}.\nCould not parse expression with acorn`,
       );

--- a/packages/plugin-preview/static/global-components/FixedDevice.tsx
+++ b/packages/plugin-preview/static/global-components/FixedDevice.tsx
@@ -1,6 +1,5 @@
 import { useDark, usePage } from '@rspress/core/runtime';
 import { useCallback, useEffect, useRef, useState } from 'react';
-// @ts-expect-error
 import { normalizeId } from '../../dist/utils';
 import { getPageFullUrl, getPageUrl } from './common/getPageUrl';
 import MobileOperation from './common/PreviewOperations';

--- a/packages/plugin-preview/static/global-components/FixedDevice.tsx
+++ b/packages/plugin-preview/static/global-components/FixedDevice.tsx
@@ -1,5 +1,6 @@
 import { useDark, usePage } from '@rspress/core/runtime';
 import { useCallback, useEffect, useRef, useState } from 'react';
+// @ts-ignore -- this declaration is generated concurrently by the package build
 import { normalizeId } from '../../dist/utils';
 import { getPageFullUrl, getPageUrl } from './common/getPageUrl';
 import MobileOperation from './common/PreviewOperations';

--- a/packages/plugin-preview/tsconfig.json
+++ b/packages/plugin-preview/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@rspress/config/tsconfig",
   "compilerOptions": {
     "composite": true,
-    "rootDir": "."
+    "rootDir": ".",
+    "types": ["node", "@rsbuild/core/types"]
   },
   "include": ["src", "static/"],
   "references": [

--- a/rslint.config.ts
+++ b/rslint.config.ts
@@ -15,6 +15,19 @@ export default defineConfig([
   js.configs.recommended,
   ts.configs.recommended,
   {
+    languageOptions: {
+      parserOptions: {
+        project: [
+          './tsconfig.json',
+          './scripts/config/tsconfig.json',
+          './packages/*/tsconfig*.json',
+          './packages/*/tests/tsconfig.json',
+          './website/tsconfig.json',
+        ],
+      },
+    },
+  },
+  {
     rules: {
       '@typescript-eslint/ban-ts-comment': 'off',
       '@typescript-eslint/no-explicit-any': 'off',

--- a/website/docs/components/CssPickerEditor.tsx
+++ b/website/docs/components/CssPickerEditor.tsx
@@ -60,8 +60,8 @@ function hexToHsl(hex: string) {
   const max = Math.max(r, g, b),
     min = Math.min(r, g, b);
   let h = 0,
-    s = 0,
-    l = (max + min) / 2;
+    s = 0;
+  const l = (max + min) / 2;
   if (max !== min) {
     const d = max - min;
     s = l > 0.5 ? d / (2 - max - min) : d / (max + min);


### PR DESCRIPTION
## Summary

- configure Rslint with the workspace TypeScript projects
- add missing ambient types for Node.js and Rsbuild
- update test mocks issues exposed by type-checking
- resolve reported lint errors
