### PR TITLE
fix(theme): update light-mode Shiki string token color

### DIFF
--- a/packages/core/src/theme/styles/vars/shiki-vars.css
+++ b/packages/core/src/theme/styles/vars/shiki-vars.css
@@ -4,7 +4,7 @@
   --shiki-background: transparent; /* Priority higher than var(--rp-code-block-bg); */
 
   --shiki-token-constant: #1976d2;
-  --shiki-token-string: #31a94d;
+  --shiki-token-string: #032f62;
   --shiki-token-comment: rgb(182, 180, 180);
   --shiki-token-keyword: #cf2727;
   --shiki-token-parameter: #f59403;


### PR DESCRIPTION
## Summary

Update the default light-mode `--shiki-token-string` color from `#31a94d` to `#032f62`.

- Dark-mode string color remains `#f9a86e`.
- All other token colors, including `--shiki-token-string-expression`, are unchanged.
- Branched from the latest fetched `origin/main` (`4cb6816bb`); this PR contains only the one-line CSS change.

Validation:

- Passed Prettier check for the changed CSS file and `git diff --check`.
- Passed a PostCSS parse and assertions for both light/dark values and an exact one-line change against `origin/main`.
- Full checks were not validated locally: no `preflight` script exists, and the shared dependency checkout does not include the required Rstack CLI. `npm run check` resolves to macOS `/usr/bin/rs`, so its exit status is not treated as a successful project check.

## Related Issue

None.

## Screenshots
before

<img width="1490" height="957" alt="image" src="https://github.com/user-attachments/assets/ac37ce55-e288-4c11-a1e7-37baa6bc1887" />
after

<img width="1510" height="935" alt="image" src="https://github.com/user-attachments/assets/ee01a232-8371-4a56-aa39-96f5937b45de" />


## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
