### PR TITLE
chore(deps): group Rslint updates with Rstack

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,7 +35,6 @@
       groupName: 'dev-tools',
       matchPackageNames: [
         'cspell',
-        '@rslint/core',
         'prettier',
         'lint-staged',
         '@microsoft/api-extractor',
@@ -60,6 +59,7 @@
         'rspack',
         'rstest',
         'rspress',
+        '@rslint/core',
         '@rstackjs/create-toolkit',
       ],
       groupSlug: 'rstack',


### PR DESCRIPTION
## Summary

- Move `@rslint/core` from the `dev-tools` Renovate group to the `rstack` group.
- Keep Rslint updates out of the catch-all patch dependency PR, such as #3595.

## Related Issue

Related to #3595.

## Validation

- `prettier .github/renovate.json5 --check`
- `renovate-config-validator --no-global .github/renovate.json5`
- `git diff --check`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
