### PR TITLE
fix(core): normalize persistent cache build dependency path

### DIFF
--- a/packages/core/src/node/initRsbuild.ts
+++ b/packages/core/src/node/initRsbuild.ts
@@ -331,7 +331,7 @@ async function createInternalBuildConfig(
             buildCache: {
               // 1. config file: rspress.config.ts
               buildDependencies: [
-                new URL(import.meta.url).href, // this file,  __filename
+                fileURLToPath(import.meta.url), // this file, __filename
                 pluginDriver.getConfigFilePath(), // rspress.config.ts
               ],
               cacheDigest: [


### PR DESCRIPTION
## Summary

Convert `import.meta.url` to a filesystem path before adding it to persistent cache build dependencies.

Rspack treats build dependencies as paths. Passing a `file:` URL makes it resolve to a nonexistent project-relative path, which can invalidate the legacy persistent cache on every process start.

Reproduction: https://github.com/hardfist/rspress-legacy-cache-invalidation-repro