### PR TITLE
fix(theme/Search): await FlexSearch addAsync before init resolves

### DIFF
--- a/packages/core/src/theme/components/Search/logic/providers/LocalProvider.test.ts
+++ b/packages/core/src/theme/components/Search/logic/providers/LocalProvider.test.ts
@@ -1,0 +1,78 @@
+import type { PageIndexInfo } from '@rspress/core';
+import { describe, expect, rstest, test } from '@rstest/core';
+
+interface MockAddRecord {
+  id: string;
+  settled: boolean;
+}
+
+interface FlexSearchMockState {
+  pendingAdds: MockAddRecord[];
+}
+
+// FlexSearch resolves addAsync through an internal async queue, so searching
+// immediately after unawaited adds can still find documents. To make the
+// contract observable, replace Document with a mock whose addAsync settles in
+// a later macrotask and records whether init() waited for it.
+rstest.mock('flexsearch', () => {
+  const globalState = globalThis as unknown as {
+    __flexSearchMockState?: FlexSearchMockState;
+  };
+  globalState.__flexSearchMockState ??= { pendingAdds: [] };
+
+  class Document {
+    addAsync(id: string): Promise<void> {
+      const state = globalState.__flexSearchMockState!;
+      const record: MockAddRecord = { id, settled: false };
+      state.pendingAdds.push(record);
+      return new Promise(resolve => {
+        setTimeout(() => {
+          record.settled = true;
+          resolve();
+        }, 0);
+      });
+    }
+
+    searchAsync(): Promise<unknown[]> {
+      return Promise.resolve([]);
+    }
+  }
+
+  return { Document };
+});
+
+rstest.mock('virtual-page-data', () => ({ searchIndexHash: {} }));
+
+import { LocalProvider } from './LocalProvider';
+
+function createPage(index: number): PageIndexInfo {
+  return {
+    routePath: `/page-${index}`,
+    title: `Page ${index}`,
+    toc: [],
+    content: `content of page ${index}`,
+    frontmatter: {},
+    lang: 'en',
+    version: '',
+    _filepath: `/page-${index}.md`,
+    _relativePath: `page-${index}.md`,
+  } as PageIndexInfo;
+}
+
+describe('LocalProvider', () => {
+  test('init() awaits FlexSearch addAsync before resolving', async () => {
+    const pages = Array.from({ length: 4 }, (_, i) => createPage(i));
+
+    const provider = new LocalProvider();
+    provider.fetchSearchIndex = async () => pages;
+
+    await provider.init({ mode: 'local', currentLang: 'en', currentVersion: '' });
+
+    const state = (
+      globalThis as unknown as { __flexSearchMockState: FlexSearchMockState }
+    ).__flexSearchMockState;
+
+    expect(state.pendingAdds.length).toBe(pages.length * 3);
+    expect(state.pendingAdds.every(add => add.settled)).toBe(true);
+  });
+});

--- a/packages/core/src/theme/components/Search/logic/providers/LocalProvider.ts
+++ b/packages/core/src/theme/components/Search/logic/providers/LocalProvider.ts
@@ -160,14 +160,18 @@ export class LocalProvider implements Provider {
           str.flatMap(s => tokenize(s, cyrillicRegex)),
       },
     });
+    const pending: Promise<unknown>[] = [];
     for (const item of pagesForSearch) {
       // Add search index async to avoid blocking the main thread
       // Type assertion: PageIndexForFlexSearch is compatible with FlexSearchCompatibleData at runtime
       const flexSearchItem = item as unknown as FlexSearchCompatibleData;
-      this.#index!.addAsync(item.routePath, flexSearchItem);
-      this.#cjkIndex!.addAsync(item.routePath, flexSearchItem);
-      this.#cyrillicIndex!.addAsync(item.routePath, flexSearchItem);
+      pending.push(
+        this.#index!.addAsync(item.routePath, flexSearchItem),
+        this.#cjkIndex!.addAsync(item.routePath, flexSearchItem),
+        this.#cyrillicIndex!.addAsync(item.routePath, flexSearchItem),
+      );
     }
+    await Promise.all(pending);
   }
 
   async search(query: SearchQuery) {


### PR DESCRIPTION
## Motivation

`LocalProvider.init()` issues `addAsync()` on the three FlexSearch indexes for every page but never awaits the returned promises. `SearchPanel.initSearch()` awaits `init()` and sets `initStatus` to `'inited'` while indexing is still running, so on a medium site a query typed shortly after opening search can render "No matching results" until the user retypes. This reproduces with 952 documents per locale, as described in #3658.

## Changes

Collect the `addAsync()` promises for each page's three indexes into a pending array and `await Promise.all(pending)` before `init()` resolves. The panel therefore keeps its loading state until the index is ready and then runs the pending query. No other behavior changes.

Related to #1725
Fixes #3658

## Verification

- `tsc --noEmit` on `packages/core` passes.
- Repo build and diff checks pass.
