### PR TITLE
fix(theme/Nav): expand navbar item click areas

### DIFF
--- a/packages/core/src/theme/components/Nav/NavMenu.scss
+++ b/packages/core/src/theme/components/Nav/NavMenu.scss
@@ -11,7 +11,11 @@
   }
 
   &--left {
-    margin: 0 0 0 var(--rp-nav-menu-item-padding-x);
+    margin: 0 0 0 32px;
+
+    @media (max-width: 1279px) {
+      margin: 0 0 0 24px;
+    }
   }
 
   &__item {
@@ -37,6 +41,14 @@
       font-style: normal;
       font-weight: 500;
       line-height: 22px;
+    }
+
+    &:first-child > .rp-nav-menu__item__container {
+      padding-left: 0;
+    }
+
+    &:last-child > .rp-nav-menu__item__container {
+      padding-right: 0;
     }
 
     &__icon {

--- a/packages/core/src/theme/components/Nav/NavMenu.scss
+++ b/packages/core/src/theme/components/Nav/NavMenu.scss
@@ -11,11 +11,7 @@
   }
 
   &--left {
-    margin: 0 0 0 32px;
-
-    @media (max-width: 1279px) {
-      margin: 0 0 0 24px;
-    }
+    margin: 0 0 0 24px;
   }
 
   &__item {

--- a/packages/core/src/theme/components/Nav/NavMenu.scss
+++ b/packages/core/src/theme/components/Nav/NavMenu.scss
@@ -5,14 +5,15 @@
   align-items: center;
   height: 100%;
   list-style: none;
-  margin-inline: calc(0px - var(--rp-nav-menu-item-padding-x));
+  margin: 0 calc(0px - var(--rp-nav-menu-item-padding-x)) 0
+    calc(0px - var(--rp-nav-menu-item-padding-x));
 
   @media (max-width: 1279px) {
     --rp-nav-menu-item-padding-x: 12px;
   }
 
   &--left {
-    margin-inline: var(--rp-nav-menu-item-padding-x) 0;
+    margin: 0 0 0 var(--rp-nav-menu-item-padding-x);
   }
 
   &__item {

--- a/packages/core/src/theme/components/Nav/NavMenu.scss
+++ b/packages/core/src/theme/components/Nav/NavMenu.scss
@@ -5,8 +5,6 @@
   align-items: center;
   height: 100%;
   list-style: none;
-  margin: 0 calc(0px - var(--rp-nav-menu-item-padding-x)) 0
-    calc(0px - var(--rp-nav-menu-item-padding-x));
 
   @media (max-width: 1279px) {
     --rp-nav-menu-item-padding-x: 12px;

--- a/packages/core/src/theme/components/Nav/NavMenu.scss
+++ b/packages/core/src/theme/components/Nav/NavMenu.scss
@@ -12,7 +12,7 @@
   }
 
   &--left {
-    margin-inline-start: var(--rp-nav-menu-item-padding-x);
+    margin-inline: var(--rp-nav-menu-item-padding-x) 0;
   }
 
   &__item {

--- a/packages/core/src/theme/components/Nav/NavMenu.scss
+++ b/packages/core/src/theme/components/Nav/NavMenu.scss
@@ -30,7 +30,8 @@
       align-items: center;
       height: 100%;
       gap: 4px;
-      padding-inline: var(--rp-nav-menu-item-padding-x);
+      padding: 0 var(--rp-nav-menu-item-padding-x) 0
+        var(--rp-nav-menu-item-padding-x);
 
       // text
       text-align: center;

--- a/packages/core/src/theme/components/Nav/NavMenu.scss
+++ b/packages/core/src/theme/components/Nav/NavMenu.scss
@@ -1,5 +1,5 @@
 .rp-nav-menu {
-  --rp-nav-menu-item-padding-x: 16px;
+  --rp-nav-menu-item-gap: 32px;
 
   display: inline-flex;
   align-items: center;
@@ -7,7 +7,7 @@
   list-style: none;
 
   @media (max-width: 1279px) {
-    --rp-nav-menu-item-padding-x: 12px;
+    --rp-nav-menu-item-gap: 24px;
   }
 
   &--left {
@@ -28,8 +28,8 @@
       align-items: center;
       height: 100%;
       gap: 4px;
-      padding: 0 var(--rp-nav-menu-item-padding-x) 0
-        var(--rp-nav-menu-item-padding-x);
+      padding: 0 calc(var(--rp-nav-menu-item-gap) / 2) 0
+        calc(var(--rp-nav-menu-item-gap) / 2);
 
       // text
       text-align: center;

--- a/packages/core/src/theme/components/Nav/NavMenu.scss
+++ b/packages/core/src/theme/components/Nav/NavMenu.scss
@@ -1,23 +1,18 @@
 .rp-nav-menu {
+  --rp-nav-menu-item-padding-x: 16px;
+
   display: inline-flex;
   align-items: center;
   height: 100%;
   list-style: none;
-
-  @media (min-width: 1280px) {
-    gap: 32px;
-  }
+  margin-inline: calc(0px - var(--rp-nav-menu-item-padding-x));
 
   @media (max-width: 1279px) {
-    gap: 24px;
+    --rp-nav-menu-item-padding-x: 12px;
   }
 
   &--left {
-    margin-left: 32px;
-
-    @media (max-width: 1279px) {
-      margin-left: 24px;
-    }
+    margin-inline-start: var(--rp-nav-menu-item-padding-x);
   }
 
   &__item {
@@ -34,6 +29,7 @@
       align-items: center;
       height: 100%;
       gap: 4px;
+      padding-inline: var(--rp-nav-menu-item-padding-x);
 
       // text
       text-align: center;


### PR DESCRIPTION
## Summary

Follow up on #3629 by making the spacing between navbar items interactive:

- express navbar item spacing as a `32px` / `24px` gap variable, then apply half of it as padding on each adjacent item so click targets meet without dead space
- use the same item sizing and spacing model for both left- and right-positioned navbar menus
- remove the outer padding from the first and last items, preserving the menu's outer bounds without negative margins
- use a fixed `24px` spacing before the left menu, matching the other top-level navbar spacing and removing an unnecessary responsive branch

Validation:

- Prettier check for `NavMenu.scss`
- `git diff --check`
- `@rspress/core` build and Publint for the navbar padding change
- local before/after fixture available at both responsive sizes

The latest variable rename is calculation-equivalent: `32px / 2 = 16px` and `24px / 2 = 12px`, so it does not change rendered geometry. Repository CI remains the authoritative automated check.

## Related Issue

Follow-up to #3629.

## Screenshots

| Before | After |
| --- | --- |
| Navbar items were separated by non-interactive `gap`, limiting links to their text width | The gap is split into adjacent item padding, making the full horizontal area interactive while keeping the left menu spacing at a consistent `24px` |

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
