### PR TITLE
docs: add before and after guidance to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 
 ## Screenshots
 
-<!--- Required for theme or other visual changes. Add before and after screenshots when applicable. Otherwise, remove this section. -->
+<!--- Required for theme or other visual changes. You must provide a before / after comparison. Otherwise, remove this section. -->
 
 ## Checklist
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Summary
 
-<!--- Introduce what this PR changes and why. You must describe the behavior before and after this change. -->
+<!--- Please introduce what this PR changes and why. For behavior changes, include a before / after comparison to help reviewers understand the impact. -->
 
 ## Related Issue
 
@@ -8,7 +8,7 @@
 
 ## Screenshots
 
-<!--- Required for theme or other visual changes. You must provide a before / after comparison. Otherwise, remove this section. -->
+<!--- For theme or other visual changes, please include a before / after comparison to help reviewers understand the change. Otherwise, remove this section. -->
 
 ## Checklist
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 
 ## Screenshots
 
-<!--- For theme or other visual changes, please include a before / after comparison to help reviewers understand the change. Otherwise, remove this section. -->
+<!--- For theme or other visual changes, please include before and after screenshots to help reviewers understand the change. Otherwise, remove this section. -->
 
 ## Checklist
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
 ## Summary
 
+<!--- Introduce what this PR changes and why. You must describe the behavior before and after this change. -->
+
 ## Related Issue
 
 <!--- Provide link of related issues -->


### PR DESCRIPTION
## Summary

The PR template currently limits before / after guidance to screenshots, which can make expectations unclear for non-visual behavior changes. This PR adds friendly, context-focused guidance under Summary asking authors to explain what changed and why, and to include a before / after comparison for behavior changes. It also asks contributors making visual changes to include before and after screenshots so reviewers can quickly understand the impact.

## Related Issue

N/A

## Screenshots

N/A. This pull request only updates the pull request template guidance.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
