### PR TITLE
fix(plugin-twoslash): stop tracking hover popup position outside of visible state

### DIFF
--- a/packages/plugin-twoslash/static/global-components/elements/TwoslashPopupContainer.ts
+++ b/packages/plugin-twoslash/static/global-components/elements/TwoslashPopupContainer.ts
@@ -133,8 +133,12 @@ class TwoslashPopupContainer extends HTMLElement {
     };
 
     const hidePopup = () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
       // Add a slight delay to avoid flickering when moving the mouse between the trigger and the popup.
       timeoutId = setTimeout(() => {
+        timeoutId = null;
         popup.dataset.state = 'hidden';
         stopTracking?.();
         stopTracking = null;
@@ -151,7 +155,14 @@ class TwoslashPopupContainer extends HTMLElement {
       trigger.removeEventListener('mouseleave', hidePopup);
       popup.removeEventListener('mouseenter', showPopup);
       popup.removeEventListener('mouseleave', hidePopup);
+
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+
       stopTracking?.();
+      stopTracking = null;
     };
   }
 }

--- a/packages/plugin-twoslash/static/global-components/elements/TwoslashPopupContainer.ts
+++ b/packages/plugin-twoslash/static/global-components/elements/TwoslashPopupContainer.ts
@@ -33,6 +33,9 @@ class TwoslashPopupContainer extends HTMLElement {
       element,
     );
 
+    TwoslashPopupPortal.instance.append(element);
+    element.dataset.initialized = 'true';
+
     // Position it once up front so it doesn't sit at the bottom of the page
     // (its unset `top`/`left` static position) before it's first shown.
     void updatePosition();
@@ -47,10 +50,6 @@ class TwoslashPopupContainer extends HTMLElement {
       element,
       cleanup: () => cleanups.forEach(cleanup => cleanup()),
     };
-    TwoslashPopupPortal.instance.append(this.#clone.element);
-
-    // Mark it as initialized to differentiate between the original and the clone.
-    this.#clone.element.dataset.initialized = 'true';
   }
 
   disconnectedCallback() {

--- a/packages/plugin-twoslash/static/global-components/elements/TwoslashPopupContainer.ts
+++ b/packages/plugin-twoslash/static/global-components/elements/TwoslashPopupContainer.ts
@@ -28,9 +28,19 @@ class TwoslashPopupContainer extends HTMLElement {
 
     // Clone it to avoid breaking React's rendering tree.
     const element = this.cloneNode(true) as TwoslashPopupContainer;
+    const { updatePosition, startTracking } = this.#createPositionTracker(
+      trigger,
+      element,
+    );
+
+    // Position it once up front so it doesn't sit at the bottom of the page
+    // (its unset `top`/`left` static position) before it's first shown.
+    void updatePosition();
     const cleanups = [
-      this.#registerUpdatePosition(trigger, element),
-      this.#registerPopupEvent(trigger, element),
+      // "always" popups need tracking for their whole lifetime; hover popups
+      // start/stop it themselves in #registerPopupEvent.
+      element.dataset.always === 'true' ? startTracking() : () => {},
+      this.#registerPopupEvent(trigger, element, startTracking),
     ];
 
     this.#clone = {
@@ -56,12 +66,12 @@ class TwoslashPopupContainer extends HTMLElement {
     );
   }
 
-  #registerUpdatePosition(
+  #createPositionTracker(
     trigger: TwoslashPopupTrigger,
     popup: TwoslashPopupContainer,
-  ): () => void {
+  ): { updatePosition: () => Promise<void>; startTracking: () => () => void } {
     const arrowElement = popup.findArrow();
-    return autoUpdate(trigger, popup, async () => {
+    const updatePosition = async () => {
       const position = await computePosition(trigger, popup, {
         placement: 'bottom-start',
         middleware: [
@@ -93,12 +103,18 @@ class TwoslashPopupContainer extends HTMLElement {
       arrowElement.style.left = `${position.middlewareData.arrow?.x}px`;
       arrowElement.style.top = `${position.middlewareData.arrow?.y}px`;
       arrowElement.dataset.side = position.placement;
-    });
+    };
+
+    return {
+      updatePosition,
+      startTracking: () => autoUpdate(trigger, popup, updatePosition),
+    };
   }
 
   #registerPopupEvent(
     trigger: TwoslashPopupTrigger,
     popup: TwoslashPopupContainer,
+    startTracking: () => () => void,
   ) {
     // If the popup is always visible, do nothing.
     if (popup.dataset.always === 'true') {
@@ -106,12 +122,14 @@ class TwoslashPopupContainer extends HTMLElement {
     }
 
     let timeoutId: NodeJS.Timeout | null = null;
+    let stopTracking: (() => void) | null = null;
 
     const showPopup = () => {
       if (timeoutId) {
         clearTimeout(timeoutId);
         timeoutId = null;
       }
+      stopTracking ??= startTracking();
       popup.dataset.state = 'show';
     };
 
@@ -119,6 +137,8 @@ class TwoslashPopupContainer extends HTMLElement {
       // Add a slight delay to avoid flickering when moving the mouse between the trigger and the popup.
       timeoutId = setTimeout(() => {
         popup.dataset.state = 'hidden';
+        stopTracking?.();
+        stopTracking = null;
       }, 100);
     };
 
@@ -132,6 +152,7 @@ class TwoslashPopupContainer extends HTMLElement {
       trigger.removeEventListener('mouseleave', hidePopup);
       popup.removeEventListener('mouseenter', showPopup);
       popup.removeEventListener('mouseleave', hidePopup);
+      stopTracking?.();
     };
   }
 }


### PR DESCRIPTION
## Summary

`TwoslashPopupContainer` started a floating-ui `autoUpdate()` (scroll/resize listeners + `ResizeObserver`) for **every** hover-triggered type-info popup as soon as it mounted, regardless of whether it was ever shown. On docs pages with many hoverable tokens in TS/TSX code blocks, this left dozens to hundreds of permanent listeners running on every single `scroll` event for the page's entire lifetime, even though at most one popup is ever visible at a time. On mobile this is enough main-thread work per scroll tick to cause visible scroll jank.

This PR starts position tracking only while a hover popup is actually shown (on `mouseenter`, stopped on `mouseleave`), and stops it once hidden. `data-always="true"` popups (e.g. `// ^?` query results) have no show/hide state and keep tracking continuously as before.

Since the popup is `position: absolute` with no `top`/`left` set until it's positioned, deferring tracking entirely until first hover would leave it at its DOM static position (the bottom of the page, since it's appended last to a portal) until then — inflating the page's scroll height even though it's invisible. To avoid that, each popup is still positioned once up front on mount, independent of continuous tracking.

## Related Issue

close #3602

## Screenshots

<!--- Required for theme or other visual changes. Add before and after screenshots when applicable. Otherwise, remove this section. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
