### PR TITLE
fix(theme): limit link hover opacity to callouts

### DIFF
--- a/packages/core/src/theme/components/Callout/index.scss
+++ b/packages/core/src/theme/components/Callout/index.scss
@@ -113,6 +113,10 @@
     a {
       text-decoration: underline;
       text-underline-offset: 4px;
+
+      &:hover {
+        opacity: 0.85;
+      }
     }
   }
 }

--- a/packages/core/src/theme/components/DocContent/doc.scss
+++ b/packages/core/src/theme/components/DocContent/doc.scss
@@ -38,7 +38,6 @@
       &:hover {
         text-decoration: underline;
         text-underline-offset: 4px;
-        opacity: 0.85;
       }
       &[target='_blank'] {
         &::after {


### PR DESCRIPTION
## Summary

This PR removes the opacity change from regular document links because hover is already indicated by an underline.

Before, both regular document links and Callout links faded to 85% opacity on hover. After, only links inside Callout and Markdown containers retain the faded hover state.

## Screenshots

Not included because this is a subtle hover-only opacity change.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).