### PR TITLE
docs: fix SourceCode implementation links

### DIFF
--- a/website/docs/en/ui/components/source-code.mdx
+++ b/website/docs/en/ui/components/source-code.mdx
@@ -12,7 +12,7 @@ overviewHeaders: []
 ```mdx title="index.mdx" preview
 import { SourceCode } from '@rspress/core/theme';
 
-<SourceCode href="https://github.com/web-infra-dev/rspress/blob/main/packages/theme-default/src/components/SourceCode/index.tsx" />
+<SourceCode href="https://github.com/web-infra-dev/rspress/blob/main/packages/core/src/theme/components/SourceCode/index.tsx" />
 ```
 
 ## Props

--- a/website/docs/zh/ui/components/source-code.mdx
+++ b/website/docs/zh/ui/components/source-code.mdx
@@ -12,7 +12,7 @@ overviewHeaders: []
 ```mdx title="index.mdx" preview
 import { SourceCode } from '@rspress/core/theme';
 
-<SourceCode href="https://github.com/web-infra-dev/rspress/blob/main/packages/theme-default/src/components/SourceCode/index.tsx" />
+<SourceCode href="https://github.com/web-infra-dev/rspress/blob/main/packages/core/src/theme/components/SourceCode/index.tsx" />
 ```
 
 ## Props


### PR DESCRIPTION
## Summary

Update the English and Chinese `SourceCode` examples to link to the component's current implementation under `packages/core` instead of the removed `packages/theme-default` path.

## Related Issue

Fixes #3618

## Validation

- Current target URL returns HTTP 200.
- `pnpm exec prettier website/docs/en/ui/components/source-code.mdx website/docs/zh/ui/components/source-code.mdx --check --end-of-line auto`
- `pnpm exec heading-case website/docs/en/ui/components/source-code.mdx website/docs/zh/ui/components/source-code.mdx`
- `pnpm build:website`
- `git diff --check`

## Checklist

- [x] Tests updated (not required for link-only documentation changes).
- [x] Documentation updated.