### PR TITLE
feat(theme/Steps): support multiple heading levels

### DIFF
--- a/packages/core/src/theme/components/Steps/index.scss
+++ b/packages/core/src/theme/components/Steps/index.scss
@@ -11,7 +11,7 @@
   padding-left: var(--rp-steps-gap);
   counter-reset: step;
 
-  h3 {
+  > :is(h2, h3, h4, h5, h6) {
     counter-increment: step;
     margin-top: 0;
     position: relative;

--- a/website/docs/en/ui/components/steps.mdx
+++ b/website/docs/en/ui/components/steps.mdx
@@ -39,4 +39,4 @@ Content for step 1.
 </Steps>
 ```
 
-Write headings inside `<Steps>`; each heading starts a new step. Markdown under a heading becomes that step’s body.
+Write direct child headings from `h2` to `h6` inside `<Steps>`; each heading starts a new step. Markdown under a heading becomes that step’s body.

--- a/website/docs/zh/ui/components/steps.mdx
+++ b/website/docs/zh/ui/components/steps.mdx
@@ -39,4 +39,4 @@ import { Steps } from '@rspress/core/theme';
 </Steps>
 ```
 
-在 `<Steps>` 中书写标题；每个标题会开启一个新的步骤，标题下的 Markdown 内容会作为该步骤的正文。
+在 `<Steps>` 中书写 `h2` 到 `h6` 级别的直属标题；每个标题会开启一个新的步骤，标题下的 Markdown 内容会作为该步骤的正文。


### PR DESCRIPTION
## Summary

- support direct child headings from `h2` to `h6` in the `Steps` component
- preserve the existing `h3` behavior while preventing nested headings from being treated as steps
- clarify the supported heading levels in the English and Chinese documentation

Before this change, only `h3` elements received step numbering and styling.
After this change, authors can choose a heading level that matches the document
hierarchy.

## Related issue

Closes #3651

## Screenshots

No visual style changes. The newly supported heading levels reuse the existing
step appearance.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).