### PR TITLE
fix(theme/Banner): support SSR and prevent flash before hydration

### DIFF
--- a/e2e/fixtures/banner/index.test.ts
+++ b/e2e/fixtures/banner/index.test.ts
@@ -1,14 +1,49 @@
 import { expect, test } from '@e2e/test';
-import { getPort, killProcess, runDevCommand } from '../../utils/runCommands';
+import {
+  getPort,
+  killProcess,
+  runBuildCommand,
+  runPreviewCommand,
+} from '../../utils/runCommands';
+
+type BannerProbeWindow = typeof window & {
+  __bannerWasVisible: boolean;
+};
+
+function installBannerVisibilityProbe(storageKey: string) {
+  window.localStorage.setItem(storageKey, 'true');
+  const state = window as BannerProbeWindow;
+  state.__bannerWasVisible = false;
+
+  const inspectBanner = () => {
+    const banner = document.querySelector('.rp-banner');
+    if (banner && getComputedStyle(banner).display !== 'none') {
+      state.__bannerWasVisible = true;
+    }
+  };
+
+  const observer = new MutationObserver(() => {
+    inspectBanner();
+    if (state.__bannerWasVisible) {
+      observer.disconnect();
+    }
+  });
+  observer.observe(document, {
+    childList: true,
+    subtree: true,
+  });
+  window.addEventListener('load', () => observer.disconnect(), { once: true });
+}
 
 test.describe('banner', async () => {
   let appPort: number;
-  let app: Awaited<ReturnType<typeof runDevCommand>> | null;
+  let app: Awaited<ReturnType<typeof runPreviewCommand>> | null;
 
   test.beforeAll(async () => {
     const appDir = import.meta.dirname;
     appPort = await getPort();
-    app = await runDevCommand(appDir, appPort);
+    await runBuildCommand(appDir);
+    app = await runPreviewCommand(appDir, appPort);
   });
 
   test.afterAll(async () => {
@@ -35,30 +70,7 @@ test.describe('banner', async () => {
   });
 
   test('Banner does not flash when previously dismissed', async ({ page }) => {
-    await page.addInitScript(() => {
-      window.localStorage.setItem('rp-banner-closed', 'true');
-      const state = window as typeof window & {
-        __bannerWasVisible: boolean;
-      };
-      state.__bannerWasVisible = false;
-
-      const detectVisibleBanner = () => {
-        const banner = document.querySelector('.rp-banner');
-        if (banner && getComputedStyle(banner).display !== 'none') {
-          state.__bannerWasVisible = true;
-        }
-      };
-
-      new MutationObserver(detectVisibleBanner).observe(document, {
-        childList: true,
-        subtree: true,
-      });
-      const detectVisibleBannerOnFrame = () => {
-        detectVisibleBanner();
-        requestAnimationFrame(detectVisibleBannerOnFrame);
-      };
-      requestAnimationFrame(detectVisibleBannerOnFrame);
-    });
+    await page.addInitScript(installBannerVisibilityProbe, 'rp-banner-closed');
 
     await page.goto(`http://localhost:${appPort}`, {
       waitUntil: 'networkidle',
@@ -66,9 +78,7 @@ test.describe('banner', async () => {
 
     expect(
       await page.evaluate(
-        () =>
-          (window as typeof window & { __bannerWasVisible: boolean })
-            .__bannerWasVisible,
+        () => (window as BannerProbeWindow).__bannerWasVisible,
       ),
     ).toBe(false);
     await expect(page.locator('.rp-banner')).toHaveCount(0);

--- a/e2e/fixtures/banner/index.test.ts
+++ b/e2e/fixtures/banner/index.test.ts
@@ -34,6 +34,46 @@ test.describe('banner', async () => {
     expect(stored).toBe('true');
   });
 
+  test('Banner does not flash when previously dismissed', async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem('rp-banner-closed', 'true');
+      const state = window as typeof window & {
+        __bannerWasVisible: boolean;
+      };
+      state.__bannerWasVisible = false;
+
+      const detectVisibleBanner = () => {
+        const banner = document.querySelector('.rp-banner');
+        if (banner && getComputedStyle(banner).display !== 'none') {
+          state.__bannerWasVisible = true;
+        }
+      };
+
+      new MutationObserver(detectVisibleBanner).observe(document, {
+        childList: true,
+        subtree: true,
+      });
+      const detectVisibleBannerOnFrame = () => {
+        detectVisibleBanner();
+        requestAnimationFrame(detectVisibleBannerOnFrame);
+      };
+      requestAnimationFrame(detectVisibleBannerOnFrame);
+    });
+
+    await page.goto(`http://localhost:${appPort}`, {
+      waitUntil: 'networkidle',
+    });
+
+    expect(
+      await page.evaluate(
+        () =>
+          (window as typeof window & { __bannerWasVisible: boolean })
+            .__bannerWasVisible,
+      ),
+    ).toBe(false);
+    await expect(page.locator('.rp-banner')).toHaveCount(0);
+  });
+
   test('Banner message stays single line on narrow viewport', async ({
     page,
   }) => {

--- a/packages/core/src/theme/components/Banner/index.tsx
+++ b/packages/core/src/theme/components/Banner/index.tsx
@@ -84,6 +84,7 @@ export const Banner = forwardRef<HTMLDivElement, BannerProps>(
       storage?: 'localStorage' | 'sessionStorage' | false;
       customChildren?: ReactNode;
     };
+    const isCustom = 'customChildren' in props;
 
     const [height, setHeight] = useState(36);
     const ref = mergeRefs(forwardedRef, element => {
@@ -98,7 +99,7 @@ export const Banner = forwardRef<HTMLDivElement, BannerProps>(
 
     useEffect(() => {
       let isDisabled = false;
-      if (typeof window !== 'undefined' && storage && storageKey) {
+      if (!isCustom && typeof window !== 'undefined' && storage && storageKey) {
         try {
           isDisabled = Boolean(window[storage].getItem(storageKey));
         } catch {
@@ -112,7 +113,7 @@ export const Banner = forwardRef<HTMLDivElement, BannerProps>(
       return () => {
         document.documentElement.classList.remove(hiddenClass);
       };
-    }, [hiddenClass, storage, storageKey]);
+    }, [hiddenClass, isCustom, storage, storageKey]);
 
     if (!display || disable) {
       return null;
@@ -120,7 +121,7 @@ export const Banner = forwardRef<HTMLDivElement, BannerProps>(
 
     return (
       <>
-        {storage && storageKey ? (
+        {!isCustom && storage && storageKey ? (
           <script
             data-rp-banner-hidden-class={hiddenClass}
             data-rp-banner-storage={storage}

--- a/packages/core/src/theme/components/Banner/index.tsx
+++ b/packages/core/src/theme/components/Banner/index.tsx
@@ -1,7 +1,20 @@
 import { IconClose, Link, mergeRefs, SvgWrapper } from '@rspress/core/theme';
 import clsx from 'clsx';
-import { forwardRef, type ReactNode, useEffect, useState } from 'react';
+import { forwardRef, type ReactNode, useEffect, useId, useState } from 'react';
 import './index.scss';
+
+const inlineStorageScript = `(function () {
+  var script = document.currentScript;
+  if (!script) return;
+  try {
+    var storage = window[script.dataset.rpBannerStorage];
+    var storageKey = script.dataset.rpBannerStorageKey;
+    var hiddenClass = script.dataset.rpBannerHiddenClass;
+    if (storage && storageKey && hiddenClass && storage.getItem(storageKey)) {
+      document.documentElement.classList.add(hiddenClass);
+    }
+  } catch (e) {}
+})();`;
 
 export type BannerProps = {
   /**
@@ -79,14 +92,27 @@ export const Banner = forwardRef<HTMLDivElement, BannerProps>(
       }
     });
     const [disable, setDisable] = useState(false);
+    const bannerId = useId().replace(/[^a-zA-Z0-9_-]/g, '');
+    const bannerClass = `rp-banner-${bannerId}`;
+    const hiddenClass = `${bannerClass}-hidden`;
 
-    // TODO: support SSR
     useEffect(() => {
-      if (typeof window === 'undefined' || !storage || !storageKey) {
-        return;
+      let isDisabled = false;
+      if (typeof window !== 'undefined' && storage && storageKey) {
+        try {
+          isDisabled = Boolean(window[storage].getItem(storageKey));
+        } catch {
+          isDisabled = false;
+        }
       }
-      setDisable(Boolean(window[storage].getItem(storageKey)));
-    }, []);
+
+      document.documentElement.classList.toggle(hiddenClass, isDisabled);
+      setDisable(isDisabled);
+
+      return () => {
+        document.documentElement.classList.remove(hiddenClass);
+      };
+    }, [hiddenClass, storage, storageKey]);
 
     if (!display || disable) {
       return null;
@@ -94,7 +120,17 @@ export const Banner = forwardRef<HTMLDivElement, BannerProps>(
 
     return (
       <>
-        <div className={clsx('rp-banner', className)} ref={ref}>
+        {storage && storageKey ? (
+          <script
+            data-rp-banner-hidden-class={hiddenClass}
+            data-rp-banner-storage={storage}
+            data-rp-banner-storage-key={storageKey}
+            suppressHydrationWarning
+            dangerouslySetInnerHTML={{ __html: inlineStorageScript }}
+          />
+        ) : null}
+        <style>{`:root {--rp-banner-height: ${height}px;} :root.${hiddenClass} {--rp-banner-height: 0px;} :root.${hiddenClass} .${bannerClass} {display: none;}`}</style>
+        <div className={clsx('rp-banner', bannerClass, className)} ref={ref}>
           {customChildren ?? (
             <>
               <Link
@@ -107,9 +143,14 @@ export const Banner = forwardRef<HTMLDivElement, BannerProps>(
               <SvgWrapper
                 icon={IconClose}
                 onClick={() => {
+                  document.documentElement.classList.add(hiddenClass);
                   setDisable(true);
                   if (storage) {
-                    window[storage].setItem(storageKey, 'true');
+                    try {
+                      window[storage].setItem(storageKey, 'true');
+                    } catch {
+                      return;
+                    }
                   }
                 }}
                 className="rp-banner__close"
@@ -117,7 +158,6 @@ export const Banner = forwardRef<HTMLDivElement, BannerProps>(
             </>
           )}
         </div>
-        <style>{`:root {--rp-banner-height: ${height}px;}`}</style>
       </>
     );
   },


### PR DESCRIPTION
## Summary

Before this change, an SSR-rendered Banner could briefly appear until hydration read its dismissed state from web storage. This PR applies the stored state before the first paint and skips the bootstrap for fully custom Banners.

The existing Banner E2E fixture now runs against a production build and includes a regression check for first-paint visibility.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).