### PR TITLE
fix(plugin-twoslash): relax typescript peerDependency to ^5.5.0 || ^6.0.0

### DIFF
--- a/packages/plugin-twoslash/package.json
+++ b/packages/plugin-twoslash/package.json
@@ -51,7 +51,7 @@
   "peerDependencies": {
     "@rspress/core": "workspace:^2.0.10",
     "react": ">=18.0.0",
-    "typescript": "^6.0.3"
+    "typescript": "^5.5.0 || ^6.0.0"
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"


### PR DESCRIPTION
## Summary

The `typescript` peerDependency in `@rspress/plugin-twoslash` was set to `^6.0.3`, which is unnecessarily restrictive. This causes peer dependency errors when users install `typescript@npm:@typescript/typescript6@^6.0.2` for side-by-side use with TypeScript 7, since the highest published version under that alias is 6.0.2.

All upstream dependencies already support TypeScript 5.5+:
- `twoslash@0.3.9` declares `^5.5.0 || ^6.0.0`
- `@shikijs/twoslash@4.2.0` declares `>=5.5.0`
- The plugin itself does not call any TypeScript APIs directly

This PR relaxes the peer to `^5.5.0 || ^6.0.0` to match upstream constraints.

## Related Links

- https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0