### PR TITLE
chore(skills): add docs writer and update existing skills

### DIFF
--- a/skills.json
+++ b/skills.json
@@ -3,12 +3,13 @@
   "installDir": ".agents/skills",
   "linkTargets": [".cursor/skills"],
   "skills": {
-    "pr-creator": "github:rstackjs/agent-skills#c6348a1127e0022ea1f99f00dba701b6a8524024&path:/.agents/skills/pr-creator",
-    "rspress-custom-theme": "github:rstackjs/agent-skills#c6348a1127e0022ea1f99f00dba701b6a8524024&path:/skills/rspress-custom-theme",
-    "rspress-best-practices": "github:rstackjs/agent-skills#c6348a1127e0022ea1f99f00dba701b6a8524024&path:/skills/rspress-best-practices",
-    "rspress-description-generator": "github:rstackjs/agent-skills#c6348a1127e0022ea1f99f00dba701b6a8524024&path:/skills/rspress-description-generator",
-    "rspress-docs-generator": "github:rstackjs/agent-skills#c6348a1127e0022ea1f99f00dba701b6a8524024&path:/skills/rspress-docs-generator",
-    "create-draft-release-notes": "github:rstackjs/agent-skills#c6348a1127e0022ea1f99f00dba701b6a8524024&path:/.agents/skills/create-draft-release-notes",
-    "rstack-cli-docs": "github:rstackjs/rstack-cli#c0ab876d3b3732925b48e1843c7728ad670e56b3&path:/.agents/skills/rstack-cli-docs"
+    "pr-creator": "github:rstackjs/agent-skills#50cd2ed8938501ff3067be8383621bba314642d5&path:/.agents/skills/pr-creator",
+    "rspress-custom-theme": "github:rstackjs/agent-skills#50cd2ed8938501ff3067be8383621bba314642d5&path:/skills/rspress-custom-theme",
+    "rspress-best-practices": "github:rstackjs/agent-skills#50cd2ed8938501ff3067be8383621bba314642d5&path:/skills/rspress-best-practices",
+    "rspress-description-generator": "github:rstackjs/agent-skills#50cd2ed8938501ff3067be8383621bba314642d5&path:/skills/rspress-description-generator",
+    "rspress-docs-generator": "github:rstackjs/agent-skills#50cd2ed8938501ff3067be8383621bba314642d5&path:/skills/rspress-docs-generator",
+    "create-draft-release-notes": "github:rstackjs/agent-skills#50cd2ed8938501ff3067be8383621bba314642d5&path:/.agents/skills/create-draft-release-notes",
+    "rstack-cli-docs": "github:rstackjs/rstack-cli#d28d4d652799ff077b5527aa7e3c5ebeba80131f&path:/.agents/skills/rstack-cli-docs",
+    "rstack-docs-writer": "github:rstackjs/agent-skills#50cd2ed8938501ff3067be8383621bba314642d5&path:/.agents/skills/rstack-docs-writer"
   }
 }


### PR DESCRIPTION
## Motivation

Add the upstream [rstack-docs-writer](https://github.com/rstackjs/agent-skills#rstack-docs-writer) skill and keep the repository's existing skills current.

## Changes

Use the existing skills-package-manager workflow to add rstack-docs-writer and update all seven existing skill pins in skills.json. Agent skills are pinned to [50cd2ed](https://github.com/rstackjs/agent-skills/commit/50cd2ed8938501ff3067be8383621bba314642d5), and rstack-cli-docs to [d28d4d6](https://github.com/rstackjs/rstack-cli/commit/d28d4d652799ff077b5527aa7e3c5ebeba80131f).

Validation: skill installation and all eight agent links, pnpm check, and pnpm check-spell passed. pnpm test:unit passed 382 tests, but gitLog.test.ts failed during its beforeAll hook with a 10-second timeout; an isolated retry reproduced the timeout.