### PR TITLE
fix(theme/SwitchAppearance): correct appearance transition animation

### DIFF
--- a/e2e/fixtures/view-transition-dark-mode/README.md
+++ b/e2e/fixtures/view-transition-dark-mode/README.md
@@ -1,0 +1,16 @@
+# View transition dark mode reproduction
+
+Run the fixture from the repository root:
+
+```bash
+pnpm --filter @rspress-fixture/view-transition-dark-mode dev
+```
+
+Open the URL printed by Rspress. The root page exercises Rspress's current
+appearance switch. `/native.html` is a framework-free control using percentage
+coordinates relative to the View Transition snapshot.
+
+Test both pages at the same viewport size, browser zoom, and device pixel ratio.
+If only the Rspress page is offset, the issue is in Rspress or its page styles.
+If both pages are offset by the same amount, it is likely a browser/environment
+interaction.

--- a/e2e/fixtures/view-transition-dark-mode/doc/index.mdx
+++ b/e2e/fixtures/view-transition-dark-mode/doc/index.mdx
@@ -1,0 +1,43 @@
+---
+description: Reproduce and compare Rspress and native View Transition dark mode animations across viewport sizes and device pixel ratios
+---
+
+import { CoordinateReadout } from '../src/CoordinateReadout';
+
+# Rspress appearance transition
+
+This page only enables `themeConfig.enableAppearanceAnimation`. Use the
+appearance button in the upper-right corner and check whether the circle is
+centered on the pointer.
+
+<CoordinateReadout />
+
+## Compare with the browser baseline
+
+Open <a href="/native.html">the native View Transition version</a> in the same
+browser, at the same window size and zoom level. It uses percentage coordinates
+relative to the View Transition snapshot, without Rspress or React.
+
+## Things to compare
+
+- The circle center should match the appearance button that was clicked.
+- Browser zoom and device pixel ratio should not move the center.
+- Resizing the window should only change the final radius.
+
+### Content block
+
+This section makes the light/dark boundary easier to see while the transition
+is running.
+
+```ts
+const center = { x: event.clientX, y: event.clientY };
+const radius = Math.hypot(
+  Math.max(center.x, innerWidth - center.x + 200),
+  Math.max(center.y, innerHeight - center.y + 200),
+);
+const normalizedDiagonal = Math.hypot(innerWidth, innerHeight) / Math.SQRT2;
+
+const clipPath = `circle(${(radius / normalizedDiagonal) * 100}% at ${
+  (center.x / innerWidth) * 100
+}% ${(center.y / innerHeight) * 100}%)`;
+```

--- a/e2e/fixtures/view-transition-dark-mode/doc/public/native.html
+++ b/e2e/fixtures/view-transition-dark-mode/doc/public/native.html
@@ -1,0 +1,186 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Native View Transition dark mode baseline</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family:
+          Inter,
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          'Segoe UI',
+          sans-serif;
+        color: #202124;
+        background: #ffffff;
+      }
+
+      :root.dark {
+        color-scheme: dark;
+        color: #f1f3f5;
+        background: #101214;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        min-height: 100vh;
+        margin: 0;
+        background: inherit;
+      }
+
+      header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        height: 72px;
+        padding: 0 24px;
+        border-bottom: 1px solid #8885;
+      }
+
+      button {
+        width: 44px;
+        height: 44px;
+        border: 1px solid #8886;
+        border-radius: 50%;
+        color: inherit;
+        background: transparent;
+        cursor: pointer;
+        font-size: 20px;
+      }
+
+      main {
+        width: min(760px, calc(100% - 48px));
+        margin: 72px auto;
+      }
+
+      .card {
+        margin-top: 32px;
+        padding: 24px;
+        border: 1px solid #8885;
+        border-radius: 16px;
+        background: #8881;
+      }
+
+      output {
+        position: fixed;
+        right: 16px;
+        bottom: 16px;
+        z-index: 10000;
+        display: grid;
+        gap: 2px;
+        min-width: 220px;
+        padding: 12px 14px;
+        border: 1px solid #8886;
+        border-radius: 10px;
+        background: inherit;
+        box-shadow: 0 8px 24px #0002;
+        font:
+          12px/1.5 ui-monospace,
+          monospace;
+      }
+
+      ::view-transition-old(root),
+      ::view-transition-new(root) {
+        animation: none;
+        mix-blend-mode: normal;
+      }
+
+      ::view-transition-old(root),
+      .dark::view-transition-new(root) {
+        z-index: 1;
+      }
+
+      ::view-transition-new(root),
+      .dark::view-transition-old(root) {
+        z-index: 9999;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <strong>Native View Transition baseline</strong>
+      <button id="appearance" type="button" aria-label="Toggle dark mode">
+        ◐
+      </button>
+    </header>
+    <main>
+      <h1>Dark mode circle reveal</h1>
+      <p>
+        This page has no framework. The circle must stay centered on the button
+        at every browser zoom level and device pixel ratio.
+      </p>
+      <div class="card">
+        Compare this animation with the Rspress page at the same viewport size.
+      </div>
+    </main>
+    <output id="coordinates"></output>
+    <script>
+      const root = document.documentElement;
+      const button = document.querySelector('#appearance');
+      const output = document.querySelector('#coordinates');
+      const roundPercentage = value => Math.round(value * 1e6) / 1e6;
+
+      const renderCoordinates = event => {
+        output.innerHTML = `
+          <span>click: ${Math.round(event?.clientX ?? 0)}, ${Math.round(event?.clientY ?? 0)}</span>
+          <span>viewport: ${innerWidth} × ${innerHeight}</span>
+          <span>DPR: ${devicePixelRatio}</span>
+        `;
+      };
+
+      renderCoordinates();
+      addEventListener('resize', () => renderCoordinates());
+      addEventListener('pointerdown', renderCoordinates, true);
+
+      button.addEventListener('click', event => {
+        const isDark = !root.classList.contains('dark');
+        const x = event.clientX;
+        const y = event.clientY;
+        const endRadius = Math.hypot(
+          Math.max(x, innerWidth - x + 200),
+          Math.max(y, innerHeight - y + 200),
+        );
+        const normalizedDiagonal =
+          Math.hypot(innerWidth, innerHeight) / Math.SQRT2;
+        const xPercentage = roundPercentage((x / innerWidth) * 100);
+        const yPercentage = roundPercentage((y / innerHeight) * 100);
+        const endRadiusPercentage = roundPercentage(
+          (endRadius / normalizedDiagonal) * 100,
+        );
+
+        if (!document.startViewTransition) {
+          root.classList.toggle('dark', isDark);
+          return;
+        }
+
+        const transition = document.startViewTransition(() => {
+          root.classList.toggle('dark', isDark);
+        });
+        const clipPath = [
+          `circle(0% at ${xPercentage}% ${yPercentage}%)`,
+          `circle(${endRadiusPercentage}% at ${xPercentage}% ${yPercentage}%)`,
+        ];
+
+        transition.ready.then(() => {
+          root.animate(
+            { clipPath: isDark ? [...clipPath].reverse() : clipPath },
+            {
+              duration: 400,
+              easing: 'ease-in',
+              pseudoElement: isDark
+                ? '::view-transition-old(root)'
+                : '::view-transition-new(root)',
+            },
+          );
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/e2e/fixtures/view-transition-dark-mode/package.json
+++ b/e2e/fixtures/view-transition-dark-mode/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@rspress-fixture/view-transition-dark-mode",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rspress build",
+    "dev": "rspress dev",
+    "preview": "rspress preview"
+  },
+  "dependencies": {
+    "@rspress/core": "workspace:*",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8"
+  },
+  "devDependencies": {
+    "@types/node": "^22.8.1",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4"
+  }
+}

--- a/e2e/fixtures/view-transition-dark-mode/rspress.config.ts
+++ b/e2e/fixtures/view-transition-dark-mode/rspress.config.ts
@@ -1,0 +1,11 @@
+import * as path from 'node:path';
+import { defineConfig } from '@rspress/core';
+
+export default defineConfig({
+  root: path.join(import.meta.dirname, 'doc'),
+  globalStyles: path.join(import.meta.dirname, 'styles/index.css'),
+  title: 'View Transition dark mode reproduction',
+  themeConfig: {
+    enableAppearanceAnimation: true,
+  },
+});

--- a/e2e/fixtures/view-transition-dark-mode/src/CoordinateReadout.tsx
+++ b/e2e/fixtures/view-transition-dark-mode/src/CoordinateReadout.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+
+type PointerSnapshot = {
+  clientX: number;
+  clientY: number;
+  devicePixelRatio: number;
+  innerHeight: number;
+  innerWidth: number;
+};
+
+const readPointerSnapshot = (event?: PointerEvent): PointerSnapshot => ({
+  clientX: Math.round(event?.clientX ?? 0),
+  clientY: Math.round(event?.clientY ?? 0),
+  devicePixelRatio: window.devicePixelRatio,
+  innerHeight: window.innerHeight,
+  innerWidth: window.innerWidth,
+});
+
+export function CoordinateReadout() {
+  const [snapshot, setSnapshot] = useState<PointerSnapshot>();
+
+  useEffect(() => {
+    setSnapshot(readPointerSnapshot());
+
+    const updatePointer = (event: PointerEvent) => {
+      setSnapshot(readPointerSnapshot(event));
+    };
+    const updateViewport = () => setSnapshot(readPointerSnapshot());
+
+    window.addEventListener('pointerdown', updatePointer, true);
+    window.addEventListener('resize', updateViewport);
+
+    return () => {
+      window.removeEventListener('pointerdown', updatePointer, true);
+      window.removeEventListener('resize', updateViewport);
+    };
+  }, []);
+
+  if (!snapshot) {
+    return null;
+  }
+
+  return (
+    <output className="coordinate-readout">
+      <span>
+        click: {snapshot.clientX}, {snapshot.clientY}
+      </span>
+      <span>
+        viewport: {snapshot.innerWidth} × {snapshot.innerHeight}
+      </span>
+      <span>DPR: {snapshot.devicePixelRatio}</span>
+    </output>
+  );
+}

--- a/e2e/fixtures/view-transition-dark-mode/styles/index.css
+++ b/e2e/fixtures/view-transition-dark-mode/styles/index.css
@@ -1,0 +1,22 @@
+.coordinate-readout {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  z-index: 10000;
+  display: grid;
+  gap: 2px;
+  min-width: 220px;
+  padding: 12px 14px;
+  border: 1px solid var(--rp-c-divider);
+  border-radius: 10px;
+  background: var(--rp-c-bg-soft);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 12%);
+  color: var(--rp-c-text-1);
+  font:
+    12px/1.5 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    monospace;
+}

--- a/packages/core/src/theme/components/SwitchAppearance/getClipPath.test.ts
+++ b/packages/core/src/theme/components/SwitchAppearance/getClipPath.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from '@rstest/core';
+import { getClipPath } from './getClipPath';
+
+describe('getClipPath', () => {
+  it('uses percentages relative to the view transition snapshot', () => {
+    expect(
+      getClipPath({
+        height: 600,
+        width: 800,
+        x: 800,
+        y: 0,
+      }),
+    ).toEqual(['circle(0% at 100% 0%)', 'circle(160% at 100% 0%)']);
+  });
+});

--- a/packages/core/src/theme/components/SwitchAppearance/getClipPath.ts
+++ b/packages/core/src/theme/components/SwitchAppearance/getClipPath.ts
@@ -1,0 +1,26 @@
+type ClipPathOptions = {
+  height: number;
+  width: number;
+  x: number;
+  y: number;
+};
+
+const roundPercentage = (value: number) => Math.round(value * 1e6) / 1e6;
+
+export const getClipPath = ({ height, width, x, y }: ClipPathOptions) => {
+  const endRadius = Math.hypot(
+    Math.max(x, width - x + 200),
+    Math.max(y, height - y + 200),
+  );
+  const normalizedDiagonal = Math.hypot(width, height) / Math.SQRT2;
+  const xPercentage = roundPercentage((x / width) * 100);
+  const yPercentage = roundPercentage((y / height) * 100);
+  const endRadiusPercentage = roundPercentage(
+    (endRadius / normalizedDiagonal) * 100,
+  );
+
+  return [
+    `circle(0% at ${xPercentage}% ${yPercentage}%)`,
+    `circle(${endRadiusPercentage}% at ${xPercentage}% ${yPercentage}%)`,
+  ];
+};

--- a/packages/core/src/theme/components/SwitchAppearance/index.tsx
+++ b/packages/core/src/theme/components/SwitchAppearance/index.tsx
@@ -4,6 +4,7 @@ import { type MouseEvent, useContext } from 'react';
 import './global.scss';
 import './index.scss';
 import { flushSync } from 'react-dom';
+import { getClipPath } from './getClipPath';
 
 const supportAppearanceTransition = () => {
   return (
@@ -36,11 +37,6 @@ export function SwitchAppearance({ onClick }: { onClick?: () => void }) {
       const x = event.clientX;
       const y = event.clientY;
 
-      const endRadius = Math.hypot(
-        Math.max(x, innerWidth - x + 200),
-        Math.max(y, innerHeight - y + 200),
-      );
-
       const dispose = removeClipViewTransition();
       const transition = document.startViewTransition(async () => {
         flushSync(() => {
@@ -49,30 +45,30 @@ export function SwitchAppearance({ onClick }: { onClick?: () => void }) {
         });
       });
 
-      const clipPath = [
-        `circle(0px at ${x}px ${y}px)`,
-        `circle(${endRadius}px at ${x}px ${y}px)`,
-      ];
-      transition.ready.then(() => {
-        document.documentElement
-          .animate(
-            {
-              clipPath: isDark ? [...clipPath].reverse() : clipPath,
-            },
-            {
-              duration: 400,
-              easing: 'ease-in',
-              pseudoElement: isDark
-                ? '::view-transition-old(root)'
-                : '::view-transition-new(root)',
-
-              id: '',
-            },
-          )
-          .finished.then(() => {
-            dispose();
-          });
+      const clipPath = getClipPath({
+        height: innerHeight,
+        width: innerWidth,
+        x,
+        y,
       });
+      transition.ready.then(() => {
+        document.documentElement.animate(
+          {
+            clipPath: isDark ? [...clipPath].reverse() : clipPath,
+          },
+          {
+            duration: 400,
+            easing: 'ease-in',
+            fill: 'both',
+            pseudoElement: isDark
+              ? '::view-transition-old(root)'
+              : '::view-transition-new(root)',
+
+            id: '',
+          },
+        );
+      });
+      transition.finished.then(dispose, dispose);
     } else {
       setTheme(nextTheme);
       onClick?.();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1793,6 +1793,28 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(@types/react@19.2.18)
 
+  e2e/fixtures/view-transition-dark-mode:
+    dependencies:
+      '@rspress/core':
+        specifier: workspace:*
+        version: link:../../../packages/core
+      react:
+        specifier: ^19.2.8
+        version: 19.2.8
+      react-dom:
+        specifier: ^19.2.8
+        version: 19.2.8(react@19.2.8)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.8.1
+        version: 22.19.15
+      '@types/react':
+        specifier: ^19.2.18
+        version: 19.2.18
+      '@types/react-dom':
+        specifier: ^19.2.4
+        version: 19.2.4(@types/react@19.2.18)
+
   e2e/fixtures/with-base:
     dependencies:
       react:


### PR DESCRIPTION
## Summary

The appearance transition could originate from the wrong position on high-DPI displays and briefly flash the previous light snapshot when switching to dark mode.

Before, the clip path used CSS pixel coordinates against the View Transition snapshot and dropped its final keyframe before the transition pseudo-elements were removed. After, the clip path uses snapshot-relative percentages, retains its first and final frames, and cleans up after the complete View Transition finishes. A minimal Rspress fixture and native browser baseline are included for comparison across viewport sizes and device pixel ratios.

## Related issue

N/A

## Screenshots

N/A — this is an animation timing and coordinate fix. Run `pnpm --filter @rspress-fixture/view-transition-dark-mode dev` to compare the Rspress page with `/native.html` interactively.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).