### PR TITLE
feat(theme/Search): animate search panel opening

### DIFF
--- a/e2e/fixtures/search/index.test.ts
+++ b/e2e/fixtures/search/index.test.ts
@@ -17,61 +17,6 @@ test.describe('search keyboard', async () => {
     }
   });
 
-  test('search panel should animate based on the motion preference', async ({
-    page,
-  }) => {
-    await page.goto(`http://localhost:${appPort}/base/`, {
-      waitUntil: 'networkidle',
-    });
-
-    await page.locator('.rp-search-button').click();
-
-    const searchModal = page.locator('.rp-search-panel__modal');
-    await expect(searchModal).toBeVisible();
-    await expect(searchModal).toHaveCSS('animation-name', 'rp-search-panel-in');
-    await expect(searchModal).toHaveCSS('animation-duration', '0.18s');
-    await expect(searchModal).toHaveCSS(
-      'animation-timing-function',
-      'ease-out',
-    );
-
-    const keyframes = await page.evaluate(() => {
-      const rules = Array.from(document.styleSheets).flatMap(styleSheet =>
-        Array.from(styleSheet.cssRules),
-      );
-      const rule = rules.find(
-        (cssRule): cssRule is CSSKeyframesRule =>
-          cssRule instanceof CSSKeyframesRule &&
-          cssRule.name === 'rp-search-panel-in',
-      );
-
-      return rule
-        ? Array.from(rule.cssRules, keyframe => ({
-            keyText: keyframe.keyText,
-            opacity: keyframe.style.opacity,
-            transform: keyframe.style.transform,
-          }))
-        : null;
-    });
-
-    expect(keyframes).toEqual([
-      {
-        keyText: '0%',
-        opacity: '0',
-        transform: 'translateY(-8px) scale(0.98)',
-      },
-      { keyText: '100%', opacity: '1', transform: 'none' },
-    ]);
-
-    await page.keyboard.press('Escape');
-    await expect(searchModal).toBeHidden();
-
-    await page.emulateMedia({ reducedMotion: 'reduce' });
-    await page.locator('.rp-search-button').click();
-    await expect(searchModal).toBeVisible();
-    await expect(searchModal).toHaveCSS('animation-name', 'none');
-  });
-
   test('keyboard navigation should work', async ({ page }) => {
     await page.goto(`http://localhost:${appPort}/base/`, {
       waitUntil: 'networkidle',

--- a/e2e/fixtures/search/index.test.ts
+++ b/e2e/fixtures/search/index.test.ts
@@ -17,6 +17,61 @@ test.describe('search keyboard', async () => {
     }
   });
 
+  test('search panel should animate based on the motion preference', async ({
+    page,
+  }) => {
+    await page.goto(`http://localhost:${appPort}/base/`, {
+      waitUntil: 'networkidle',
+    });
+
+    await page.locator('.rp-search-button').click();
+
+    const searchModal = page.locator('.rp-search-panel__modal');
+    await expect(searchModal).toBeVisible();
+    await expect(searchModal).toHaveCSS('animation-name', 'rp-search-panel-in');
+    await expect(searchModal).toHaveCSS('animation-duration', '0.18s');
+    await expect(searchModal).toHaveCSS(
+      'animation-timing-function',
+      'ease-out',
+    );
+
+    const keyframes = await page.evaluate(() => {
+      const rules = Array.from(document.styleSheets).flatMap(styleSheet =>
+        Array.from(styleSheet.cssRules),
+      );
+      const rule = rules.find(
+        (cssRule): cssRule is CSSKeyframesRule =>
+          cssRule instanceof CSSKeyframesRule &&
+          cssRule.name === 'rp-search-panel-in',
+      );
+
+      return rule
+        ? Array.from(rule.cssRules, keyframe => ({
+            keyText: keyframe.keyText,
+            opacity: keyframe.style.opacity,
+            transform: keyframe.style.transform,
+          }))
+        : null;
+    });
+
+    expect(keyframes).toEqual([
+      {
+        keyText: '0%',
+        opacity: '0',
+        transform: 'translateY(-8px) scale(0.98)',
+      },
+      { keyText: '100%', opacity: '1', transform: 'none' },
+    ]);
+
+    await page.keyboard.press('Escape');
+    await expect(searchModal).toBeHidden();
+
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await page.locator('.rp-search-button').click();
+    await expect(searchModal).toBeVisible();
+    await expect(searchModal).toHaveCSS('animation-name', 'none');
+  });
+
   test('keyboard navigation should work', async ({ page }) => {
     await page.goto(`http://localhost:${appPort}/base/`, {
       waitUntil: 'networkidle',

--- a/e2e/fixtures/view-transition-dark-mode/package.json
+++ b/e2e/fixtures/view-transition-dark-mode/package.json
@@ -16,6 +16,6 @@
   "devDependencies": {
     "@types/node": "^22.8.1",
     "@types/react": "^19.2.18",
-    "@types/react-dom": "^19.2.4"
+    "@types/react-dom": "^19.2.7"
   }
 }

--- a/packages/core/src/theme/components/Search/SearchPanel.scss
+++ b/packages/core/src/theme/components/Search/SearchPanel.scss
@@ -19,6 +19,11 @@
     padding: 20px;
     padding-bottom: 20px;
     height: auto;
+    animation: rp-search-panel-in 0.18s ease-out;
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
   }
 
   &__header {
@@ -121,5 +126,17 @@
     &__input {
       font-size: 16px;
     }
+  }
+}
+
+@keyframes rp-search-panel-in {
+  from {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: none;
   }
 }

--- a/packages/core/src/theme/components/Search/SearchPanel.scss
+++ b/packages/core/src/theme/components/Search/SearchPanel.scss
@@ -134,9 +134,4 @@
     opacity: 0;
     transform: translateY(-8px) scale(0.98);
   }
-
-  to {
-    opacity: 1;
-    transform: none;
-  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1813,7 +1813,7 @@ importers:
         version: 19.2.18
       '@types/react-dom':
         specifier: ^19.2.4
-        version: 19.2.4(@types/react@19.2.18)
+        version: 19.2.7(@types/react@19.2.18)
 
   e2e/fixtures/with-base:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1812,7 +1812,7 @@ importers:
         specifier: ^19.2.18
         version: 19.2.18
       '@types/react-dom':
-        specifier: ^19.2.4
+        specifier: ^19.2.7
         version: 19.2.7(@types/react@19.2.18)
 
   e2e/fixtures/with-base:


### PR DESCRIPTION
## Summary

The default search panel currently appears without an entrance transition. This PR adopts the subtle 180 ms fade, translate, and scale animation used by [Halo Docs](https://docs.halo.run/), while preserving the existing layout and disabling motion when `prefers-reduced-motion: reduce` is active.

Inspired by [Halo Docs' Rspress theme override](https://github.com/halo-dev/docs/blob/cbdaa883009ffe21ecdbe67960f3e28e6175eee8/theme/override.scss#L48-L100). The production search fixture grows by 231 B raw CSS / 75 B gzip, with no JavaScript or dependency changes.

## Related issue

N/A

## Screenshots

Motion-only change; the source behavior can be previewed by opening search on [Halo Docs](https://docs.halo.run/).

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required). No public API or configuration was added.