### PR TITLE
feat(theme/Llms): Add `Head` component for metadata links in `LlmsHint`  🔗 

### DIFF
--- a/packages/core/src/theme/components/Llms/LlmsHint.test.tsx
+++ b/packages/core/src/theme/components/Llms/LlmsHint.test.tsx
@@ -1,3 +1,4 @@
+import type React from 'react';
 import { afterEach, describe, expect, it, rs } from '@rstest/core';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { renderToMarkdownString } from 'react-render-to-markdown';
@@ -21,6 +22,7 @@ let page = defaultPage;
 let site = defaultSite;
 
 rs.mock('@rspress/core/runtime', () => ({
+  Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
   routePathToMdPath: (path: string) => `/docs${path}index.md`,
   usePage: () => ({ page }),
   useSite: () => ({ site }),
@@ -57,6 +59,12 @@ describe('LlmsHint', () => {
     expect(html).not.toContain('<a ');
     expect(html).toContain(
       'For AI agents: the complete documentation index is available at https://example.com/docs/llms.txt, the full documentation bundle is available at https://example.com/docs/llms-full.txt, and this page is available as Markdown at https://example.com/docs/guide/index.md.',
+    );
+    expect(html).toContain(
+      '<link rel="alternate" type="text/markdown" href="https://example.com/docs/guide/index.md"/>',
+    );
+    expect(html).toContain(
+      '<link rel="describedby" href="https://example.com/docs/llms.txt"/>',
     );
   });
 

--- a/packages/core/src/theme/components/Llms/LlmsHint.tsx
+++ b/packages/core/src/theme/components/Llms/LlmsHint.tsx
@@ -4,7 +4,9 @@ import {
   useSite,
   withBase,
   withSiteOrigin,
+  Head,
 } from '@rspress/core/runtime';
+
 import type React from 'react';
 
 const visuallyHiddenStyle: React.CSSProperties = {
@@ -67,8 +69,14 @@ export function LlmsHint() {
   });
 
   return (
-    <div className="rp-llms-hint" style={visuallyHiddenStyle}>
-      {hintText}
-    </div>
+    <>
+      <Head>
+        <link rel="alternate" type="text/markdown" href={pageMdUrl} />
+        <link rel="describedby" href={llmsTxtUrl} />
+      </Head>
+      <div className="rp-llms-hint" style={visuallyHiddenStyle}>
+        {hintText}
+      </div>
+    </>
   );
 }


### PR DESCRIPTION


Adds standard discovery `<link>` relations to `<Head>` in accordance with the [llmstxt.org proposal](https://llmstxt.org/#proposal).

While Rspress already provides an in-body hint (`.rp-llms-hint`), AI agents and crawlers standardly inspect `<head>` link relations for discovery:
- `rel="alternate"` with `type="text/markdown"`: points to the clean Markdown version of the page.
- `rel="describedby"`: points to the relevant `llms.txt` index.

## Changes

- Injected `rel="alternate"` and `rel="describedby"` `<link>` tags into `<Head>` inside `LlmsHint`.
- Reused existing URL resolving logic (`pageMdUrl` and `llmsTxtUrl`).
- Kept intact early return for `SSG_MD` mode so markdown outputs remain unaffected.

## Reference

- [llmstxt.org #proposal](https://llmstxt.org/#proposal)