### PR TITLE
fix(search): strip directive markers from search index content

### DIFF
--- a/packages/core/src/node/route/extractPageData.test.ts
+++ b/packages/core/src/node/route/extractPageData.test.ts
@@ -597,6 +597,125 @@ describe('getPageIndexInfoByRoute', async () => {
     );
   });
 
+  it('should strip container directive markers from search content', async () => {
+    const pageIndexInfo = await getPageIndexInfoByRoute(
+      createRoute('with-container-directive.mdx', fixtureContentProcessingDir),
+      {
+        alias: {},
+        replaceRules: [],
+        root: fixtureContentProcessingDir,
+        searchCodeBlocks: false,
+      },
+    );
+
+    expect(pageIndexInfo.content).toBe(`This is the actual description.
+
+This tip content should not appear in description.
+
+More description text after the tip.
+
+Section two
+
+Content in section two.`);
+    expect(pageIndexInfo.content).not.toContain(':::');
+  });
+
+  it('should strip split container directive markers from search content', async () => {
+    const pageIndexInfo = await getPageIndexInfoByRoute(
+      createRoute(
+        'with-container-directive-blank-lines.mdx',
+        fixtureContentProcessingDir,
+      ),
+      {
+        alias: {},
+        replaceRules: [],
+        root: fixtureContentProcessingDir,
+        searchCodeBlocks: false,
+      },
+    );
+
+    expect(pageIndexInfo.content).toBe(`This is the description.
+
+This tip has blank lines around it.
+
+More text after.
+
+Section two
+
+Content here.`);
+    expect(pageIndexInfo.content).not.toContain(':::');
+  });
+
+  it('should strip indented container directive markers from searchable code content', async () => {
+    const pageIndexInfo = await getPageIndexInfoByRoute(
+      createRoute(
+        'with-indented-container-directive.mdx',
+        fixtureContentProcessingDir,
+      ),
+      {
+        alias: {},
+        replaceRules: [],
+        root: fixtureContentProcessingDir,
+        searchCodeBlocks: true,
+      },
+    );
+
+    expect(pageIndexInfo.content).toBe(`Configure enough memory for redis.
+
+{
+  "Resource": "arn:aws:s3:::test"
+}`);
+    expect(pageIndexInfo.content).not.toContain(':::tip');
+    expect(pageIndexInfo.content).not.toMatch(/(^|\n)\s*:::/);
+    expect(pageIndexInfo.content).toContain('arn:aws:s3:::test');
+  });
+
+  it('should strip GitHub alert markers from search content', async () => {
+    const pageIndexInfo = await getPageIndexInfoByRoute(
+      createRoute('with-github-alert.mdx', fixtureContentProcessingDir),
+      {
+        alias: {},
+        replaceRules: [],
+        root: fixtureContentProcessingDir,
+        searchCodeBlocks: false,
+      },
+    );
+
+    expect(pageIndexInfo.content).toBe(`Intro before alert.
+
+Remember to configure enough memory for redis.
+Otherwise the process may OOM.
+
+Section two
+
+More content here.`);
+    expect(pageIndexInfo.content).not.toContain('[!TIP]');
+  });
+
+  it('should strip custom heading ids from search content', async () => {
+    const pageIndexInfo = await getPageIndexInfoByRoute(
+      createRoute('with-heading-custom-id.mdx', fixtureContentProcessingDir),
+      {
+        alias: {},
+        replaceRules: [],
+        root: fixtureContentProcessingDir,
+        searchCodeBlocks: false,
+      },
+    );
+
+    expect(pageIndexInfo.content).toBe(`Intro text.
+
+Redis notes
+
+Configure enough memory for redis.
+
+Plain custom id
+
+More content here.`);
+    expect(pageIndexInfo.content).not.toContain('{#redis-notes}');
+    expect(pageIndexInfo.content).not.toContain('{#plain-custom-id}');
+  });
+
   it('should skip code blocks when extracting description', async () => {
     const pageIndexInfo = await getPageIndexInfoByRoute(
       createRoute('with-code.mdx', fixtureContentProcessingDir),

--- a/packages/core/src/node/route/extractPageData.ts
+++ b/packages/core/src/node/route/extractPageData.ts
@@ -7,7 +7,7 @@ import {
   type ReplaceRule,
   type RouteMeta,
 } from '@rspress/shared';
-import { loadFrontMatter } from '@rspress/shared/node-utils';
+import { extractTextAndId, loadFrontMatter } from '@rspress/shared/node-utils';
 import type { Node, Nodes, Root } from 'mdast';
 import remarkGFM from 'remark-gfm';
 import remarkParse from 'remark-parse';
@@ -98,7 +98,11 @@ const SEARCH_BLOCK_TYPES = new Set([
 /**
  * Recursively extract raw text from the mdast
  */
-function extractSearchText(node: Nodes, codeblocks: boolean): Array<string> {
+function extractSearchText(
+  node: Nodes,
+  codeblocks: boolean,
+  parentType?: string,
+): Array<string> {
   const { type } = node;
 
   // Return an empty string for any kind of "non-content" node
@@ -115,19 +119,26 @@ function extractSearchText(node: Nodes, codeblocks: boolean): Array<string> {
     return ['\n'];
   }
 
-  // If we are text or inline code then just return that nodes value, for example `**test**` becomes `test`
-  if (type === 'text' || type === 'inlineCode') {
+  // If we are inline code then just return that nodes value, for example `**test**` becomes `test`
+  if (type === 'inlineCode') {
     return [node.value];
+  }
+
+  if (type === 'text') {
+    const value =
+      parentType === 'heading' ? extractTextAndId(node.value)[0] : node.value;
+    return [stripSearchMarkdownMarkers(value)];
   }
   // multiline code blocks are prefixed and suffixed with newlines
   if (type === 'code') {
-    return [`\n${node.value}\n`];
+    const value = stripSearchMarkdownMarkers(node.value);
+    return value ? [`\n${value}\n`] : [];
   }
 
   const result: Array<string> = [];
   if ('children' in node) {
     for (const child of node.children) {
-      result.push(...extractSearchText(child as Nodes, codeblocks));
+      result.push(...extractSearchText(child as Nodes, codeblocks, type));
     }
   }
 
@@ -227,6 +238,27 @@ const CONTAINER_DIRECTIVE_REGEX = /^\s*:::\s*(\w+)\s*(.*)?/;
  * Regex to match a closing container directive marker (:::)
  */
 const CONTAINER_DIRECTIVE_END_REGEX = /^\s*:::\s*$/;
+
+/**
+ * Regex to match GitHub alert markers ([!TIP], [!NOTE], etc.)
+ */
+const GITHUB_ALERT_MARKER_REGEX = /^\s*\[!\w+\]\s*$/;
+
+/**
+ * Strip markdown-only marker lines from search content while keeping their
+ * visible body searchable.
+ */
+function stripSearchMarkdownMarkers(text: string): string {
+  return text
+    .split('\n')
+    .filter(
+      line =>
+        !CONTAINER_DIRECTIVE_REGEX.test(line) &&
+        !CONTAINER_DIRECTIVE_END_REGEX.test(line) &&
+        !GITHUB_ALERT_MARKER_REGEX.test(line),
+    )
+    .join('\n');
+}
 
 /**
  * Remove container directive blocks (:::tip ... :::) from text.

--- a/packages/core/src/node/route/fixtures/content-processing/with-github-alert.mdx
+++ b/packages/core/src/node/route/fixtures/content-processing/with-github-alert.mdx
@@ -1,0 +1,11 @@
+# Page with GitHub alert
+
+Intro before alert.
+
+> [!TIP]
+> Remember to configure enough memory for redis.
+> Otherwise the process may OOM.
+
+## Section two
+
+More content here.

--- a/packages/core/src/node/route/fixtures/content-processing/with-heading-custom-id.mdx
+++ b/packages/core/src/node/route/fixtures/content-processing/with-heading-custom-id.mdx
@@ -1,0 +1,11 @@
+# Page with heading IDs
+
+Intro text.
+
+## Redis notes \{#redis-notes}
+
+Configure enough memory for redis.
+
+### Plain custom id {#plain-custom-id}
+
+More content here.

--- a/packages/core/src/node/route/fixtures/content-processing/with-indented-container-directive.mdx
+++ b/packages/core/src/node/route/fixtures/content-processing/with-indented-container-directive.mdx
@@ -1,0 +1,11 @@
+# Page with indented container directive
+
+    :::tip
+    Configure enough memory for redis.
+    :::
+
+```json
+{
+  "Resource": "arn:aws:s3:::test"
+}
+```


### PR DESCRIPTION
## Summary

This PR fixes local search snippets that exposed Markdown-only syntax such as container directive markers (`:::`) and GitHub alert markers (`[!TIP]`).

The search index now strips those marker lines while keeping the visible body text searchable. It also handles custom heading IDs and indented directive blocks parsed as searchable code content, while preserving real inline `:::` strings inside code.

## Screenshots

### Before

<img width="562" height="290" alt="image" src="https://github.com/user-attachments/assets/2948a01b-c6d5-4499-801b-bfa2d24381fa" />

### After

<img width="561" height="284" alt="image" src="https://github.com/user-attachments/assets/a30fed9b-2d4c-405f-a2f9-080a253f4c33" />

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
