### PR TITLE
fix(plugins): use import.meta.dirname for package paths

### DIFF
--- a/packages/plugin-api-docgen/src/constants.ts
+++ b/packages/plugin-api-docgen/src/constants.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
 
-export const PACKAGE_ROOT = path.join(__dirname, '..');
+export const PACKAGE_ROOT = path.join(import.meta.dirname, '..');
 
 export const apiDocMap: Record<string, string> = {};

--- a/packages/plugin-api-docgen/src/index.ts
+++ b/packages/plugin-api-docgen/src/index.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import type { RspressPlugin } from '@rspress/core';
 import { logger } from '@rspress/core';
 import { pluginVirtualModule } from 'rsbuild-plugin-virtual-module';
-import { apiDocMap } from './constants';
+import { apiDocMap, PACKAGE_ROOT } from './constants';
 import { docgen } from './docgen';
 import type { PluginOptions, SupportLanguages } from './types';
 
@@ -101,7 +101,7 @@ export function pluginApiDocgen(options?: PluginOptions): RspressPlugin {
     },
     markdown: {
       globalComponents: [
-        path.join(__dirname, '..', 'static', 'global-components', 'API.tsx'),
+        path.join(PACKAGE_ROOT, 'static', 'global-components', 'API.tsx'),
       ],
     },
   };

--- a/packages/plugin-preview/src/constants.ts
+++ b/packages/plugin-preview/src/constants.ts
@@ -1,7 +1,8 @@
 import path from 'node:path';
 import { RSPRESS_TEMP_DIR } from '@rspress/core';
 
-export const STATIC_DIR = path.join(__dirname, '..', 'static');
+export const PACKAGE_ROOT = path.join(import.meta.dirname, '..');
+export const STATIC_DIR = path.join(PACKAGE_ROOT, 'static');
 
 export const VIRTUAL_DEMO_DIR = path.join(
   process.cwd(),

--- a/packages/plugin-preview/src/index.ts
+++ b/packages/plugin-preview/src/index.ts
@@ -13,7 +13,7 @@ import {
 } from '@rspress/core';
 import picocolors from 'picocolors';
 import entryContent from '../static/iframe/entry?raw';
-import { STATIC_DIR } from './constants';
+import { PACKAGE_ROOT, STATIC_DIR } from './constants';
 import { generateEntry } from './generateEntry';
 import { pluginLogger, previewLogger } from './logger';
 import { globalDemos, isDirtyRef, remarkWriteCodeFile } from './remarkPlugin';
@@ -179,7 +179,7 @@ export function pluginPreview(options?: Options): RspressPlugin {
     },
     builderConfig: {
       source: {
-        include: [join(__dirname, '..')],
+        include: [PACKAGE_ROOT],
       },
       tools: {
         bundlerChain(chain) {


### PR DESCRIPTION
## Summary

The ESM builds of `@rspress/plugin-api-docgen` and `@rspress/plugin-preview` retained the CommonJS-only `__dirname` global.

Importing either package with native Node.js ESM threw `ReferenceError: __dirname is not defined`, which prevented native config loaders such as Rstack CLI from evaluating `rstack.config.*` and caused `rs doc build` to exit before compilation.

- Before: package paths were resolved from `__dirname`, so native ESM imports failed.
- After: both plugins resolve a shared package root from `import.meta.dirname`, allowing native imports while preserving their static asset paths.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).