### PR TITLE
docs: remove empty useDark code block

### DIFF
--- a/website/docs/en/ui/hooks/use-dark.mdx
+++ b/website/docs/en/ui/hooks/use-dark.mdx
@@ -38,7 +38,3 @@ If you need to apply dark theme styles during SSG, use the `.dark` CSS selector.
 ```
 
 :::
-
-```
-
-```


### PR DESCRIPTION
## Summary

Remove the stray empty fenced code block at the end of the English `useDark` documentation so the page no longer renders an empty code panel.

## Related Issue

Fixes #3617

## Validation

- `pnpm exec prettier website/docs/en/ui/hooks/use-dark.mdx --check --end-of-line auto`
- `pnpm exec heading-case website/docs/en/ui/hooks/use-dark.mdx`
- `pnpm build:website`
- `git diff --check`

## Checklist

- [x] Tests updated (not required for a documentation-only fence removal).
- [x] Documentation updated.