### PR TITLE
fix(theme/Nav): fix left-positioned menu alignment and spacing

### DIFF
--- a/packages/core/src/theme/components/Nav/NavMenu.scss
+++ b/packages/core/src/theme/components/Nav/NavMenu.scss
@@ -12,6 +12,14 @@
     gap: 24px;
   }
 
+  &--left {
+    margin-left: 32px;
+
+    @media (max-width: 1279px) {
+      margin-left: 24px;
+    }
+  }
+
   &__item {
     display: flex;
     height: 100%;

--- a/packages/core/src/theme/components/Nav/index.scss
+++ b/packages/core/src/theme/components/Nav/index.scss
@@ -39,6 +39,8 @@
 
   &__left {
     display: flex;
+    align-items: center;
+    height: 100%;
   }
 
   &__title {


### PR DESCRIPTION
## Summary

When nav items set `position: "left"` in `_nav.json`, the left-positioned menu had two style issues:

1. **Not vertically centered**: `.rp-nav__left` lacked `align-items: center`, and its indefinite height made the menu's `height: 100%` fail to resolve (22px instead of the full nav height), so menu items stuck to the top of the navbar.
2. **No spacing from the title**: the right side of the nav has `gap: 24px`, but there was no gap between the nav title and the left menu, making them touch.

Fixes:

- Add `align-items: center` and `height: 100%` to `.rp-nav__left`, so the left menu is vertically centered and its hover/click area fills the nav height, consistent with the right side.
- Add `margin-left: 32px` (24px below 1280px) to `.rp-nav-menu--left`, matching the menu's own gap rhythm.

Before / after (measured in browser with two `position: "left"` items):

| | Before | After |
| --- | --- | --- |
| Menu height | 22px (top-aligned) | 63.3px (full nav height, centered) |
| Gap between title and menu | 0px | 32px |

## Related Issue

N/A

## Screenshots

Before:

<img width="321" height="157" alt="image" src="https://github.com/user-attachments/assets/022faa57-8ef6-4cfd-96e4-cf696d0f7070" />

After:

<img width="342" height="132" alt="image" src="https://github.com/user-attachments/assets/106331bd-5032-46f7-8091-48f432c1ab84" />


## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
