### PR TITLE
fix(ssg-md): include siteOrigin in Markdown links

### DIFF
--- a/e2e/fixtures/plugin-llms/doc/guide/index.mdx
+++ b/e2e/fixtures/plugin-llms/doc/guide/index.mdx
@@ -1,1 +1,3 @@
 # Guide
+
+Read the [API documentation](/api/).

--- a/e2e/fixtures/plugin-llms/index.test.ts
+++ b/e2e/fixtures/plugin-llms/index.test.ts
@@ -71,6 +71,14 @@ test.describe('plugin-llms', async () => {
     expect(llmsFullTxt).toContain(
       'url: https://example.com/docs/api/commands.md',
     );
+
+    const guideMd = await readFile(
+      path.resolve(appDir, 'doc_build', 'guide', 'index.md'),
+      'utf-8',
+    );
+    expect(guideMd).toContain(
+      '[API documentation](https://example.com/docs/api/index.md)',
+    );
   });
 
   test('should order llms.txt entries according to _meta.json', async () => {

--- a/e2e/fixtures/ssg-md/doc/index.mdx
+++ b/e2e/fixtures/ssg-md/doc/index.mdx
@@ -4,6 +4,8 @@ import { Tabs, Tab } from '@rspress/core/theme';
 
 Rspress uses [Shiki](https://shiki.style) for syntax highlighting at compile time, which means better runtime performance.
 
+Learn more about [MDX and React components](./components.mdx).
+
 When using code blocks in multiple languages, the corresponding language is automatically detected at compile time, and the runtime bundle size does not increase. For supported programming languages, refer to the [Shiki supported languages list](https://shiki.style/languages).
 
 ````mdx

--- a/e2e/fixtures/ssg-md/index.test.ts
+++ b/e2e/fixtures/ssg-md/index.test.ts
@@ -54,6 +54,9 @@ test('llms should be successful', async () => {
         '> For AI agents: the complete documentation index is available at https://example.com/docs/llms.txt, the full documentation bundle is available at https://example.com/docs/llms-full.txt.',
       ),
   ).toBeTruthy();
+  expect(indexMd).toContain(
+    '[MDX and React components](https://example.com/docs/components.md)',
+  );
 
   const indexHtml = await fs.readFile(
     path.join(docBuildDir, 'index.html'),

--- a/packages/core/src/node/mdx/options.ts
+++ b/packages/core/src/node/mdx/options.ts
@@ -95,6 +95,7 @@ export async function createMDXOptions(options: {
                 autoPrefix: true,
               },
               __base: config?.base,
+              __siteOrigin: config?.siteOrigin,
             }
           : {
               // we do cleanUrls in runtime side

--- a/packages/core/src/node/mdx/remarkPlugins/link.ts
+++ b/packages/core/src/node/mdx/remarkPlugins/link.ts
@@ -8,6 +8,7 @@ import {
   normalizeHref,
   parseUrl,
   withBase,
+  withSiteOrigin,
 } from '@rspress/shared';
 import { logger } from '@rspress/shared/logger';
 import type { Root } from 'mdast';
@@ -212,7 +213,8 @@ function normalizeLink(
   cleanUrls: boolean | string,
   autoPrefix: boolean,
   deadLinks: Map<string, string>,
-  __base?: string, // just for plugin-llms, we should normalize the link with base
+  __base?: string, // generated Markdown links should include the configured base
+  __siteOrigin?: string,
 ): NormalizedLink {
   if (!nodeUrl) {
     return { url: '' };
@@ -280,6 +282,9 @@ function normalizeLink(
   if (__base) {
     url = withBase(url, __base);
   }
+  if (__siteOrigin) {
+    url = withSiteOrigin(url, __siteOrigin);
+  }
   return { url, routePath, hash };
 }
 
@@ -295,12 +300,14 @@ export const remarkLink =
     remarkLinkOptions,
     lint,
     __base,
+    __siteOrigin,
   }: {
     cleanUrls: boolean | string;
     routeService: RouteService | null;
     remarkLinkOptions?: MarkdownOptions['link'];
     lint?: boolean;
     __base?: string;
+    __siteOrigin?: string;
   }) =>
   (tree: Root, file: VFile) => {
     const {
@@ -320,6 +327,7 @@ export const remarkLink =
         autoPrefix,
         deadLinks,
         __base,
+        __siteOrigin,
       );
       if (link.hash) {
         anchorLinks.set(nodeUrl, link);
@@ -337,6 +345,7 @@ export const remarkLink =
         autoPrefix,
         deadLinks,
         __base,
+        __siteOrigin,
       );
       if (link.hash) {
         anchorLinks.set(nodeUrl, link);

--- a/packages/core/src/node/mdx/remarkPlugins/link.ts
+++ b/packages/core/src/node/mdx/remarkPlugins/link.ts
@@ -214,7 +214,7 @@ function normalizeLink(
   autoPrefix: boolean,
   deadLinks: Map<string, string>,
   __base?: string, // generated Markdown links should include the configured base
-  __siteOrigin?: string,
+  __siteOrigin?: string, // make generated Markdown links absolute when siteOrigin is configured
 ): NormalizedLink {
   if (!nodeUrl) {
     return { url: '' };

--- a/packages/plugin-llms/src/normalizeMdFile.ts
+++ b/packages/plugin-llms/src/normalizeMdFile.ts
@@ -46,6 +46,7 @@ async function normalizeMdFile(
   filepath: string,
   routeService: RouteService,
   base: string,
+  siteOrigin: string | undefined,
   mdxToMd: boolean,
   isMd: boolean,
   remarkPlugins: PluggableList,
@@ -67,6 +68,7 @@ async function normalizeMdFile(
         autoPrefix: true,
       },
       __base: base,
+      __siteOrigin: siteOrigin,
     } satisfies Parameters<typeof remarkLink>[0])
     .use(remarkPlugins)
     .use(remarkStringify);

--- a/packages/plugin-llms/src/plugin.ts
+++ b/packages/plugin-llms/src/plugin.ts
@@ -114,6 +114,7 @@ const rsbuildPluginLlms = ({
               filepath,
               routeServiceRef.current!,
               baseRef.current,
+              siteOriginRef.current,
               typeof mdFiles !== 'boolean'
                 ? (mdFiles?.mdxToMd ?? false)
                 : false,


### PR DESCRIPTION
## Summary

Rspress currently applies `base` but not `siteOrigin` to internal links in generated Markdown pages, so deployed `.md` files contain origin-less URLs.

This change applies `siteOrigin` after Markdown route normalization in native SSG-MD and `plugin-llms`, while preserving external links, page anchors, and unresolved links. It also adds artifact E2E coverage for both generation paths.

## Related Links

- https://rspress.rs/guide/basic/custom-theme.md

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).