### PR TITLE
fix(theme): align hook usage with React rules

### DIFF
--- a/packages/core/src/theme/components/ReadPercent/useReadPercent.ts
+++ b/packages/core/src/theme/components/ReadPercent/useReadPercent.ts
@@ -31,7 +31,7 @@ export const useReadPercent = () => {
         Math.min(Math.max(0, ((scrollTop - 50 + deltaHeight) / h) * 100), 100),
       ) || 0
     );
-  }, [scrollTop, height]);
+  }, [h, scrollTop, height]);
 
   return [readPercent, scrollTop];
 };

--- a/packages/core/src/theme/components/Tabs/index.tsx
+++ b/packages/core/src/theme/components/Tabs/index.tsx
@@ -116,6 +116,20 @@ export const Tabs = forwardRef(
       return getTabValuesFromChildren(children, values);
     }, [children, values]);
 
+    const defaultValueIndex =
+      defaultValue !== undefined
+        ? tabValues.findIndex(item => item.value === defaultValue)
+        : -1;
+    const initialActiveIndex =
+      defaultValueIndex === -1 ? (defaultIndex ?? 0) : defaultValueIndex;
+
+    const [activeIndex, setActiveIndex] = useState(initialActiveIndex);
+
+    const [storageIndex, setStorageIndex] = useStorageValue<string>(
+      `${groupIdPrefix}${groupId}`,
+      initialActiveIndex.toString(),
+    );
+
     if (import.meta.env.SSG_MD) {
       return (
         <>
@@ -131,20 +145,6 @@ export const Tabs = forwardRef(
         </>
       );
     }
-
-    const defaultValueIndex =
-      defaultValue !== undefined
-        ? tabValues.findIndex(item => item.value === defaultValue)
-        : -1;
-    const initialActiveIndex =
-      defaultValueIndex === -1 ? (defaultIndex ?? 0) : defaultValueIndex;
-
-    const [activeIndex, setActiveIndex] = useState(initialActiveIndex);
-
-    const [storageIndex, setStorageIndex] = useStorageValue<string>(
-      `${groupIdPrefix}${groupId}`,
-      initialActiveIndex.toString(),
-    );
 
     const currentIndex: number = groupId ? Number(storageIndex) : activeIndex;
 

--- a/packages/core/src/theme/layout/DocLayout/index.tsx
+++ b/packages/core/src/theme/layout/DocLayout/index.tsx
@@ -42,6 +42,16 @@ export function DocLayout(props: DocLayoutProps) {
   } = props;
   const { frontmatter } = useFrontmatter();
 
+  const {
+    isOutlineOpen,
+    isSidebarOpen,
+    sidebarMenu,
+    asideLayoutRef,
+    sidebarLayoutRef,
+  } = useSidebarMenu(beforeOutline, afterOutline);
+
+  const { rspressDocRef } = useWatchToc();
+
   const isOverviewPage = frontmatter?.overview ?? false;
 
   const sidebar = frontmatter?.sidebar ?? true;
@@ -72,16 +82,6 @@ export function DocLayout(props: DocLayoutProps) {
   }
 
   const isDocWide = pageType === 'doc-wide';
-
-  const {
-    isOutlineOpen,
-    isSidebarOpen,
-    sidebarMenu,
-    asideLayoutRef,
-    sidebarLayoutRef,
-  } = useSidebarMenu(beforeOutline, afterOutline);
-
-  const { rspressDocRef } = useWatchToc();
 
   return (
     <>

--- a/packages/core/src/theme/layout/Layout/index.tsx
+++ b/packages/core/src/theme/layout/Layout/index.tsx
@@ -118,6 +118,12 @@ const HeadTags = memo(
   },
 );
 
+const ClientEffects = () => {
+  useSetup();
+  useScrollReset();
+  return null;
+};
+
 export function Layout(props: LayoutProps) {
   const {
     top,
@@ -177,6 +183,10 @@ export function Layout(props: LayoutProps) {
   } = page;
   const localesData = useLocaleSiteData();
 
+  const {
+    frontmatter: { navbar: showNavbar = true },
+  } = useFrontmatter();
+
   // Always show sidebar by default
   // Priority: front matter title > h1 title
   let title = (frontmatter.title as string) ?? articleTitle;
@@ -221,16 +231,9 @@ export function Layout(props: LayoutProps) {
   if (import.meta.env.SSG_MD) {
     return <>{getContentLayout()}</>;
   }
-
-  useSetup();
-  useScrollReset();
-
-  const {
-    frontmatter: { navbar: showNavbar = true },
-  } = useFrontmatter();
-
   return (
     <>
+      <ClientEffects />
       <HeadTags
         lang={currentLang}
         title={title}

--- a/packages/core/src/theme/layout/Layout/index.tsx
+++ b/packages/core/src/theme/layout/Layout/index.tsx
@@ -183,9 +183,7 @@ export function Layout(props: LayoutProps) {
   } = page;
   const localesData = useLocaleSiteData();
 
-  const {
-    frontmatter: { navbar: showNavbar = true },
-  } = useFrontmatter();
+  const { navbar: showNavbar = true } = frontmatter;
 
   // Always show sidebar by default
   // Priority: front matter title > h1 title


### PR DESCRIPTION
## Motivation

Extract the React Hooks fixes from #3586 so we can address React rule violations first and smoothly enable React Optimizer (React Compiler) in a follow-up PR.

Hooks in `Tabs`, `DocLayout`, and `Layout` currently appear after the conditional SSG-MD return, contrary to the [Rules of Hooks](https://react.dev/reference/rules/rules-of-hooks). The reading-progress memo also omits the document height from its dependencies, which can leave the percentage stale when the height changes without a change in scroll position or viewport height.

## Changes

- Move Hooks before conditional returns in `Tabs` and `DocLayout`.
- Extract `Layout` setup and scroll-reset Hooks into `ClientEffects`, keeping them out of Markdown generation, and move `useFrontmatter` before the early return.
- Include document height in the reading-progress memo dependencies.

React Optimizer remains disabled. This PR does not change build configuration, dependencies, or the lockfile, and leaves the optimizer-specific reference-stability cleanups in #3586 for later.

Thanks to @sanjaiyan-dev for the original fixes in #3586.

## Validation

- `pnpm build`
- `pnpm check` (lint, type checking, and formatting)
- `pnpm test:unit` — 383 passed, 1 skipped
- Targeted E2E tests for tabs, package manager tabs, dynamic TOC, hash-anchor scrolling, and SSG-MD — 9 passed across 5 files
