### PR TITLE
docs: remove outdated CodeSandbox links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.en-US.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.en-US.yml
@@ -37,7 +37,7 @@ body:
     id: repro
     attributes:
       label: Reproduce link
-      description: 'Please provide a minimal reproduction of the issue. You can create a GitHub repo and use `npm create rspress@latest` as a starter. Or fork from the the [rspress-codesandbox-example](https://codesandbox.io/s/github/web-infra-dev/rspress-codesandbox-template).'
+      description: 'Please provide a minimal reproduction of the issue. You can create a GitHub repo and use `npm create rspress@latest` as a starter.'
       placeholder: paste link here
     validations:
       required: true

--- a/website/docs/en/guide/start/getting-started.mdx
+++ b/website/docs/en/guide/start/getting-started.mdx
@@ -34,10 +34,6 @@ Rspress requires Node.js version 20.19+, 22.12+.
 
 :::
 
-## Online example
-
-You can try Rspress directly in [CodeSandbox](https://codesandbox.io/p/github/web-infra-dev/rspress-codesandbox-template/main).
-
 ## Create a Rspress project
 
 The recommended way to start a new Rspress project is to use the `create-rspress` scaffold:

--- a/website/docs/zh/guide/start/getting-started.mdx
+++ b/website/docs/zh/guide/start/getting-started.mdx
@@ -34,12 +34,6 @@ Rspress 需要 Node.js 版本 20.19+, 22.12+。
 
 :::
 
-## 在线示例
-
-我们提供了 Rspress 在线示例，无需本地安装即可体验 Rspress 的文档站点开发流程：
-
-- [CodeSandbox 示例](https://codesandbox.io/p/github/web-infra-dev/rspress-codesandbox-template/main)
-
 ## 创建 Rspress 项目
 
 使用 [`create-rspress`](https://www.npmjs.com/package/create-rspress) 来创建一个 Rspress 项目，运行以下命令：


### PR DESCRIPTION
## Summary

- Remove the outdated CodeSandbox examples from the English and Chinese getting-started guides.
- Remove the CodeSandbox fork guidance from the bug report template because repository imports are no longer supported.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).