### PR TITLE
fix(theme): keep search panel cancel text on one line on mobile

### DIFF
--- a/packages/core/src/theme/components/Search/SearchPanel.scss
+++ b/packages/core/src/theme/components/Search/SearchPanel.scss
@@ -30,6 +30,9 @@
     color: var(--rp-c-brand);
     margin-left: 0.5rem;
     cursor: pointer;
+    // CJK cancel text can break between characters and get squeezed
+    // by the 100%-width input form, keep it on one line.
+    white-space: nowrap;
 
     @media (min-width: 640px) {
       display: none;


### PR DESCRIPTION
## Summary

On mobile viewports, the search panel's cancel button text wraps vertically (one character per line) in CJK locales, e.g. "取消" in Chinese.

The header is a flex row where the input form has `width: 100%`, which squeezes the cancel button down to the width of a single character. CJK text can break between any two characters, so the button text wraps; Latin words cannot break mid-word, which is why this only reproduces in CJK locales.

This PR adds `white-space: nowrap` to the cancel button so it keeps its full text width and stays on one line.

### Reproduction steps

1. Set the viewport to a mobile width (e.g. 390×844).
2. Open a site with a CJK locale (e.g. `/zh/`).
3. Open the search panel.

Before the fix, the cancel text renders vertically, one character per line.

### Verification

With the fix, the cancel text renders on a single line. Desktop behavior (≥640px) is unchanged — the cancel button stays hidden — and Latin locales are unaffected.

Besides this fix, I think the search box spacing on mobile could also be improved — either removing the rounded corners or adding some padding would probably look better visually. However, since I'm not sure whether such UI changes would be welcome, this PR only fixes the obvious wrapping issue.

## Related Issue

None

## Screenshots

before:

<img width="417" height="123" alt="dyn-d62a30be5f819b72eb7ac5d32c3fe336" src="https://github.com/user-attachments/assets/1993190f-3449-4864-94ca-c607122738b9" />

after:

<img width="418" height="138" alt="dyn-b13dd5c156f51237a3d857c432237da5" src="https://github.com/user-attachments/assets/f4f9069c-ea08-47f1-83a0-99300488bdee" />

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
