### PR TITLE
fix(theme/Nav): sync background transition with page

### DIFF
--- a/packages/core/src/theme/components/Nav/index.scss
+++ b/packages/core/src/theme/components/Nav/index.scss
@@ -1,7 +1,4 @@
 .rp-nav {
-  transition:
-    background-color 0.2s ease-in-out,
-    border-bottom 0.2s ease-in-out;
   display: flex;
   height: var(--rp-nav-height);
   flex-shrink: 0;


### PR DESCRIPTION
## Summary

This PR fixes a visual split during light/dark theme switching, where the nav background transitions independently from the page background. It removes the nav-specific background and border transitions so the nav follows the page transition and both backgrounds change in sync.

## Related Issue

Follow-up to #3017.

## Checklist

- [x] Tests updated (not required).
- [x] Documentation updated (not required).