### PR TITLE
fix(theme/CodeBlock): preserve background when scrolling horizontally

### DIFF
--- a/packages/core/src/theme/components/CodeBlock/index.scss
+++ b/packages/core/src/theme/components/CodeBlock/index.scss
@@ -52,6 +52,8 @@
     position: relative;
     z-index: 1;
     margin: 0;
+    width: fit-content;
+    min-width: 100%;
     background: transparent;
   }
 


### PR DESCRIPTION
## Summary

This PR fixes code block backgrounds becoming white when horizontally scrolling overflow with a dark Shiki theme.

Before, the `<pre>` element stayed at the visible container width while the nested `<code>` element expanded to the content width, exposing the surrounding light background. After, the `<pre>` element covers the full scrollable width while preserving wrapped code behavior.

## Related Issue

N/A

## Screenshots

| Before | After |
| --- | --- |
| <img width="628" height="281" alt="image" src="https://github.com/user-attachments/assets/27c643fd-335e-423f-9e8b-b5dcafae4b1e" /> |<img width="624" height="294" alt="image" src="https://github.com/user-attachments/assets/2513ed67-84dd-45f9-a8b4-91c24d9e2bd8" />|

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).