### PR TITLE
chore(deps): update @rsbuild/core to 2.2.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@mdx-js/mdx": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
-    "@rsbuild/core": "^2.1.13",
+    "@rsbuild/core": "^2.2.1",
     "@rsbuild/plugin-react": "~2.1.0",
     "@rspress/shared": "workspace:*",
     "@shikijs/rehype": "^4.2.0",

--- a/packages/plugin-llms/package.json
+++ b/packages/plugin-llms/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.59.0",
-    "@rsbuild/core": "^2.1.13",
+    "@rsbuild/core": "^2.2.1",
     "@rsbuild/plugin-react": "~2.1.0",
     "@rspress/config": "workspace:*",
     "@types/hast": "^3.0.5",

--- a/packages/plugin-preview/package.json
+++ b/packages/plugin-preview/package.json
@@ -28,7 +28,7 @@
     "reset": "rimraf ./**/node_modules"
   },
   "dependencies": {
-    "@rsbuild/core": "^2.1.13",
+    "@rsbuild/core": "^2.2.1",
     "@rsbuild/plugin-react": "~2.1.0",
     "picocolors": "^1.1.1",
     "qrcode.react": "^4.2.0"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -51,7 +51,7 @@
     "reset": "rimraf ./**/node_modules"
   },
   "dependencies": {
-    "@rsbuild/core": "^2.1.13",
+    "@rsbuild/core": "^2.2.1",
     "@shikijs/rehype": "^4.2.0",
     "@types/react": "^19.2.18",
     "mdast-util-mdx-jsx": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1824,11 +1824,11 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1(@types/react@19.2.18)(react@19.2.8)
       '@rsbuild/core':
-        specifier: ^2.1.13
-        version: 2.1.13
+        specifier: ^2.2.1
+        version: 2.2.1
       '@rsbuild/plugin-react':
         specifier: ~2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.13)(@rspack/core@2.2.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1(@swc/helpers@0.5.23))
       '@rspress/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1937,10 +1937,10 @@ importers:
         version: 7.59.0(@types/node@22.19.15)
       '@rsbuild/plugin-sass':
         specifier: ~2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.13)
+        version: 2.0.1(@rsbuild/core@2.2.1)
       '@rsbuild/plugin-svgr':
         specifier: ^2.0.5
-        version: 2.0.5(@rsbuild/core@2.1.13)(@rspack/core@2.2.1(@swc/helpers@0.5.23))(supports-color@9.4.0)(typescript@6.0.3)
+        version: 2.0.5(@rsbuild/core@2.2.1)(@rspack/core@2.2.1(@swc/helpers@0.5.23))(supports-color@9.4.0)(typescript@6.0.3)
       '@rspress/config':
         specifier: workspace:*
         version: link:../../scripts/config
@@ -1991,10 +1991,10 @@ importers:
         version: 4.0.0(supports-color@9.4.0)
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.1.13)
+        version: 1.0.0(@rsbuild/core@2.2.1)
       rsbuild-plugin-virtual-module:
         specifier: 0.4.5
-        version: 0.4.5(@rsbuild/core@2.1.13)
+        version: 0.4.5(@rsbuild/core@2.2.1)
       tinyglobby:
         specifier: ^0.2.17
         version: 0.2.17
@@ -2190,11 +2190,11 @@ importers:
         specifier: ^7.59.0
         version: 7.59.0(@types/node@22.19.15)
       '@rsbuild/core':
-        specifier: ^2.1.13
-        version: 2.1.13
+        specifier: ^2.2.1
+        version: 2.2.1
       '@rsbuild/plugin-react':
         specifier: ~2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.13)(@rspack/core@2.2.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1(@swc/helpers@0.5.23))
       '@rspress/config':
         specifier: workspace:*
         version: link:../../scripts/config
@@ -2215,7 +2215,7 @@ importers:
         version: 19.2.8
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.1.13)
+        version: 1.0.0(@rsbuild/core@2.2.1)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -2299,11 +2299,11 @@ importers:
   packages/plugin-preview:
     dependencies:
       '@rsbuild/core':
-        specifier: ^2.1.13
-        version: 2.1.13
+        specifier: ^2.2.1
+        version: 2.2.1
       '@rsbuild/plugin-react':
         specifier: ~2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.13)(@rspack/core@2.2.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1(@swc/helpers@0.5.23))
       '@rspress/core':
         specifier: workspace:^2.0.10
         version: link:../core
@@ -2340,7 +2340,7 @@ importers:
         version: 19.2.8(react@19.2.8)
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.1.13)
+        version: 1.0.0(@rsbuild/core@2.2.1)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -2487,8 +2487,8 @@ importers:
   packages/shared:
     dependencies:
       '@rsbuild/core':
-        specifier: ^2.1.13
-        version: 2.1.13
+        specifier: ^2.2.1
+        version: 2.2.1
       '@shikijs/rehype':
         specifier: ^4.2.0
         version: 4.2.0
@@ -2528,7 +2528,7 @@ importers:
         version: 6.1.3
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.1.13)
+        version: 1.0.0(@rsbuild/core@2.2.1)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -9638,12 +9638,12 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.2.1
 
-  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.1.13)(@rspack/core@2.2.1(@swc/helpers@0.5.23))':
+  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.2.1)(@rspack/core@2.2.1(@swc/helpers@0.5.23))':
     dependencies:
       '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.2.1(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.13
+      '@rsbuild/core': 2.2.1
     transitivePeerDependencies:
       - '@rspack/core'
 
@@ -9653,6 +9653,15 @@ snapshots:
       react-refresh: 0.18.0
     optionalDependencies:
       '@rsbuild/core': 2.1.13
+    transitivePeerDependencies:
+      - '@rspack/core'
+
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1(@swc/helpers@0.5.23))':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.1(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 2.2.1
     transitivePeerDependencies:
       - '@rspack/core'
 
@@ -9666,16 +9675,26 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.13
 
-  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.1.13)(@rspack/core@2.2.1(@swc/helpers@0.5.23))(supports-color@9.4.0)(typescript@6.0.3)':
+  '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.2.1)':
     dependencies:
-      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.1.13)(@rspack/core@2.2.1(@swc/helpers@0.5.23))
+      deepmerge: 4.3.1
+      loader-utils: 2.0.4
+      postcss: 8.5.26
+      reduce-configs: 2.0.1
+      sass-embedded: 1.100.0
+    optionalDependencies:
+      '@rsbuild/core': 2.2.1
+
+  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.2.1)(@rspack/core@2.2.1(@swc/helpers@0.5.23))(supports-color@9.4.0)(typescript@6.0.3)':
+    dependencies:
+      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.2.1)(@rspack/core@2.2.1(@swc/helpers@0.5.23))
       '@svgr/core': 8.1.0(supports-color@9.4.0)(typescript@6.0.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(supports-color@9.4.0)(typescript@6.0.3))(supports-color@9.4.0)
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(supports-color@9.4.0)(typescript@6.0.3))(typescript@6.0.3)
       deepmerge: 4.3.1
       loader-utils: 3.3.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.13
+      '@rsbuild/core': 2.2.1
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
@@ -14333,9 +14352,19 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.13
 
+  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.2.1):
+    dependencies:
+      publint: 0.3.21
+    optionalDependencies:
+      '@rsbuild/core': 2.2.1
+
   rsbuild-plugin-virtual-module@0.4.5(@rsbuild/core@2.1.13):
     optionalDependencies:
       '@rsbuild/core': 2.1.13
+
+  rsbuild-plugin-virtual-module@0.4.5(@rsbuild/core@2.2.1):
+    optionalDependencies:
+      '@rsbuild/core': 2.2.1
 
   rslog@2.1.2: {}
 


### PR DESCRIPTION
## Summary

This PR isolates the `@rsbuild/core` upgrade from #3647 so its CI impact can be evaluated independently. It updates `@rsbuild/core` from `^2.1.13` to `^2.2.1` across the workspace and refreshes the lockfile.

## Related Issue

- https://github.com/web-infra-dev/rspress/pull/3647
- https://github.com/web-infra-dev/rsbuild/releases/tag/v2.2.1

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).