### PR TITLE
fix(theme): replace `border-bottom` link underlines with `text-decoration`

### DIFF
--- a/packages/core/src/theme/components/Callout/index.scss
+++ b/packages/core/src/theme/components/Callout/index.scss
@@ -111,7 +111,7 @@
     }
 
     a {
-      border-bottom: 1px solid currentColor;
+      text-decoration: underline;
     }
   }
 }

--- a/packages/core/src/theme/components/Callout/index.scss
+++ b/packages/core/src/theme/components/Callout/index.scss
@@ -112,6 +112,7 @@
 
     a {
       text-decoration: underline;
+      text-underline-offset: 4px;
     }
   }
 }

--- a/packages/core/src/theme/components/DocContent/doc.scss
+++ b/packages/core/src/theme/components/DocContent/doc.scss
@@ -36,7 +36,7 @@
       overflow-wrap: break-word;
 
       &:hover {
-        border-bottom: 1px solid currentColor;
+        text-decoration: underline;
         opacity: 0.85;
       }
       &[target='_blank'] {

--- a/packages/core/src/theme/components/DocContent/doc.scss
+++ b/packages/core/src/theme/components/DocContent/doc.scss
@@ -37,6 +37,7 @@
 
       &:hover {
         text-decoration: underline;
+        text-underline-offset: 4px;
         opacity: 0.85;
       }
       &[target='_blank'] {

--- a/packages/core/src/theme/components/Prompt/index.scss
+++ b/packages/core/src/theme/components/Prompt/index.scss
@@ -395,6 +395,7 @@
     a {
       color: var(--rp-prompt-accent, var(--rp-c-brand-dark));
       text-decoration: underline;
+      text-underline-offset: 4px;
 
       & > code {
         color: inherit;

--- a/packages/core/src/theme/components/Prompt/index.scss
+++ b/packages/core/src/theme/components/Prompt/index.scss
@@ -394,7 +394,7 @@
 
     a {
       color: var(--rp-prompt-accent, var(--rp-c-brand-dark));
-      border-bottom: 1px solid currentColor;
+      text-decoration: underline;
 
       & > code {
         color: inherit;


### PR DESCRIPTION
## Summary

- replace `border-bottom` link underlines with `text-decoration` in document content, callouts, and prompt custom content
- apply a consistent `4px` underline offset across all three contexts
- preserve the existing visibility behavior: document links are underlined on hover, while callout and prompt links remain underlined by default
- ensure links containing inline code render the underline with the text instead of having it obscured by the code background

Validation:

- Prettier check for the three changed SCSS files
- `@rspress/core` build and Publint
- `git diff --check`

## Related Issue

N/A

## Screenshots

The visual change is limited to underline painting:

| Before | After |
| --- | --- |
| `border-bottom` can be covered by an inline code background | `text-decoration` follows the linked text with a consistent `4px` offset |

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
