### PR TITLE
docs: update Web Infra QoS link

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Come and chat with us on [Discord](https://discord.gg/XsaKEEk4mW)! The Rstack te
 
 ## 🌟 Quality
 
-Rspress uses [Web Infra QoS](https://web-infra-qos.netlify.app?product=rspress) to observe the trend of key metrics, such as bundle size, compile speed and install size.
+Rspress uses [Web Infra QoS](https://web-infra-qos.pages.dev/?product=rspress) to observe the trend of key metrics, such as bundle size, compile speed and install size.
 
 ## 📖 License
 


### PR DESCRIPTION
## Summary

Update the README's Web Infra QoS link from the retired Netlify deployment to the active Cloudflare Pages dashboard while preserving the Rspress product filter.

## Related Issue

Fixes #3619

## Validation

- Old URL returns HTTP 404; replacement URL returns HTTP 200.
- `pnpm exec prettier README.md --check --end-of-line auto`
- `pnpm exec heading-case README.md`
- `pnpm exec cspell README.md --no-progress`
- `git diff --check`

## Checklist

- [x] Tests updated (not required for a README link change).
- [x] Documentation updated.