### PR TITLE
docs(homepage): add core feature sections to homepage

### DIFF
--- a/website/i18n.json
+++ b/website/i18n.json
@@ -147,6 +147,10 @@
     "zh": "主题定制：CSS 变量、布局插槽，或 rspress eject 弹出源码",
     "en": "Theme via CSS variables, layout slots, or rspress eject"
   },
+  "homeExtendPoint3": {
+    "zh": "使用 rspress-custom-theme skill，让 AI Agent 辅助完成主题定制",
+    "en": "Use the rspress-custom-theme skill to customize your theme with an AI agent"
+  },
   "homeExtendLink": {
     "zh": "开始定制",
     "en": "Start customizing"

--- a/website/i18n.json
+++ b/website/i18n.json
@@ -70,5 +70,85 @@
   "bannerHref": {
     "zh": "/zh/guide/start/ai#agent-skills",
     "en": "/guide/start/ai#agent-skills"
+  },
+  "homeSsgMdEyebrow": {
+    "zh": "SSG-MD · llms.txt",
+    "en": "SSG-MD · llms.txt"
+  },
+  "homeSsgMdTitle": {
+    "zh": "人看 HTML，\nAI 读 Markdown",
+    "en": "HTML for humans,\nMarkdown for AI"
+  },
+  "homeSsgMdDesc": {
+    "zh": "同一份源文件，两套产物。每个页面既是给人阅读的 HTML（SSG），也是给大语言模型的 Markdown 副本（SSG-MD），并遵循 llms.txt 规范生成站点级索引与全文。",
+    "en": "One source, two outputs. Every page is built as a fast HTML page for readers (SSG) and a clean Markdown twin for LLMs (SSG-MD), with site-wide llms.txt and llms-full.txt following the llms.txt standard."
+  },
+  "homeSsgMdPoint1": {
+    "zh": "每个页面都有 .md 副本，URL 中 .html 换成 .md 即可访问",
+    "en": "Every page gets a .md twin — swap .html for .md in the URL"
+  },
+  "homeSsgMdPoint2": {
+    "zh": "按导航结构生成 llms.txt 索引与 llms-full.txt 全文",
+    "en": "llms.txt index and llms-full.txt, ordered by your navigation"
+  },
+  "homeSsgMdPoint3": {
+    "zh": "MDX 组件渲染为干净的 Markdown，而非语法噪音",
+    "en": "MDX components render to clean Markdown, not syntax noise"
+  },
+  "homeSsgMdLink": {
+    "zh": "了解 SSG-MD",
+    "en": "Explore SSG-MD"
+  },
+  "homeNavEyebrow": {
+    "zh": "_nav.json / _meta.json",
+    "en": "_nav.json / _meta.json"
+  },
+  "homeNavTitle": {
+    "zh": "导航与侧边栏，自动生成",
+    "en": "Navigation that writes itself"
+  },
+  "homeNavDesc": {
+    "zh": "在内容旁边声明导航结构：Rspress 通过 _nav.json 和 _meta.json 生成导航栏与侧边栏，并支持热更新，结构调整即时生效。",
+    "en": "Declare the navbar and sidebar next to your content. Rspress generates them from _nav.json and _meta.json — with hot reload, so structure changes show up instantly."
+  },
+  "homeNavPoint1": {
+    "zh": "_nav.json 生成导航栏，各目录 _meta.json 生成侧边栏",
+    "en": "Navbar from _nav.json, per-directory sidebars from _meta.json"
+  },
+  "homeNavPoint2": {
+    "zh": "支持排序、标签、图标、分组标题、分隔线与自定义链接",
+    "en": "Order, labels, icons, section headers, dividers and custom links"
+  },
+  "homeNavPoint3": {
+    "zh": "页面元信息写在 frontmatter 中，与内容放在一起",
+    "en": "Page metadata stays in frontmatter, next to the content"
+  },
+  "homeNavLink": {
+    "zh": "了解自动生成导航",
+    "en": "Learn about auto nav & sidebar"
+  },
+  "homeExtendEyebrow": {
+    "zh": "插件与主题",
+    "en": "Plugins & Themes"
+  },
+  "homeExtendTitle": {
+    "zh": "扩展构建流程，定制主题外观",
+    "en": "Extend the build, shape the theme"
+  },
+  "homeExtendDesc": {
+    "zh": "通过插件机制介入构建的每个阶段，主题则可以从 CSS 变量一路定制到完全弹出的组件源码。",
+    "en": "Hook into every stage with the plugin system, and tailor the look from CSS variables to fully ejected components."
+  },
+  "homeExtendPoint1": {
+    "zh": "官方插件覆盖搜索、Sitemap、API 文档、组件预览等场景",
+    "en": "Official plugins for search, sitemap, API docs, previews and more"
+  },
+  "homeExtendPoint2": {
+    "zh": "主题定制：CSS 变量、布局插槽，或 rspress eject 弹出源码",
+    "en": "Theme via CSS variables, layout slots, or rspress eject"
+  },
+  "homeExtendLink": {
+    "zh": "开始定制",
+    "en": "Start customizing"
   }
 }

--- a/website/i18n.json
+++ b/website/i18n.json
@@ -150,5 +150,9 @@
   "homeExtendLink": {
     "zh": "开始定制",
     "en": "Start customizing"
+  },
+  "homeYourPlugin": {
+    "zh": "你的插件",
+    "en": "Your plugin"
   }
 }

--- a/website/theme/components/HomeSections/index.module.scss
+++ b/website/theme/components/HomeSections/index.module.scss
@@ -396,6 +396,7 @@
 
 /* scaled-down replica of the real LlmsCopyButton (.rp-llms-button) */
 .copyMdButton {
+  appearance: none;
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -410,6 +411,20 @@
   font-weight: 500;
   white-space: nowrap;
   box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    color 0.15s ease;
+
+  &:hover {
+    border-color: var(--rp-c-brand);
+    color: var(--rp-c-brand-dark);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--rp-c-brand);
+    outline-offset: 2px;
+  }
 
   svg {
     width: 12px;
@@ -555,6 +570,11 @@
   &[data-active] {
     box-shadow: inset 0 0 0 1.5px var(--rp-c-brand);
   }
+
+  &:focus-visible {
+    outline: 2px solid var(--rp-c-brand);
+    outline-offset: 1px;
+  }
 }
 
 .autoNavSidebar {
@@ -583,6 +603,11 @@
   border-radius: 8px;
   cursor: pointer;
   transition: box-shadow 0.15s ease;
+
+  &:focus-visible {
+    outline: 2px solid var(--rp-c-brand);
+    outline-offset: 1px;
+  }
 }
 
 .sidebarItem {
@@ -591,6 +616,11 @@
   color: var(--rp-c-text-1);
   cursor: pointer;
   transition: box-shadow 0.15s ease;
+
+  &:focus-visible {
+    outline: 2px solid var(--rp-c-brand);
+    outline-offset: 1px;
+  }
 
   &.sidebarItemActive {
     background-color: var(--rp-c-brand-tint);
@@ -608,6 +638,11 @@
   color: var(--rp-c-text-1);
   cursor: pointer;
   transition: box-shadow 0.15s ease;
+
+  &:focus-visible {
+    outline: 2px solid var(--rp-c-brand);
+    outline-offset: 1px;
+  }
 
   svg {
     width: 12px;

--- a/website/theme/components/HomeSections/index.module.scss
+++ b/website/theme/components/HomeSections/index.module.scss
@@ -1,0 +1,882 @@
+.root {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 1rem 1.5rem 0;
+}
+
+/* ---------- section shell ---------- */
+
+.section {
+  display: grid;
+  grid-template-columns: minmax(0, 5fr) minmax(0, 7fr);
+  gap: 4rem;
+  align-items: center;
+  padding: 4.5rem 0;
+
+  &.reverse {
+    grid-template-columns: minmax(0, 7fr) minmax(0, 5fr);
+
+    .text {
+      order: 2;
+    }
+
+    .visual {
+      order: 1;
+    }
+  }
+
+  @media (max-width: 960px) {
+    grid-template-columns: 1fr;
+    gap: 2.5rem;
+    padding: 3.5rem 0;
+
+    &.reverse {
+      grid-template-columns: 1fr;
+
+      .text {
+        order: 0;
+      }
+
+      .visual {
+        order: 1;
+      }
+    }
+  }
+}
+
+.text {
+  min-width: 0;
+}
+
+.visual {
+  min-width: 0;
+}
+
+.eyebrow {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background-color: var(--rp-c-brand-tint);
+  color: var(--rp-c-brand-dark);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  font-family: var(--rp-font-family-mono);
+}
+
+.title {
+  margin: 1rem 0 0;
+  font-size: 2rem;
+  line-height: 1.25;
+  font-weight: 700;
+  color: var(--rp-c-text-1);
+  text-wrap: balance;
+  white-space: pre-line;
+
+  @media (max-width: 640px) {
+    font-size: 1.6rem;
+  }
+}
+
+.description {
+  margin: 1rem 0 0;
+  font-size: 1rem;
+  line-height: 1.75;
+  color: var(--rp-c-text-2);
+}
+
+.points {
+  margin: 1.5rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+
+  li {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.6rem;
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: var(--rp-c-text-1);
+
+    svg {
+      flex-shrink: 0;
+      width: 1.1em;
+      height: 1.1em;
+      margin-top: 0.2em;
+      color: var(--rp-c-brand);
+    }
+  }
+}
+
+.link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-top: 1.75rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--rp-c-brand);
+  text-decoration: none;
+
+  svg {
+    width: 1em;
+    height: 1em;
+    transition: transform 0.2s ease;
+  }
+
+  &:hover {
+    text-decoration: underline;
+
+    svg {
+      transform: translateX(3px);
+    }
+  }
+}
+
+/* ---------- shared card ---------- */
+
+.card {
+  background-color: var(--rp-c-bg);
+  border: 1px solid var(--rp-c-divider-light);
+  border-radius: var(--rp-radius-large);
+  box-shadow: var(--rp-shadow-1);
+  overflow: hidden;
+  transition: box-shadow 0.3s ease;
+
+  &:hover {
+    box-shadow: var(--rp-shadow-2);
+  }
+}
+
+/* elevated cards keep their deeper shadow on hover */
+.llmsCard:hover,
+.slotsCard:hover {
+  box-shadow: var(--rp-shadow-3);
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--rp-c-divider-light);
+  background-color: var(--rp-c-bg-soft);
+  color: var(--rp-c-text-2);
+  font-size: 12px;
+  font-weight: 600;
+  font-family: var(--rp-font-family-mono);
+
+  svg {
+    width: 14px;
+    height: 14px;
+    color: var(--rp-c-brand);
+  }
+}
+
+.cardHeaderTitle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.treeLegend {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 500;
+  color: var(--rp-c-text-3);
+
+  span {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+  }
+
+  i {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+  }
+
+  .legendDotSsg {
+    background-color: var(--rp-c-text-3);
+  }
+
+  .legendDotSsgMd {
+    background-color: var(--rp-c-brand);
+  }
+}
+
+/* ---------- visual 1: SSG-MD ---------- */
+
+.ssgMdVisual {
+  display: flex;
+  align-items: flex-start;
+
+  @media (max-width: 480px) {
+    flex-direction: column;
+  }
+}
+
+.treeCard {
+  width: 62%;
+  flex-shrink: 0;
+
+  @media (max-width: 480px) {
+    width: 100%;
+  }
+}
+
+.tree {
+  padding: 12px 8px;
+  font-family: var(--rp-font-family-mono);
+  font-size: 13px;
+}
+
+.treeRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 12px;
+  border-radius: 6px;
+  color: var(--rp-c-text-2);
+
+  svg {
+    flex-shrink: 0;
+    width: 15px;
+    height: 15px;
+    color: var(--rp-c-text-3);
+  }
+
+  &.treeRowAccent {
+    color: var(--rp-c-text-1);
+
+    svg {
+      color: var(--rp-c-brand);
+    }
+  }
+
+  &.treeRowCurrent {
+    box-shadow: inset 0 0 0 1.5px var(--rp-c-brand);
+
+    &:not(.treeRowAccent) {
+      color: var(--rp-c-text-1);
+    }
+  }
+
+  transition: box-shadow 0.2s ease;
+}
+
+.treeTag {
+  margin-left: 2px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background-color: var(--rp-c-bg-mute);
+  color: var(--rp-c-text-3);
+  font-size: 10px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+/* tabbed preview card */
+
+.tabHeader {
+  display: flex;
+  gap: 2px;
+  padding: 8px 10px 0;
+  border-bottom: 1px solid var(--rp-c-divider-light);
+  background-color: var(--rp-c-bg-soft);
+  overflow-x: auto;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.tab {
+  appearance: none;
+  border: none;
+  background: transparent;
+  margin-bottom: -1px;
+  padding: 6px 8px 8px;
+  border-bottom: 2px solid transparent;
+  font-family: var(--rp-font-family-mono);
+  font-size: 11.5px;
+  font-weight: 500;
+  color: var(--rp-c-text-3);
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease;
+
+  &:hover {
+    color: var(--rp-c-text-1);
+  }
+}
+
+.tabActive {
+  color: var(--rp-c-brand-dark);
+  border-bottom-color: var(--rp-c-brand);
+  font-weight: 600;
+
+  &:hover {
+    color: var(--rp-c-brand-dark);
+  }
+}
+
+/* stack all panels in one grid cell so the card height
+   stays constant (tallest panel) and tab switches don't shift layout */
+.tabPanels {
+  display: grid;
+}
+
+.tabPanel {
+  grid-area: 1 / 1;
+  min-width: 0;
+}
+
+.tabPanelVisible {
+  animation: tabIn 0.25s ease;
+}
+
+.tabPanelHidden {
+  visibility: hidden;
+}
+
+@keyframes tabIn {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabPanelVisible {
+    animation: none;
+  }
+}
+
+.pagePreview {
+  padding: 14px 18px 16px;
+}
+
+.pageHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.pageTitle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--rp-c-text-1);
+
+  &::before {
+    content: '#';
+    color: var(--rp-c-brand);
+    font-weight: 600;
+  }
+}
+
+/* scaled-down replica of the real LlmsCopyButton (.rp-llms-button) */
+.copyMdButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 26px;
+  padding: 0 9px;
+  flex-shrink: 0;
+  border-radius: 7px;
+  border: 1px solid var(--rp-c-divider-light);
+  background: var(--rp-c-bg);
+  color: var(--rp-c-text-2);
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+
+  svg {
+    width: 12px;
+    height: 12px;
+  }
+}
+
+.pageText {
+  height: 10px;
+  border-radius: 4px;
+  background-color: var(--rp-c-bg-mute);
+  margin-top: 10px;
+}
+
+.pageCode {
+  margin-top: 12px;
+  border: 1px solid var(--rp-c-divider-light);
+  border-radius: var(--rp-radius);
+  overflow: hidden;
+}
+
+.pageCodeTitle {
+  padding: 5px 10px;
+  font-size: 10.5px;
+  font-family: var(--rp-font-family-mono);
+  color: var(--rp-c-text-2);
+  background-color: var(--rp-c-bg-soft);
+  border-bottom: 1px solid var(--rp-c-divider-light);
+}
+
+.pageCodeBody {
+  display: flex;
+  flex-direction: column;
+  padding: 10px 12px;
+  font-family: var(--rp-font-family-mono);
+  font-size: 11px;
+  line-height: 1.7;
+  color: var(--rp-c-text-2);
+  white-space: pre;
+  overflow-x: auto;
+}
+
+.mdText {
+  color: var(--rp-c-text-2);
+}
+
+.mdFence {
+  color: var(--rp-c-text-3);
+  margin-top: 4px;
+
+  &:last-child {
+    margin-top: 0;
+  }
+}
+
+.llmsCard {
+  position: relative;
+  z-index: 1;
+  width: 56%;
+  min-width: 0;
+  margin: 4.5rem 0 2rem -18%;
+  box-shadow: var(--rp-shadow-3);
+
+  @media (max-width: 480px) {
+    width: calc(100% - 1.5rem);
+    margin: -0.75rem 0 0 1.5rem;
+  }
+}
+
+.llmsContent {
+  padding: 14px 18px;
+  font-family: var(--rp-font-family-mono);
+  font-size: 12px;
+  line-height: 1.8;
+  color: var(--rp-c-text-2);
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.llmsTitle {
+  color: var(--rp-c-text-1);
+  font-weight: 700;
+  font-size: 13px;
+}
+
+.llmsQuote {
+  color: var(--rp-c-text-3);
+  border-left: 2px solid var(--rp-c-divider);
+  padding-left: 8px;
+  margin: 4px 0;
+}
+
+.llmsH2 {
+  color: var(--rp-c-text-1);
+  font-weight: 600;
+  margin-top: 6px;
+}
+
+.llmsItem span {
+  color: var(--rp-c-brand);
+}
+
+/* ---------- visual 2: auto nav & sidebar ---------- */
+
+.autoNavCard {
+  display: flex;
+  align-items: stretch;
+
+  @media (max-width: 640px) {
+    flex-direction: column;
+  }
+}
+
+.autoNavCode {
+  flex: 1;
+  min-width: 0;
+
+  .cardHeader {
+    border-bottom: none;
+    background-color: transparent;
+    padding-bottom: 0;
+  }
+}
+
+.codeContent {
+  margin: 0;
+  padding: 12px 16px 16px;
+  font-size: 12.5px;
+  font-family: var(--rp-font-family-mono);
+  color: var(--shiki-foreground, var(--rp-c-text-1));
+  line-height: 1.7;
+  white-space: pre;
+  overflow-x: auto;
+}
+
+.codeGroup {
+  margin: 0 -6px;
+  padding: 0 6px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: box-shadow 0.15s ease;
+
+  &[data-active] {
+    box-shadow: inset 0 0 0 1.5px var(--rp-c-brand);
+  }
+}
+
+.autoNavSidebar {
+  width: 180px;
+  flex-shrink: 0;
+  padding: 16px 14px;
+  border-left: 1px solid var(--rp-c-divider-light);
+  background-color: var(--rp-c-bg);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 14px;
+
+  @media (max-width: 640px) {
+    width: 100%;
+    border-left: none;
+    border-top: 1px solid var(--rp-c-divider-light);
+  }
+}
+
+.sidebarSectionHeader {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--rp-c-text-1);
+  padding: 4px 10px 6px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: box-shadow 0.15s ease;
+}
+
+.sidebarItem {
+  padding: 6px 10px;
+  border-radius: 8px;
+  color: var(--rp-c-text-1);
+  cursor: pointer;
+  transition: box-shadow 0.15s ease;
+
+  &.sidebarItemActive {
+    background-color: var(--rp-c-brand-tint);
+    color: var(--rp-c-brand-dark);
+    font-weight: 500;
+  }
+}
+
+.sidebarDir {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 10px;
+  border-radius: 8px;
+  color: var(--rp-c-text-1);
+  cursor: pointer;
+  transition: box-shadow 0.15s ease;
+
+  svg {
+    width: 12px;
+    height: 12px;
+    color: var(--rp-c-text-3);
+  }
+}
+
+/* inspect wiring: rounded outline frame only, no fill or text-color change */
+.sidebarItem.wireTarget,
+.sidebarDir.wireTarget,
+.sidebarSectionHeader.wireTarget {
+  box-shadow: inset 0 0 0 1.5px var(--rp-c-brand);
+}
+
+/* ---------- visual 3: plugin ecosystem + layout slots ---------- */
+
+.extendVisual {
+  display: flex;
+  flex-direction: column;
+}
+
+.pluginsCard {
+  width: 88%;
+
+  @media (max-width: 480px) {
+    width: 100%;
+  }
+}
+
+.slotsCard {
+  position: relative;
+  z-index: 1;
+  width: 88%;
+  align-self: flex-end;
+  margin-top: -2rem;
+  box-shadow: var(--rp-shadow-3);
+
+  @media (max-width: 480px) {
+    width: calc(100% - 1.5rem);
+  }
+}
+
+.pluginGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  padding: 14px 14px 3rem;
+}
+
+.pluginTile {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--rp-c-divider-light);
+  border-radius: var(--rp-radius);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--rp-c-text-1);
+  text-decoration: none;
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease,
+    transform 0.2s ease;
+
+  svg {
+    flex-shrink: 0;
+    width: 16px;
+    height: 16px;
+    color: var(--rp-c-text-2);
+    transition: color 0.2s ease;
+  }
+
+  &:hover {
+    border-color: var(--rp-c-brand);
+    background-color: var(--rp-c-brand-tint);
+    transform: translateY(-2px);
+
+    svg {
+      color: var(--rp-c-brand);
+    }
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--rp-c-brand);
+    outline-offset: 2px;
+  }
+}
+
+.pluginTileDashed {
+  border-style: dashed;
+  color: var(--rp-c-text-2);
+}
+
+.wire {
+  padding: 14px;
+}
+
+.wireNav {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--rp-c-divider-light);
+  border-radius: var(--rp-radius) var(--rp-radius) 0 0;
+  background-color: var(--rp-c-bg-soft);
+}
+
+.wireLogo {
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: linear-gradient(
+    135deg,
+    var(--rp-c-brand-light),
+    var(--rp-c-brand-dark)
+  );
+}
+
+.wireBody {
+  display: flex;
+  min-height: 120px;
+  border: 1px solid var(--rp-c-divider-light);
+  border-top: none;
+  border-radius: 0 0 var(--rp-radius) var(--rp-radius);
+  overflow: hidden;
+}
+
+.wireSidebar {
+  width: 42%;
+  flex-shrink: 0;
+  border-right: 1px solid var(--rp-c-divider-light);
+  background-color: var(--rp-c-bg-soft);
+  padding: 12px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.wireContent {
+  flex: 1;
+  min-width: 0;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.wireDocTitle {
+  height: 12px;
+  width: 45%;
+  border-radius: 4px;
+  background-color: var(--rp-c-text-3);
+}
+
+.wireLine {
+  height: 8px;
+  border-radius: 4px;
+  background-color: var(--rp-c-bg-mute);
+}
+
+.slotChip {
+  display: inline-block;
+  width: fit-content;
+  padding: 2px 8px;
+  border-radius: 6px;
+  background-color: var(--rp-c-brand-tint);
+  color: var(--rp-c-brand-dark);
+  font-family: var(--rp-font-family-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  white-space: nowrap;
+  transition: transform 0.2s ease;
+}
+
+.wireNav,
+.wireSidebar,
+.wireContent {
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background-color: var(--rp-c-brand-tint);
+
+    .slotChip {
+      transform: scale(1.06);
+    }
+  }
+}
+
+/* ---------- entrance & ambient animations ---------- */
+
+@media (prefers-reduced-motion: no-preference) {
+  @supports (animation-timeline: view()) {
+    .section {
+      animation: sectionIn ease-out both;
+      animation-timeline: view();
+      animation-range: entry 0% entry 35%;
+    }
+
+    .staggerRise {
+      animation: childRise ease-out both;
+      animation-timeline: view();
+      animation-range: entry calc(var(--i, 0) * 3%) entry
+        calc(22% + var(--i, 0) * 3%);
+    }
+
+    .staggerFade {
+      animation: childFade ease-out both;
+      animation-timeline: view();
+      animation-range: entry calc(var(--i, 0) * 3%) entry
+        calc(22% + var(--i, 0) * 3%);
+    }
+  }
+}
+
+@keyframes sectionIn {
+  from {
+    opacity: 0;
+    transform: translateY(32px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes childRise {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes childFade {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+/* ---------- syntax token mocks (same as HeroInteractive) ---------- */
+
+.keyword {
+  color: var(--shiki-token-keyword);
+}
+
+.string {
+  color: var(--shiki-token-string);
+}
+
+.function {
+  color: var(--shiki-token-function);
+}
+
+.punctuation {
+  color: var(--shiki-token-punctuation);
+}
+
+.constant {
+  color: var(--shiki-token-constant);
+}

--- a/website/theme/components/HomeSections/index.tsx
+++ b/website/theme/components/HomeSections/index.tsx
@@ -1,0 +1,619 @@
+import { useI18n, useLang } from '@rspress/core/runtime';
+import {
+  IconArrowRight,
+  IconCopy,
+  IconFile,
+  IconSuccess,
+  Link,
+} from '@rspress/core/theme-original';
+import {
+  type CSSProperties,
+  type PropsWithChildren,
+  type ReactNode,
+  useState,
+} from 'react';
+import styles from './index.module.scss';
+
+/* ---------- syntax token helpers (same vars as HeroInteractive) ---------- */
+
+const S = ({ children }: PropsWithChildren) => (
+  <span className={styles.string}>{children}</span>
+);
+const P = ({ children }: PropsWithChildren) => (
+  <span className={styles.punctuation}>{children}</span>
+);
+const C = ({ children }: PropsWithChildren) => (
+  <span className={styles.constant}>{children}</span>
+);
+const Line = ({ children }: PropsWithChildren) => (
+  <div className="line">{children}</div>
+);
+
+const IconFolder = () => (
+  <svg width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor">
+    <path d="M3 5a2 2 0 0 1 2-2h4.2a2 2 0 0 1 1.6.8L12.2 5H19a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5z" />
+  </svg>
+);
+
+/* ---------- section shell ---------- */
+
+function Section(props: {
+  eyebrow: string;
+  title: string;
+  description: string;
+  points: string[];
+  linkText: string;
+  linkHref: string;
+  reverse?: boolean;
+  visual: ReactNode;
+}) {
+  return (
+    <section
+      className={`${styles.section} ${props.reverse ? styles.reverse : ''}`}
+    >
+      <div className={styles.text}>
+        <span className={styles.eyebrow}>{props.eyebrow}</span>
+        <h2 className={styles.title}>{props.title}</h2>
+        <p className={styles.description}>{props.description}</p>
+        <ul className={styles.points}>
+          {props.points.map(point => (
+            <li key={point}>
+              <IconSuccess />
+              <span>{point}</span>
+            </li>
+          ))}
+        </ul>
+        <Link className={styles.link} href={props.linkHref}>
+          {props.linkText}
+          <IconArrowRight />
+        </Link>
+      </div>
+      <div className={styles.visual}>{props.visual}</div>
+    </section>
+  );
+}
+
+/* ---------- visual 1: SSG-MD output tree + tabbed preview ---------- */
+
+function TreeRow(props: {
+  depth: number;
+  type: 'folder' | 'file';
+  name: string;
+  index?: number;
+  accent?: boolean;
+  current?: boolean;
+  tag?: string;
+}) {
+  return (
+    <div
+      className={`${styles.treeRow} ${styles.staggerRise} ${props.accent ? styles.treeRowAccent : ''} ${props.current ? styles.treeRowCurrent : ''}`}
+      style={
+        {
+          paddingLeft: props.depth * 20 + 12,
+          '--i': props.index ?? 0,
+        } as CSSProperties
+      }
+    >
+      {props.type === 'folder' ? <IconFolder /> : <IconFile />}
+      <span>{props.name}</span>
+      {props.tag ? <em className={styles.treeTag}>{props.tag}</em> : null}
+    </div>
+  );
+}
+
+type SsgMdTab = 'html' | 'md' | 'llms';
+
+const SSG_MD_TABS = [
+  { key: 'html', label: 'introduction.html' },
+  { key: 'md', label: 'introduction.md' },
+  { key: 'llms', label: 'llms.txt' },
+] as const;
+
+function SsgMdVisual() {
+  const [tab, setTab] = useState<SsgMdTab>('md');
+
+  return (
+    <div className={styles.ssgMdVisual}>
+      <div className={`${styles.card} ${styles.treeCard}`}>
+        <div className={styles.cardHeader}>
+          <div className={styles.cardHeaderTitle}>
+            <IconFolder />
+            <span>doc_build</span>
+          </div>
+          <div className={styles.treeLegend}>
+            <span>
+              <i className={styles.legendDotSsg} />
+              SSG
+            </span>
+            <span>
+              <i className={styles.legendDotSsgMd} />
+              SSG-MD
+            </span>
+          </div>
+        </div>
+        <div className={styles.tree}>
+          <TreeRow index={0} depth={0} type="folder" name="guide" />
+          <TreeRow index={1} depth={1} type="folder" name="start" />
+          <TreeRow
+            index={2}
+            depth={2}
+            type="file"
+            name="introduction.html"
+            current={tab === 'html'}
+          />
+          <TreeRow
+            index={3}
+            depth={2}
+            type="file"
+            name="introduction.md"
+            accent
+            current={tab === 'md'}
+          />
+          <TreeRow
+            index={4}
+            depth={0}
+            type="file"
+            name="llms.txt"
+            accent
+            current={tab === 'llms'}
+            tag="index"
+          />
+          <TreeRow
+            index={5}
+            depth={0}
+            type="file"
+            name="llms-full.txt"
+            accent
+            current={tab === 'llms'}
+            tag="full"
+          />
+        </div>
+      </div>
+      <div className={`${styles.card} ${styles.llmsCard}`}>
+        <div className={styles.tabHeader}>
+          {SSG_MD_TABS.map(({ key, label }) => (
+            <button
+              key={key}
+              type="button"
+              className={`${styles.tab} ${tab === key ? styles.tabActive : ''}`}
+              onClick={() => setTab(key)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        <div className={styles.tabPanels}>
+          <div
+            className={`${styles.tabPanel} ${tab === 'html' ? styles.tabPanelVisible : styles.tabPanelHidden}`}
+          >
+            <div className={styles.pagePreview}>
+              <div className={styles.pageHead}>
+                <div className={styles.pageTitle}>Introduction</div>
+                <div className={styles.copyMdButton}>
+                  <IconCopy />
+                  <span>Copy Markdown</span>
+                </div>
+              </div>
+              <div className={styles.pageText} style={{ width: '94%' }} />
+              <div className={styles.pageText} style={{ width: '80%' }} />
+              <div className={styles.pageCode}>
+                <div className={styles.pageCodeTitle}>index.ts</div>
+                <div className={styles.pageCodeBody}>
+                  <span>console.log('Hello Rspress');</span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className={`${styles.tabPanel} ${tab === 'md' ? styles.tabPanelVisible : styles.tabPanelHidden}`}
+          >
+            <div className={styles.llmsContent}>
+              <div className={styles.llmsTitle}># Introduction</div>
+              <div className={styles.mdText}>
+                Rspress is a lightning fast static site
+              </div>
+              <div className={styles.mdText}>generator based on Rsbuild.</div>
+              <div className={styles.mdFence}>{'```'}ts title="index.ts"</div>
+              <div className={styles.mdText}>console.log('Hello Rspress');</div>
+              <div className={styles.mdFence}>{'```'}</div>
+            </div>
+          </div>
+          <div
+            className={`${styles.tabPanel} ${tab === 'llms' ? styles.tabPanelVisible : styles.tabPanelHidden}`}
+          >
+            <div className={styles.llmsContent}>
+              <div className={styles.llmsTitle}># Rspress</div>
+              <div className={styles.llmsQuote}>
+                Lightning fast static site generator
+              </div>
+              <div className={styles.llmsH2}>## Docs</div>
+              <div className={styles.llmsItem}>
+                - <span>[Introduction](/guide/introduction.md)</span>
+              </div>
+              <div className={styles.llmsItem}>
+                - <span>[Quick Start](/guide/getting-started.md)</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ---------- visual 2: _meta.json -> sidebar (hover wiring) ---------- */
+
+function AutoNavVisual() {
+  const [wiring, setWiring] = useState<string | null>(null);
+  const wireHandlers = (id: string) => ({
+    onMouseEnter: () => setWiring(id),
+    onMouseLeave: () => setWiring(null),
+  });
+  // bijective: hovering either side frames both the source and its counterpart
+  const ringFor = (id: string) => (wiring === id ? true : undefined);
+  const targetClass = (id: string, base: string) =>
+    `${base} ${ringFor(id) ? styles.wireTarget : ''}`;
+
+  return (
+    <div className={`${styles.card} ${styles.autoNavCard}`}>
+      <div className={styles.autoNavCode}>
+        <div className={styles.cardHeader}>
+          <div className={styles.cardHeaderTitle}>
+            <IconFile />
+            <span>docs/guide/_meta.json</span>
+          </div>
+        </div>
+        <pre className={styles.codeContent}>
+          <code>
+            <Line>
+              <P>[</P>
+            </Line>
+            <div
+              className={styles.codeGroup}
+              data-active={ringFor('header')}
+              {...wireHandlers('header')}
+            >
+              <Line>
+                {'  '}
+                <P>{'{'}</P>
+              </Line>
+              <Line>
+                {'    '}
+                <C>"type"</C>
+                <P>:</P> <S>"section-header"</S>
+                <P>,</P>
+              </Line>
+              <Line>
+                {'    '}
+                <C>"label"</C>
+                <P>:</P> <S>"Guide"</S>
+              </Line>
+              <Line>
+                {'  '}
+                <P>{'},'}</P>
+              </Line>
+            </div>
+            <div
+              className={styles.codeGroup}
+              data-active={ringFor('introduction')}
+              {...wireHandlers('introduction')}
+            >
+              <Line>
+                {'  '}
+                <S>"introduction"</S>
+                <P>,</P>
+              </Line>
+            </div>
+            <div
+              className={styles.codeGroup}
+              data-active={ringFor('quick-start')}
+              {...wireHandlers('quick-start')}
+            >
+              <Line>
+                {'  '}
+                <S>"quick-start"</S>
+                <P>,</P>
+              </Line>
+            </div>
+            <div
+              className={styles.codeGroup}
+              data-active={ringFor('advanced')}
+              {...wireHandlers('advanced')}
+            >
+              <Line>
+                {'  '}
+                <P>{'{'}</P>
+              </Line>
+              <Line>
+                {'    '}
+                <C>"type"</C>
+                <P>:</P> <S>"dir"</S>
+                <P>,</P>
+              </Line>
+              <Line>
+                {'    '}
+                <C>"name"</C>
+                <P>:</P> <S>"advanced"</S>
+              </Line>
+              <Line>
+                {'  '}
+                <P>{'}'}</P>
+              </Line>
+            </div>
+            <Line>
+              <P>]</P>
+            </Line>
+          </code>
+        </pre>
+      </div>
+      <div className={styles.autoNavSidebar}>
+        <div
+          className={targetClass('header', styles.sidebarSectionHeader)}
+          {...wireHandlers('header')}
+        >
+          Guide
+        </div>
+        <div
+          className={targetClass(
+            'introduction',
+            `${styles.sidebarItem} ${styles.sidebarItemActive}`,
+          )}
+          {...wireHandlers('introduction')}
+        >
+          Introduction
+        </div>
+        <div
+          className={targetClass('quick-start', styles.sidebarItem)}
+          {...wireHandlers('quick-start')}
+        >
+          Quick Start
+        </div>
+        <div
+          className={targetClass('advanced', styles.sidebarDir)}
+          {...wireHandlers('advanced')}
+        >
+          Advanced
+          <IconArrowRight />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ---------- visual 3: plugin ecosystem + layout slots ---------- */
+
+const stroke = (paths: ReactNode) => (
+  <svg
+    width="1em"
+    height="1em"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    {paths}
+  </svg>
+);
+
+const IconGrid = () =>
+  stroke(
+    <>
+      <rect x="3" y="3" width="7" height="7" rx="1" />
+      <rect x="14" y="3" width="7" height="7" rx="1" />
+      <rect x="14" y="14" width="7" height="7" rx="1" />
+      <rect x="3" y="14" width="7" height="7" rx="1" />
+    </>,
+  );
+const IconMagnifier = () =>
+  stroke(
+    <>
+      <circle cx="11" cy="11" r="7" />
+      <path d="m21 21-4.3-4.3" />
+    </>,
+  );
+const IconCode = () =>
+  stroke(
+    <>
+      <polyline points="16 18 22 12 16 6" />
+      <polyline points="8 6 2 12 8 18" />
+    </>,
+  );
+const IconNodes = () =>
+  stroke(
+    <>
+      <rect x="9" y="2" width="6" height="5" rx="1" />
+      <rect x="2" y="17" width="6" height="5" rx="1" />
+      <rect x="16" y="17" width="6" height="5" rx="1" />
+      <path d="M12 7v3m0 0H5v7m7-7h7v7" />
+    </>,
+  );
+const IconBook = () =>
+  stroke(
+    <>
+      <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+      <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+    </>,
+  );
+const IconEye = () =>
+  stroke(
+    <>
+      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+      <circle cx="12" cy="12" r="3" />
+    </>,
+  );
+const IconPlay = () =>
+  stroke(
+    <>
+      <circle cx="12" cy="12" r="10" />
+      <polygon points="10 8 16 12 10 16 10 8" />
+    </>,
+  );
+const IconRss = () =>
+  stroke(
+    <>
+      <path d="M4 11a9 9 0 0 1 9 9" />
+      <path d="M4 4a16 16 0 0 1 16 16" />
+      <circle cx="5" cy="19" r="1" fill="currentColor" stroke="none" />
+    </>,
+  );
+const IconPlus = () =>
+  stroke(
+    <>
+      <path d="M12 5v14" />
+      <path d="M5 12h14" />
+    </>,
+  );
+const IconLayout = () =>
+  stroke(
+    <>
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <path d="M3 9h18" />
+      <path d="M9 21V9" />
+    </>,
+  );
+
+const PLUGINS = [
+  {
+    name: 'Preview',
+    icon: <IconEye />,
+    link: '/plugin/official-plugins/preview',
+  },
+  {
+    name: 'Playground',
+    icon: <IconPlay />,
+    link: '/plugin/official-plugins/playground',
+  },
+  {
+    name: 'Algolia',
+    icon: <IconMagnifier />,
+    link: '/plugin/official-plugins/algolia',
+  },
+  {
+    name: 'Twoslash',
+    icon: <IconCode />,
+    link: '/plugin/official-plugins/twoslash',
+  },
+  {
+    name: 'Typedoc',
+    icon: <IconBook />,
+    link: '/plugin/official-plugins/typedoc',
+  },
+  {
+    name: 'Sitemap',
+    icon: <IconNodes />,
+    link: '/plugin/official-plugins/sitemap',
+  },
+  { name: 'RSS', icon: <IconRss />, link: '/plugin/official-plugins/rss' },
+];
+
+function ExtendVisual({ langPrefix = '' }: { langPrefix?: string }) {
+  return (
+    <div className={styles.extendVisual}>
+      <div className={`${styles.card} ${styles.pluginsCard}`}>
+        <div className={styles.cardHeader}>
+          <div className={styles.cardHeaderTitle}>
+            <IconGrid />
+            <span>@rspress/plugin-*</span>
+          </div>
+        </div>
+        <div className={styles.pluginGrid}>
+          {PLUGINS.map((plugin, index) => (
+            <Link
+              key={plugin.name}
+              className={`${styles.pluginTile} ${styles.staggerFade}`}
+              style={{ '--i': index } as CSSProperties}
+              href={`${langPrefix}${plugin.link}`}
+            >
+              {plugin.icon}
+              <span>{plugin.name}</span>
+            </Link>
+          ))}
+          <Link
+            className={`${styles.pluginTile} ${styles.pluginTileDashed} ${styles.staggerFade}`}
+            style={{ '--i': PLUGINS.length } as CSSProperties}
+            href={`${langPrefix}/plugin/system/write-a-plugin`}
+          >
+            <IconPlus />
+            <span>Your plugin</span>
+          </Link>
+        </div>
+      </div>
+      <div className={`${styles.card} ${styles.slotsCard}`}>
+        <div className={styles.cardHeader}>
+          <div className={styles.cardHeaderTitle}>
+            <IconLayout />
+            <span>theme/index.tsx · slots</span>
+          </div>
+        </div>
+        <div className={styles.wire}>
+          <div className={styles.wireNav}>
+            <div className={styles.wireLogo} />
+            <span className={styles.slotChip}>beforeNavTitle</span>
+          </div>
+          <div className={styles.wireBody}>
+            <div className={styles.wireSidebar}>
+              <span className={styles.slotChip}>beforeSidebar</span>
+              <div className={styles.wireLine} style={{ width: '80%' }} />
+              <div className={styles.wireLine} style={{ width: '60%' }} />
+              <div className={styles.wireLine} style={{ width: '70%' }} />
+            </div>
+            <div className={styles.wireContent}>
+              <div className={styles.wireDocTitle} />
+              <span className={styles.slotChip}>beforeDocContent</span>
+              <div className={styles.wireLine} style={{ width: '95%' }} />
+              <div className={styles.wireLine} style={{ width: '80%' }} />
+              <div className={styles.wireLine} style={{ width: '85%' }} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ---------- entry ---------- */
+
+export function HomeSections() {
+  const t = useI18n<typeof import('i18n')>();
+  const lang = useLang();
+  const prefix = lang === 'zh' ? '/zh' : '';
+
+  return (
+    <div className={styles.root}>
+      <Section
+        eyebrow={t('homeSsgMdEyebrow')}
+        title={t('homeSsgMdTitle')}
+        description={t('homeSsgMdDesc')}
+        points={[
+          t('homeSsgMdPoint1'),
+          t('homeSsgMdPoint2'),
+          t('homeSsgMdPoint3'),
+        ]}
+        linkText={t('homeSsgMdLink')}
+        linkHref={`${prefix}/guide/basic/ssg-md`}
+        visual={<SsgMdVisual />}
+      />
+      <Section
+        eyebrow={t('homeNavEyebrow')}
+        title={t('homeNavTitle')}
+        description={t('homeNavDesc')}
+        points={[t('homeNavPoint1'), t('homeNavPoint2'), t('homeNavPoint3')]}
+        linkText={t('homeNavLink')}
+        linkHref={`${prefix}/guide/basic/auto-nav-sidebar`}
+        reverse
+        visual={<AutoNavVisual />}
+      />
+      <Section
+        eyebrow={t('homeExtendEyebrow')}
+        title={t('homeExtendTitle')}
+        description={t('homeExtendDesc')}
+        points={[t('homeExtendPoint1'), t('homeExtendPoint2')]}
+        linkText={t('homeExtendLink')}
+        linkHref={`${prefix}/guide/basic/custom-theme`}
+        visual={<ExtendVisual langPrefix={prefix} />}
+      />
+    </div>
+  );
+}

--- a/website/theme/components/HomeSections/index.tsx
+++ b/website/theme/components/HomeSections/index.tsx
@@ -714,7 +714,11 @@ export function HomeSections() {
         eyebrow={t('homeExtendEyebrow')}
         title={t('homeExtendTitle')}
         description={t('homeExtendDesc')}
-        points={[t('homeExtendPoint1'), t('homeExtendPoint2')]}
+        points={[
+          t('homeExtendPoint1'),
+          t('homeExtendPoint2'),
+          t('homeExtendPoint3'),
+        ]}
         linkText={t('homeExtendLink')}
         linkHref={`${prefix}/guide/basic/custom-theme`}
         visual={

--- a/website/theme/components/HomeSections/index.tsx
+++ b/website/theme/components/HomeSections/index.tsx
@@ -1,5 +1,6 @@
 import { useI18n, useLang } from '@rspress/core/runtime';
 import {
+  copyToClipboard,
   IconArrowRight,
   IconCopy,
   IconFile,
@@ -8,8 +9,11 @@ import {
 } from '@rspress/core/theme-original';
 import {
   type CSSProperties,
+  type KeyboardEvent,
   type PropsWithChildren,
   type ReactNode,
+  useEffect,
+  useRef,
   useState,
 } from 'react';
 import styles from './index.module.scss';
@@ -109,8 +113,74 @@ const SSG_MD_TABS = [
   { key: 'llms', label: 'llms.txt' },
 ] as const;
 
-function SsgMdVisual() {
+const INTRODUCTION_MARKDOWN = `# Introduction
+
+Rspress is a lightning fast static site generator based on Rsbuild.
+
+\`\`\`ts title="index.ts"
+console.log('Hello Rspress');
+\`\`\``;
+
+function SsgMdVisual(props: { copyText: string; copiedText: string }) {
   const [tab, setTab] = useState<SsgMdTab>('md');
+  const [copied, setCopied] = useState(false);
+  const copyTimer = useRef<number | null>(null);
+  const tabRefs = useRef<Record<SsgMdTab, HTMLButtonElement | null>>({
+    html: null,
+    md: null,
+    llms: null,
+  });
+
+  useEffect(
+    () => () => {
+      if (copyTimer.current) {
+        window.clearTimeout(copyTimer.current);
+      }
+    },
+    [],
+  );
+
+  const handleCopy = async () => {
+    if (!(await copyToClipboard(INTRODUCTION_MARKDOWN))) {
+      return;
+    }
+
+    setCopied(true);
+    if (copyTimer.current) {
+      window.clearTimeout(copyTimer.current);
+    }
+    copyTimer.current = window.setTimeout(() => {
+      setCopied(false);
+      copyTimer.current = null;
+    }, 1000);
+  };
+
+  const handleTabKeyDown = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    currentTab: SsgMdTab,
+  ) => {
+    const currentIndex = SSG_MD_TABS.findIndex(item => item.key === currentTab);
+    let nextIndex: number | null = null;
+
+    if (event.key === 'ArrowRight') {
+      nextIndex = (currentIndex + 1) % SSG_MD_TABS.length;
+    } else if (event.key === 'ArrowLeft') {
+      nextIndex = (currentIndex - 1 + SSG_MD_TABS.length) % SSG_MD_TABS.length;
+    } else if (event.key === 'Home') {
+      nextIndex = 0;
+    } else if (event.key === 'End') {
+      nextIndex = SSG_MD_TABS.length - 1;
+    }
+
+    if (nextIndex === null) {
+      return;
+    }
+
+    event.preventDefault();
+    const nextTab = SSG_MD_TABS[nextIndex].key;
+    setTab(nextTab);
+    tabRefs.current[nextTab]?.focus();
+  };
 
   return (
     <div className={styles.ssgMdVisual}>
@@ -164,19 +234,27 @@ function SsgMdVisual() {
             type="file"
             name="llms-full.txt"
             accent
-            current={tab === 'llms'}
             tag="full"
           />
         </div>
       </div>
       <div className={`${styles.card} ${styles.llmsCard}`}>
-        <div className={styles.tabHeader}>
+        <div className={styles.tabHeader} role="tablist">
           {SSG_MD_TABS.map(({ key, label }) => (
             <button
               key={key}
+              ref={element => {
+                tabRefs.current[key] = element;
+              }}
               type="button"
+              id={`home-ssg-md-tab-${key}`}
+              role="tab"
+              aria-controls={`home-ssg-md-panel-${key}`}
+              aria-selected={tab === key}
+              tabIndex={tab === key ? 0 : -1}
               className={`${styles.tab} ${tab === key ? styles.tabActive : ''}`}
               onClick={() => setTab(key)}
+              onKeyDown={event => handleTabKeyDown(event, key)}
             >
               {label}
             </button>
@@ -184,15 +262,25 @@ function SsgMdVisual() {
         </div>
         <div className={styles.tabPanels}>
           <div
+            id="home-ssg-md-panel-html"
+            role="tabpanel"
+            aria-labelledby="home-ssg-md-tab-html"
+            aria-hidden={tab !== 'html'}
             className={`${styles.tabPanel} ${tab === 'html' ? styles.tabPanelVisible : styles.tabPanelHidden}`}
           >
             <div className={styles.pagePreview}>
               <div className={styles.pageHead}>
                 <div className={styles.pageTitle}>Introduction</div>
-                <div className={styles.copyMdButton}>
-                  <IconCopy />
-                  <span>Copy Markdown</span>
-                </div>
+                <button
+                  type="button"
+                  className={styles.copyMdButton}
+                  onClick={() => void handleCopy()}
+                >
+                  {copied ? <IconSuccess /> : <IconCopy />}
+                  <span aria-live="polite">
+                    {copied ? props.copiedText : props.copyText}
+                  </span>
+                </button>
               </div>
               <div className={styles.pageText} style={{ width: '94%' }} />
               <div className={styles.pageText} style={{ width: '80%' }} />
@@ -205,6 +293,10 @@ function SsgMdVisual() {
             </div>
           </div>
           <div
+            id="home-ssg-md-panel-md"
+            role="tabpanel"
+            aria-labelledby="home-ssg-md-tab-md"
+            aria-hidden={tab !== 'md'}
             className={`${styles.tabPanel} ${tab === 'md' ? styles.tabPanelVisible : styles.tabPanelHidden}`}
           >
             <div className={styles.llmsContent}>
@@ -219,6 +311,10 @@ function SsgMdVisual() {
             </div>
           </div>
           <div
+            id="home-ssg-md-panel-llms"
+            role="tabpanel"
+            aria-labelledby="home-ssg-md-tab-llms"
+            aria-hidden={tab !== 'llms'}
             className={`${styles.tabPanel} ${tab === 'llms' ? styles.tabPanelVisible : styles.tabPanelHidden}`}
           >
             <div className={styles.llmsContent}>
@@ -228,10 +324,10 @@ function SsgMdVisual() {
               </div>
               <div className={styles.llmsH2}>## Docs</div>
               <div className={styles.llmsItem}>
-                - <span>[Introduction](/guide/introduction.md)</span>
+                - <span>[Introduction](/guide/start/introduction.md)</span>
               </div>
               <div className={styles.llmsItem}>
-                - <span>[Quick Start](/guide/getting-started.md)</span>
+                - <span>[Quick Start](/guide/start/getting-started.md)</span>
               </div>
             </div>
           </div>
@@ -248,8 +344,11 @@ function AutoNavVisual() {
   const wireHandlers = (id: string) => ({
     onMouseEnter: () => setWiring(id),
     onMouseLeave: () => setWiring(null),
+    onFocus: () => setWiring(id),
+    onBlur: () => setWiring(null),
+    tabIndex: 0,
   });
-  // bijective: hovering either side frames both the source and its counterpart
+  // Hovering or focusing either side frames the source and its counterpart.
   const ringFor = (id: string) => (wiring === id ? true : undefined);
   const targetClass = (id: string, base: string) =>
     `${base} ${ringFor(id) ? styles.wireTarget : ''}`;
@@ -508,7 +607,8 @@ const PLUGINS = [
   { name: 'RSS', icon: <IconRss />, link: '/plugin/official-plugins/rss' },
 ];
 
-function ExtendVisual({ langPrefix = '' }: { langPrefix?: string }) {
+function ExtendVisual(props: { langPrefix?: string; yourPluginText: string }) {
+  const { langPrefix = '', yourPluginText } = props;
   return (
     <div className={styles.extendVisual}>
       <div className={`${styles.card} ${styles.pluginsCard}`}>
@@ -536,7 +636,7 @@ function ExtendVisual({ langPrefix = '' }: { langPrefix?: string }) {
             href={`${langPrefix}/plugin/system/write-a-plugin`}
           >
             <IconPlus />
-            <span>Your plugin</span>
+            <span>{yourPluginText}</span>
           </Link>
         </div>
       </div>
@@ -593,7 +693,12 @@ export function HomeSections() {
         ]}
         linkText={t('homeSsgMdLink')}
         linkHref={`${prefix}/guide/basic/ssg-md`}
-        visual={<SsgMdVisual />}
+        visual={
+          <SsgMdVisual
+            copyText={t('copyMarkdownText')}
+            copiedText={t('promptCopiedText')}
+          />
+        }
       />
       <Section
         eyebrow={t('homeNavEyebrow')}
@@ -612,7 +717,12 @@ export function HomeSections() {
         points={[t('homeExtendPoint1'), t('homeExtendPoint2')]}
         linkText={t('homeExtendLink')}
         linkHref={`${prefix}/guide/basic/custom-theme`}
-        visual={<ExtendVisual langPrefix={prefix} />}
+        visual={
+          <ExtendVisual
+            langPrefix={prefix}
+            yourPluginText={t('homeYourPlugin')}
+          />
+        }
       />
     </div>
   );

--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -28,6 +28,7 @@ import { CssModificationIndicator } from '../docs/components/CssModificationIndi
 import { CssStyleSync } from '../docs/components/CssStyleSync';
 import { BlogBackButton } from './components/BlogBackButton';
 import { HeroInteractive } from './components/HeroInteractive';
+import { HomeSections } from './components/HomeSections';
 import { Tag } from './components/Tag';
 import { ToolStack } from './components/ToolStack';
 import './index.css';
@@ -35,7 +36,12 @@ import './index.css';
 function HomeLayout() {
   return (
     <BasicHomeLayout
-      afterFeatures={<ToolStack />}
+      afterFeatures={
+        <>
+          <HomeSections />
+          <ToolStack />
+        </>
+      }
       afterHeroActions={
         <div
           className="rp-doc"


### PR DESCRIPTION
## Summary

The homepage previously jumped from the hero straight into the features grid, with no in-depth showcase of Rspress's distinctive capabilities. This PR adds three interactive feature sections (rendered in the `afterFeatures` slot, before `ToolStack`):

- **SSG-MD · llms.txt** — "One source, two outputs": a `doc_build` file tree paired with a tabbed preview (`introduction.html` with a Copy Markdown button / `introduction.md` / `llms.txt`). Tree row colors distinguish SSG vs SSG-MD outputs, and tabs stay in sync with the highlighted tree row. Panels are grid-stacked so tab switches cause no layout shift.
- **Auto nav & sidebar** — a `_meta.json` mock wired to a sidebar replica; hovering either side outlines both the source and its counterpart (bijective inspect effect, outline ring only, no hover fill).
- **Plugins & Themes** — clickable tiles linking to the official plugin docs (preview, playground, algolia, twoslash, typedoc, sitemap, rss) plus a layout-slot wireframe showing `beforeNavTitle` / `beforeSidebar` / `beforeDocContent`.

All copy is bilingual (en/zh) via `i18n.json`, and entrance animations are pure CSS (`animation-timeline: view()`) gated behind `prefers-reduced-motion: no-preference`.

## Related Issue

N/A

## Screenshots

Before: hero → features grid → tool stack. After: hero → **three new feature sections** → features grid → tool stack. See the deploy preview for the interactive behavior (tab switching, inspect wiring, clickable plugin tiles).

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
