### PR TITLE
chore: migrate Git hooks and staged tasks to Rstack CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,6 @@
 *.lcov
 lib-cov
 
-.husky
-
 node_modules/
 .npm
 .lock-wscript

--- a/.rstack/hooks/pre-commit
+++ b/.rstack/hooks/pre-commit
@@ -1,0 +1,1 @@
+rs staged

--- a/package.json
+++ b/package.json
@@ -12,29 +12,12 @@
     "format": "rs lint --fix && rs fmt && heading-case --write",
     "generate-release-pr": "zx scripts/generateReleasePr.mjs",
     "lint": "rs lint --type-check && rs fmt --check && pnpm run check-spell",
-    "prepare": "skills-package-manager install && pnpm run build && simple-git-hooks",
+    "prepare": "skills-package-manager install && pnpm run build && rs hooks",
     "preview:website": "cd website && npm run preview",
     "test": "pnpm test:unit && pnpm test:e2e",
     "test:e2e": "rstest run --config rstest.e2e.config.mts",
     "test:unit": "rstest run",
     "update:rsbuild": "npx taze minor --include /rsbuild/ -w -r -l"
-  },
-  "simple-git-hooks": {
-    "pre-commit": "pnpm exec nano-staged"
-  },
-  "nano-staged": {
-    "*.{md,mdx,css,less,scss,json,jsonc,json5}": [
-      "rs fmt",
-      "heading-case --write"
-    ],
-    "*.{js,jsx,ts,tsx,mts,mjs,cjs}": [
-      "rs lint --fix",
-      "rs fmt"
-    ],
-    "package.json": [
-      "pnpm run check-dependency-version",
-      "rs fmt"
-    ]
   },
   "devDependencies": {
     "@playwright/test": "1.62.1",
@@ -54,12 +37,10 @@
     "cspell-ban-words": "^0.0.4",
     "get-port": "5.1.1",
     "heading-case": "^1.1.5",
-    "nano-staged": "^0.9.0",
     "nx": "22.7.8",
     "path-serializer": "0.6.0",
     "playwright": "1.62.1",
     "rstack": "^0.6.5",
-    "simple-git-hooks": "^2.13.1",
     "skills-package-manager": "0.11.0",
     "tree-kill": "^1.2.2",
     "zx": "^8.8.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,9 +59,6 @@ importers:
       heading-case:
         specifier: ^1.1.5
         version: 1.1.5
-      nano-staged:
-        specifier: ^0.9.0
-        version: 0.9.0
       nx:
         specifier: 22.7.8
         version: 22.7.8
@@ -74,9 +71,6 @@ importers:
       rstack:
         specifier: ^0.6.5
         version: 0.6.5(@microsoft/api-extractor@7.59.0(@types/node@22.19.15))(@rspress/core@packages+core)(jiti@2.7.0)(typescript@7.0.2)
-      simple-git-hooks:
-        specifier: ^2.13.1
-        version: 2.13.1
       skills-package-manager:
         specifier: 0.11.0
         version: 0.11.0
@@ -7173,11 +7167,6 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nano-staged@0.9.0:
-    resolution: {integrity: sha512-0JfyX4i0Vp5HhC9RDtJ1kp7psz8CFuS3Gya3Z6WZv//QCwA9dPzi1S803VdR0c0P6R7sSvweZ5mSJmYQ/N+loQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    hasBin: true
-
   nanoid@3.3.18:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -8021,10 +8010,6 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
-
-  simple-git-hooks@2.13.1:
-    resolution: {integrity: sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==}
-    hasBin: true
 
   skills-package-manager@0.11.0:
     resolution: {integrity: sha512-WD7JgUNefusVOBzOAacuT4XqL2aIPSvtP2brDHqM9gyby8rMU/vLZphoL9jwxQz6RWtHOAvobqDqvCcS5bf9iw==}
@@ -13914,10 +13899,6 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nano-staged@0.9.0:
-    dependencies:
-      picocolors: 1.1.1
-
   nanoid@3.3.18: {}
 
   negotiator@0.6.3: {}
@@ -15042,8 +15023,6 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
-
-  simple-git-hooks@2.13.1: {}
 
   skills-package-manager@0.11.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,6 @@ packages:
 allowBuilds:
   nx: false
   sharp: true
-  simple-git-hooks: false
 
 hoistPattern: []
 

--- a/rstack.config.mts
+++ b/rstack.config.mts
@@ -62,3 +62,12 @@ define.fmt({
   singleQuote: true,
   sortPackageJson: true,
 });
+
+define.staged({
+  '*.{md,mdx,css,less,scss,json,jsonc,json5}': [
+    'rs fmt',
+    'heading-case --write',
+  ],
+  '*.{js,jsx,ts,tsx,mts,mjs,cjs}': ['rs lint --fix', 'rs fmt'],
+  'package.json': ['pnpm run check-dependency-version'],
+});


### PR DESCRIPTION
## Summary

This PR migrates the repository's Git hook and staged-file workflows from `simple-git-hooks` and `nano-staged` to Rstack CLI. Existing pre-commit behavior is preserved through `rs hooks`, `rs staged`, and `define.staged()`, while the obsolete dependencies and configuration are removed.

## Related Links

- https://rstack.rs/guide/migration

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).