### PR TITLE
feat(core): support React 19 `browser()` API in BrowserOnly 

### DIFF
--- a/packages/core/src/runtime/BrowserOnly.tsx
+++ b/packages/core/src/runtime/BrowserOnly.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
-import { Suspense, useEffect, useState } from 'react';
-import { browser, use } from '@rspress/core/runtime';
+import { Suspense, useEffect, useMemo, useState } from 'react';
+import { browser, use } from './reactDom';
 
 export interface BrowserOnlyProps {
   children: () => ReactNode | Promise<ReactNode>;
@@ -70,25 +70,28 @@ function OldBrowserOnly(props: BrowserOnlyProps) {
   return fallback;
 }
 
-const ModernBrowserOnly = (props: BrowserOnlyProps) => {
+const ModernBrowserOnly = (props: BrowserOnlyProps): any => {
   const { children } = props;
   use(browser!());
+  const content = useMemo(() => children(), [children]);
+  if (content instanceof Promise) {
+    return use(content);
+  }
 
-  const content = use(children);
-  return content as ReactNode;
+  return content;
 };
 
 export function BrowserOnly(props: BrowserOnlyProps) {
-  const { children, fallback = null } = props;
+  const { fallback = null } = props;
 
   if (typeof use === 'function' && typeof browser === 'function') {
     return (
       <Suspense fallback={fallback}>
-        <ModernBrowserOnly>{children}</ModernBrowserOnly>
+        <ModernBrowserOnly {...props} />
       </Suspense>
     );
   }
 
-  return <OldBrowserOnly>{children}</OldBrowserOnly>;
+  return <OldBrowserOnly {...props} />;
 }
 export default BrowserOnly;

--- a/packages/core/src/runtime/BrowserOnly.tsx
+++ b/packages/core/src/runtime/BrowserOnly.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
-import { useEffect, useState } from 'react';
+import { Suspense, useEffect, useState } from 'react';
+import { browser, use } from '@rspress/core/runtime';
 
 export interface BrowserOnlyProps {
   children: () => ReactNode | Promise<ReactNode>;
@@ -22,7 +23,7 @@ type BrowserOnlyState =
       error: unknown;
     };
 
-export function BrowserOnly(props: BrowserOnlyProps) {
+function OldBrowserOnly(props: BrowserOnlyProps) {
   const { children, fallback = null } = props;
   const [state, setState] = useState<BrowserOnlyState>({
     status: 'pending',
@@ -69,4 +70,25 @@ export function BrowserOnly(props: BrowserOnlyProps) {
   return fallback;
 }
 
+const ModernBrowserOnly = (props: BrowserOnlyProps) => {
+  const { children } = props;
+  use(browser!());
+
+  const content = use(children);
+  return content as ReactNode;
+};
+
+export function BrowserOnly(props: BrowserOnlyProps) {
+  const { children, fallback = null } = props;
+
+  if (typeof use === 'function' && typeof browser === 'function') {
+    return (
+      <Suspense fallback={fallback}>
+        <ModernBrowserOnly>{children}</ModernBrowserOnly>
+      </Suspense>
+    );
+  }
+
+  return <OldBrowserOnly>{children}</OldBrowserOnly>;
+}
 export default BrowserOnly;

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -29,7 +29,7 @@ export { useVersion } from './hooks/useVersion';
 export { useWindowSize } from './hooks/useWindowSize';
 export { initPageData, warmPageData } from './initPageData';
 export { NoSSR } from './NoSSR';
-export { safePreconnect, safePreload } from './reactDom';
+export { safePreconnect, safePreload, use, browser } from './reactDom';
 export { isActive, pathnameToRouteService, preloadLink } from './route';
 export {
   addLeadingSlash,

--- a/packages/core/src/runtime/reactDom.ts
+++ b/packages/core/src/runtime/reactDom.ts
@@ -1,4 +1,5 @@
 import * as ReactDOM from 'react-dom';
+import * as React from 'react';
 
 type CrossOrigin = '' | 'anonymous' | 'use-credentials';
 
@@ -40,6 +41,7 @@ type Preload = (
 type ReactDOMCompat = {
   preconnect?: Preconnect;
   preload?: Preload;
+  browser?: (reason?: string) => any;
   default?: ReactDOMCompat;
 };
 
@@ -48,3 +50,6 @@ const reactDOM = ReactDOM as unknown as ReactDOMCompat;
 export const safePreconnect =
   reactDOM.preconnect ?? reactDOM.default?.preconnect;
 export const safePreload = reactDOM.preload ?? reactDOM.default?.preload;
+
+export const use = (React as any).use as <T>(promise: Promise<T> | any) => T;
+export const browser = reactDOM.browser ?? reactDOM.default?.browser;


### PR DESCRIPTION

Modernizes `BrowserOnly` to use React 19's new `use(browser())` API while preserving 100% backward compatibility with React 18. The component API remains unchanged.

#### Key Improvements
- **Prevents unnecessary re-renders**: Eliminates the double-render cycle caused by `useEffect` on initial client mount.
- **Reduces CLS (Cumulative Layout Shift)**: Leaves a clean `<Suspense>` fallback in the initial HTML during SSR, preventing layout shifts and visual flicker during hydration.
- **Full Backward Compatibility**: Automatically detects environment capabilities. Falls back to the legacy `useEffect` implementation if React 18 is detected.

#### Changes
- Added feature check for `use` (`react`) and `browser` (`react-dom`).
- Wrapped modern implementation in `<Suspense fallback={...}>`.
- Used `useMemo` to safely cache `children()` and prevent infinite Suspense loops with promises.

#### Reference 
https://react.dev/reference/react-dom/browser

#### Checklist
- [x] Tested with React 18 (backward compatibility verified)
- [x] All existing unit tests pass